### PR TITLE
fix: use portable paths for iOS libsodium in build config

### DIFF
--- a/stellar-sdk/src/nativeInterop/cinterop/libsodium.def
+++ b/stellar-sdk/src/nativeInterop/cinterop/libsodium.def
@@ -13,15 +13,5 @@ linkerOpts.macosArm64 = -L/opt/homebrew/lib -L/usr/local/lib -lsodium
 compilerOpts.macosX64 = -I/opt/homebrew/include -I/usr/local/include
 linkerOpts.macosX64 = -L/opt/homebrew/lib -L/usr/local/lib -lsodium
 
-# iOS - Use bundled static libsodium (no external dependencies)
-compilerOpts.ios = -I/Users/chris/projects/Stellar/kmp/kmp-stellar-sdk/stellar-sdk/native-libs/libsodium-ios/include
-linkerOpts.ios = /Users/chris/projects/Stellar/kmp/kmp-stellar-sdk/stellar-sdk/native-libs/libsodium-ios/lib/libsodium.a
-
-compilerOpts.iosArm64 = -I/Users/chris/projects/Stellar/kmp/kmp-stellar-sdk/stellar-sdk/native-libs/libsodium-ios/include
-linkerOpts.iosArm64 = /Users/chris/projects/Stellar/kmp/kmp-stellar-sdk/stellar-sdk/native-libs/libsodium-ios/lib/libsodium.a
-
-compilerOpts.iosX64 = -I/Users/chris/projects/Stellar/kmp/kmp-stellar-sdk/stellar-sdk/native-libs/libsodium-ios/include
-linkerOpts.iosX64 = /Users/chris/projects/Stellar/kmp/kmp-stellar-sdk/stellar-sdk/native-libs/libsodium-ios/lib/libsodium.a
-
-compilerOpts.iosSimulatorArm64 = -I/Users/chris/projects/Stellar/kmp/kmp-stellar-sdk/stellar-sdk/native-libs/libsodium-ios/include
-linkerOpts.iosSimulatorArm64 = -Wl,-force_load,/Users/chris/projects/Stellar/kmp/kmp-stellar-sdk/stellar-sdk/native-libs/libsodium-ios/lib/libsodium.a
+# iOS - compilerOpts and linkerOpts are configured in build.gradle.kts
+# using project.projectDir for portable paths (see cinterops block)


### PR DESCRIPTION
## Summary

Move hardcoded absolute iOS paths from `libsodium.def` to `build.gradle.kts` using `project.projectDir.resolve()` so the iOS build works for any developer regardless of where they clone the repo.

## Problem

The `libsodium.def` file contained hardcoded absolute paths like:
```
compilerOpts.ios = -I/Users/chris/projects/Stellar/kmp/kmp-stellar-sdk/stellar-sdk/native-libs/libsodium-ios/include
```
This breaks for anyone who clones the repo to a different location.

## Solution

- Remove iOS `compilerOpts`/`linkerOpts` from `libsodium.def`
- Add dynamic path resolution in the cinterop config block in `build.gradle.kts`
- Detect iOS targets via `konanTarget.family == Family.IOS`
- Special-case `IOS_SIMULATOR_ARM64` for `-force_load` linker flag

## Testing

- Clean rebuild from scratch (`./gradlew clean` + delete DerivedData)
- `./gradlew :demo:shared:linkDebugFrameworkIosSimulatorArm64` ✅
- `xcodebuild` for simulator ✅
- App installed and launched on iPhone 16 Pro simulator ✅

## Changes

| File | Changes |
|------|---------|
| `stellar-sdk/build.gradle.kts` | +11 lines (dynamic iOS path config) |
| `stellar-sdk/src/nativeInterop/cinterop/libsodium.def` | -12/+2 lines (removed hardcoded paths) |