### PR TITLE
Add Kover code coverage and CI workflow for unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,89 @@
+name: Unit Tests & Coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: JVM Unit Tests + Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run JVM unit tests with coverage
+        run: ./gradlew :stellar-sdk:koverHtmlReport :stellar-sdk:koverXmlReport --no-daemon
+
+      - name: Print coverage summary
+        if: always()
+        run: |
+          XML_REPORT="stellar-sdk/build/reports/kover/report.xml"
+          if [ -f "$XML_REPORT" ]; then
+            echo "## Coverage Summary" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            # Extract coverage counters from JaCoCo XML
+            # Parse line coverage
+            LINE_MISSED=$(grep -o 'type="LINE" missed="[0-9]*"' "$XML_REPORT" | tail -1 | grep -o 'missed="[0-9]*"' | grep -o '[0-9]*')
+            LINE_COVERED=$(grep -o 'type="LINE".*covered="[0-9]*"' "$XML_REPORT" | tail -1 | grep -o 'covered="[0-9]*"' | grep -o '[0-9]*')
+
+            # Parse branch coverage
+            BRANCH_MISSED=$(grep -o 'type="BRANCH" missed="[0-9]*"' "$XML_REPORT" | tail -1 | grep -o 'missed="[0-9]*"' | grep -o '[0-9]*')
+            BRANCH_COVERED=$(grep -o 'type="BRANCH".*covered="[0-9]*"' "$XML_REPORT" | tail -1 | grep -o 'covered="[0-9]*"' | grep -o '[0-9]*')
+
+            if [ -n "$LINE_COVERED" ] && [ -n "$LINE_MISSED" ]; then
+              TOTAL=$((LINE_COVERED + LINE_MISSED))
+              if [ "$TOTAL" -gt 0 ]; then
+                PCT=$((LINE_COVERED * 100 / TOTAL))
+                echo "| Metric | Covered | Missed | Total | % |" >> $GITHUB_STEP_SUMMARY
+                echo "|--------|---------|--------|-------|---|" >> $GITHUB_STEP_SUMMARY
+                echo "| Lines | $LINE_COVERED | $LINE_MISSED | $TOTAL | ${PCT}% |" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+
+            if [ -n "$BRANCH_COVERED" ] && [ -n "$BRANCH_MISSED" ]; then
+              TOTAL=$((BRANCH_COVERED + BRANCH_MISSED))
+              if [ "$TOTAL" -gt 0 ]; then
+                PCT=$((BRANCH_COVERED * 100 / TOTAL))
+                echo "| Branches | $BRANCH_COVERED | $BRANCH_MISSED | $TOTAL | ${PCT}% |" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+          else
+            echo "⚠️ Coverage report not found at $XML_REPORT" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: stellar-sdk/build/reports/kover/
+          retention-days: 30
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: stellar-sdk/build/reports/tests/
+          retention-days: 30

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     kotlin("android") version "2.2.20" apply false
     id("org.jetbrains.compose") version "1.9.1" apply false
     id("org.jetbrains.dokka") version "2.1.0" apply false
+    id("org.jetbrains.kotlinx.kover") version "0.9.4" apply false
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 

--- a/stellar-sdk/build.gradle.kts
+++ b/stellar-sdk/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
     id("org.jetbrains.dokka")
+    id("org.jetbrains.kotlinx.kover")
     id("maven-publish")
     id("signing")
 }
@@ -232,6 +233,21 @@ kotlin {
 
         val macosX64Test by getting { dependsOn(macosTest) }
         val macosArm64Test by getting { dependsOn(macosTest) }
+    }
+}
+
+// Kover Code Coverage Configuration
+kover {
+    reports {
+        // Filter out integration tests from coverage measurement
+        filters {
+            excludes {
+                classes(
+                    "*IntegrationTest*",
+                    "*IntegrationTest\$*"
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds unit test code coverage tracking using [Kover](https://github.com/Kotlin/kotlinx-kover) (JetBrains' official Kotlin coverage tool) and a CI workflow to run tests + generate reports on every push/PR.

## Changes

### Kover Setup
- **Root `build.gradle.kts`**: Added Kover 0.9.4 plugin declaration (`apply false`)
- **`stellar-sdk/build.gradle.kts`**: Applied Kover plugin with filters to exclude integration test classes (`*IntegrationTest*`) from coverage metrics

### CI Workflow (`.github/workflows/tests.yml`)
- Triggers on push to `main`, PRs targeting `main`, and manual dispatch
- Runs JVM unit tests with Kover instrumentation
- Generates HTML + XML coverage reports
- Prints a coverage summary table (lines + branches) in the GitHub Actions step summary
- Uploads both coverage and test result reports as artifacts (30-day retention)

## Notes
- Kover for KMP measures coverage on **JVM targets only** (JS/Native not supported yet by Kover) — this covers all `commonTest` + `jvmTest` code
- Integration tests are `@Ignore` by default and also excluded from coverage filters to keep CI fast and deterministic
- No external coverage service (Codecov, etc.) configured yet — can add later if desired