### PR TITLE
Add SEP-8 (Regulated Assets) support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ The SDK is **production-ready** with comprehensive functionality implemented:
 - **Soroban RPC**: Contract calls, simulation, state restoration, polling
 - **High-Level API**: ContractClient, AssembledTransaction with full lifecycle
 - **XDR**: Complete XDR type system and serialization
-- **SEP Support**: SEP-1 (Stellar TOML), SEP-5 (Key Derivation), SEP-6 (Deposit and Withdrawal API), SEP-9/12 (KYC), SEP-10 (Web Authentication), SEP-24 (Hosted Deposit/Withdrawal), SEP-38 (Anchor RFQ), SEP-45 (Web Authentication for Contract Accounts)
+- **SEP Support**: SEP-1 (Stellar TOML), SEP-5 (Key Derivation), SEP-6 (Deposit and Withdrawal API), SEP-8 (Regulated Assets), SEP-9/12 (KYC), SEP-10 (Web Authentication), SEP-24 (Hosted Deposit/Withdrawal), SEP-38 (Anchor RFQ), SEP-45 (Web Authentication for Contract Accounts)
 
 ### Demo Application
 - **Platforms**: Android, iOS, macOS, Desktop (JVM), Web
@@ -142,6 +142,24 @@ secureMnemonic.close()
 - NFKD normalization for mnemonic and passphrase
 - Memory cleanup (entropy zeroed after use, close() zeros seed)
 - PBKDF2-HMAC-SHA512 with 2048 iterations
+
+### SEP-8 Regulated Assets
+
+The SDK implements SEP-8 (Regulated Assets) for assets requiring issuer approval before transactions can be submitted.
+
+#### Package Structure
+```
+com.soneso.stellar.sdk.sep.sep08/
+├── Sep08Service.kt                    # Service client (fromDomain, postTransaction, postAction)
+├── Sep08PostTransactionResponse.kt    # Sealed class: Success, Revised, Pending, ActionRequired, Rejected
+├── Sep08PostActionResponse.kt         # Sealed class: Done, NextUrl
+├── RegulatedAsset.kt                  # Regulated asset with approval server URL
+└── exceptions/
+    ├── Sep08Exception.kt                          # Base exception
+    ├── Sep08IncompleteInitDataException.kt        # Missing network/Horizon config
+    ├── Sep08InvalidTransactionResponseException.kt # Malformed approval server response
+    └── Sep08InvalidActionResponseException.kt     # Malformed action URL response
+```
 
 ## Documentation Standards
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The SDK provides comprehensive Stellar functionality:
 - **Soroban RPC Client** - Transaction simulation, event queries, ledger data, contract deployment and invocation
 - **Contract Deployment** - One-step deploy() or two-step install/deployFromWasmId for WASM reuse
 - **Authorization** - Automatic and custom auth handling with signature verification
-- **SEP Support** - SEP-1 (stellar.toml), SEP-6 (Deposit and Withdrawal API), SEP-9/12 (KYC), SEP-10 (Web Authentication), SEP-24 (Hosted Deposit/Withdrawal), SEP-38 (Anchor RFQ), SEP-45 (Web Authentication for Contracts)
+- **SEP Support** - SEP-1 (stellar.toml), SEP-6 (Deposit and Withdrawal API), SEP-8 (Regulated Assets), SEP-9/12 (KYC), SEP-10 (Web Authentication), SEP-24 (Hosted Deposit/Withdrawal), SEP-38 (Anchor RFQ), SEP-45 (Web Authentication for Contracts)
 
 ## Installation
 

--- a/compatibility/sep/SEP-0008_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0008_COMPATIBILITY_MATRIX.md
@@ -1,0 +1,153 @@
+# SEP-0008 (Regulated Assets) Compatibility Matrix
+
+**Generated:** 2026-02-10 12:00:00
+
+**SEP Version:** 1.0.0<br>
+**SEP Status:** Active<br>
+**SDK Version:** 1.2.0<br>
+**SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md
+
+## SEP Summary
+
+SEP-8 defines a protocol for regulated assets that require issuer approval before transactions can be submitted to the Stellar network. Issuers publish an approval server URL in their stellar.toml, and clients submit transactions to the approval server for authorization before network submission.
+
+## Overall Implementation
+
+**Implementation Type:** Client-Side Only
+
+This SDK implements the client-side of SEP-8 regulated assets. The implementation provides service discovery from stellar.toml, authorization flag checking, transaction submission to approval servers, and action URL handling.
+
+## Overall Coverage
+
+**Total Coverage:** 100% (22/22 features)
+
+- ✅ **Implemented:** 22/22
+- ❌ **Not Implemented:** 0/22
+
+## Implementation Status
+
+✅ **Fully Implemented**
+
+### Implementation Files
+
+- `stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/Sep08Service.kt`
+- `stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/Sep08PostTransactionResponse.kt`
+- `stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/Sep08PostActionResponse.kt`
+- `stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/RegulatedAsset.kt`
+- `stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/exceptions/` (4 exception types)
+
+### Key Classes
+
+- **`Sep08Service`** - Main client class with methods: fromDomain, authorizationRequired, postTransaction, postAction
+- **`Sep08PostTransactionResponse`** - Sealed class with 5 response variants: Success, Revised, Pending, ActionRequired, Rejected
+- **`Sep08PostActionResponse`** - Sealed class with 2 response variants: Done, NextUrl
+- **`RegulatedAsset`** - Regulated asset with code, issuer, approval server URL, and optional criteria
+
+### Test Coverage
+
+**Tests:** 108 test cases across 4 test files (2,950 lines of test code)
+
+**Test Files:**
+- `Sep08ExceptionsTest.kt` - Exception hierarchy and error handling
+- `Sep08ResponseParsingTest.kt` - All response type parsing and validation
+- `Sep08ServiceTest.kt` - Service initialization, regulated asset discovery, HTTP client behavior
+- `Sep08IntegrationTest.kt` - Live testnet integration
+
+## Detailed Feature Matrix
+
+### Service Discovery and Initialization
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Initialize from domain (stellar.toml) | ✅ | `Sep08Service.fromDomain()` |
+| Network passphrase resolution from stellar.toml | ✅ | Falls back to NETWORK_PASSPHRASE in toml |
+| Horizon URL resolution from stellar.toml | ✅ | Falls back to HORIZON_URL in toml |
+| Explicit network override | ✅ | Optional `network` parameter |
+| Explicit Horizon URL override | ✅ | Optional `horizonUrl` parameter |
+| Direct constructor initialization | ✅ | For pre-configured scenarios |
+| Custom HTTP client support | ✅ | Injectable HttpClient for testing/proxies |
+| Custom HTTP headers | ✅ | Add custom headers to requests |
+
+### Regulated Asset Discovery
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Extract regulated assets from stellar.toml | ✅ | Filters currencies with `regulated = true` |
+| Asset code extraction | ✅ | `RegulatedAsset.code` |
+| Asset issuer extraction | ✅ | `RegulatedAsset.issuer` |
+| Approval server URL extraction | ✅ | `RegulatedAsset.approvalServer` |
+| Approval criteria extraction | ✅ | `RegulatedAsset.approvalCriteria` (optional) |
+| Underlying Asset conversion | ✅ | `toAsset()` returns AlphaNum4 or AlphaNum12 |
+| XDR conversion | ✅ | `toXdr()` returns AssetXdr |
+
+### Authorization Flag Checking
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Check AUTH_REQUIRED flag | ✅ | Via `authorizationRequired()` |
+| Check AUTH_REVOCABLE flag | ✅ | Both flags validated together |
+
+### Transaction Approval (POST /tx_approve)
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Submit transaction XDR to approval server | ✅ | `postTransaction(tx, approvalServer)` |
+| Parse "success" response | ✅ | `Sep08PostTransactionResponse.Success` with tx and optional message |
+| Parse "revised" response | ✅ | `Sep08PostTransactionResponse.Revised` with tx and message |
+| Parse "pending" response | ✅ | `Sep08PostTransactionResponse.Pending` with timeout and optional message |
+| Parse "action_required" response | ✅ | `Sep08PostTransactionResponse.ActionRequired` with actionUrl, actionMethod, actionFields |
+| Parse "rejected" response (200) | ✅ | `Sep08PostTransactionResponse.Rejected` with error |
+| Parse "rejected" response (400) | ✅ | HTTP 400 with status "rejected" handled |
+| Unexpected HTTP status handling | ✅ | Throws Sep08InvalidTransactionResponseException |
+
+### Action URL Handling (POST action_url)
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Submit action fields to action URL | ✅ | `postAction(url, actionFields)` |
+| Parse "no_further_action_required" response | ✅ | `Sep08PostActionResponse.Done` |
+| Parse "follow_next_url" response | ✅ | `Sep08PostActionResponse.NextUrl` with nextUrl and optional message |
+| Unexpected HTTP status handling | ✅ | Throws Sep08InvalidActionResponseException |
+
+### Error Handling
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Base exception class | ✅ | `Sep08Exception` |
+| Incomplete init data exception | ✅ | `Sep08IncompleteInitDataException` |
+| Invalid transaction response exception | ✅ | `Sep08InvalidTransactionResponseException` |
+| Invalid action response exception | ✅ | `Sep08InvalidActionResponseException` |
+
+### Server-Side Features (Not Applicable)
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Approval server implementation | ⚪ N/A | Server-side functionality - not in scope for client SDK |
+| Transaction evaluation and compliance rules | ⚪ N/A | Server-side functionality - not in scope for client SDK |
+| Action URL server implementation | ⚪ N/A | Server-side functionality - not in scope for client SDK |
+
+## Platform Support
+
+All features work across all supported platforms:
+- JVM (Android, Server)
+- iOS
+- macOS
+- JavaScript (Browser & Node.js)
+
+## Additional Information
+
+**Documentation:** See `docs/sep/sep-08.md` for usage examples and API reference
+
+**Specification:** [SEP-0008: Regulated Assets](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md)
+
+**Implementation Package:** `com.soneso.stellar.sdk.sep.sep08`
+
+**Integration Tests:** Live testnet integration with regulated asset approval flow
+
+**Last Updated:** 2026-02-10
+
+## Legend
+
+- ✅ **Implemented**: Feature is fully supported in the SDK
+- ❌ **Not Implemented**: Feature is not currently supported
+- ⚪ **N/A**: Not applicable (server-side feature)

--- a/docs/sep/README.md
+++ b/docs/sep/README.md
@@ -13,6 +13,7 @@ Stellar Ecosystem Proposals (SEPs) are standards that define how services, appli
 | SEP-1 | Stellar TOML | [sep-01.md](sep-01.md) |
 | SEP-5 | Key Derivation Methods for Stellar Keys | [sep-05.md](sep-05.md) |
 | SEP-6 | Programmatic Deposit and Withdrawal | [sep-06-transfer-service.md](sep-06-transfer-service.md) |
+| SEP-8 | Regulated Assets | [sep-08.md](sep-08.md) |
 | SEP-9 | Standard KYC Fields | [sep-09.md](sep-09.md) |
 | SEP-10 | Web Authentication | [sep-10.md](sep-10.md) |
 | SEP-12 | KYC API | [sep-12.md](sep-12.md) |
@@ -29,6 +30,7 @@ Detailed field-by-field coverage for each SEP implementation:
 | SEP-1 | 100% (71/71 fields) | [SEP-0001 Compatibility Matrix](../../compatibility/sep/SEP-0001_COMPATIBILITY_MATRIX.md) |
 | SEP-5 | 100% (31/31 features) | [SEP-0005 Compatibility Matrix](../../compatibility/sep/SEP-0005_COMPATIBILITY_MATRIX.md) |
 | SEP-6 | 100% (95/95 fields) | [SEP-0006 Compatibility Matrix](../../compatibility/sep/SEP-0006_COMPATIBILITY_MATRIX.md) |
+| SEP-8 | 100% (22/22 features) | [SEP-0008 Compatibility Matrix](../../compatibility/sep/SEP-0008_COMPATIBILITY_MATRIX.md) |
 | SEP-9 | 100% (76/76 fields) | [SEP-0009 Compatibility Matrix](../../compatibility/sep/SEP-0009_COMPATIBILITY_MATRIX.md) |
 | SEP-10 | 100% (31/31 features) | [SEP-0010 Compatibility Matrix](../../compatibility/sep/SEP-0010_COMPATIBILITY_MATRIX.md) |
 | SEP-12 | 100% (28/28 fields) | [SEP-0012 Compatibility Matrix](../../compatibility/sep/SEP-0012_COMPATIBILITY_MATRIX.md) |
@@ -41,9 +43,8 @@ Detailed field-by-field coverage for each SEP implementation:
 | SEP | Title |
 |-----|-------|
 | SEP-2 | Federation Protocol |
-| SEP-8 | Regulated Assets |
 | SEP-30 | Account Recovery |
 
 ---
 
-**Last Updated**: 2026-02-04
+**Last Updated**: 2026-02-10

--- a/docs/sep/sep-08.md
+++ b/docs/sep/sep-08.md
@@ -1,0 +1,447 @@
+# SEP-8: Regulated Assets
+
+**[SEP-0008 Compatibility Matrix](../../compatibility/sep/SEP-0008_COMPATIBILITY_MATRIX.md)** - Full implementation coverage details
+
+SEP-8 defines a protocol for assets that require issuer approval before transactions can be submitted to the Stellar network. The issuer publishes an approval server URL in their stellar.toml, and all transactions involving the regulated asset must be submitted to this server for authorization.
+
+**Use Cases**:
+- Securities tokens where a transfer agent must validate each trade
+- Stablecoins subject to sanctions screening or geographic restrictions
+- Assets with daily transfer limits or tiered access controls
+
+## Quick Start
+
+```kotlin
+import com.soneso.stellar.sdk.*
+import com.soneso.stellar.sdk.sep.sep08.*
+import com.soneso.stellar.sdk.horizon.HorizonServer
+
+suspend fun regulatedAssetExample() {
+    // Initialize from issuer's domain
+    val sep08 = Sep08Service.fromDomain("issuer.example.com")
+
+    // Discover regulated assets
+    sep08.regulatedAssets.forEach { asset ->
+        println("${asset.code}:${asset.issuer}")
+        println("Approval server: ${asset.approvalServer}")
+        asset.approvalCriteria?.let { println("Criteria: $it") }
+    }
+
+    // Check issuer authorization flags
+    val asset = sep08.regulatedAssets.first()
+    val isRegulated = sep08.authorizationRequired(asset)
+    println("Authorization required: $isRegulated")
+
+    // Build a payment transaction involving the regulated asset
+    val server = HorizonServer("https://horizon-testnet.stellar.org")
+    val senderKeyPair = KeyPair.fromSecretSeed("SCZANGBA5YHTNYVVV3C7CAZMTQDBJHJG6C34CBOEPVCBWVISXZ3DQHKP")
+    val sourceAccount = server.accounts().account(senderKeyPair.getAccountId())
+    val destination = "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"
+
+    val transaction = TransactionBuilder(sourceAccount, Network.TESTNET)
+        .addOperation(
+            PaymentOperation(destination, asset.toAsset(), "100")
+        )
+        .build()
+    transaction.sign(senderKeyPair)
+
+    // Submit to approval server
+    val response = sep08.postTransaction(
+        tx = transaction.toEnvelopeXdrBase64(),
+        approvalServer = asset.approvalServer
+    )
+
+    // Handle response
+    when (response) {
+        is Sep08PostTransactionResponse.Success -> {
+            println("Approved: ${response.message}")
+            // Submit response.tx to the Stellar network
+        }
+        is Sep08PostTransactionResponse.Revised -> {
+            println("Revised: ${response.message}")
+            // Review and sign the revised transaction, then submit
+        }
+        is Sep08PostTransactionResponse.Pending -> {
+            println("Pending - retry after ${response.timeout} milliseconds")
+        }
+        is Sep08PostTransactionResponse.ActionRequired -> {
+            println("Action required: ${response.message}")
+            println("URL: ${response.actionUrl}")
+        }
+        is Sep08PostTransactionResponse.Rejected -> {
+            println("Rejected: ${response.error}")
+        }
+    }
+}
+```
+
+## Service Initialization
+
+### From Domain (Recommended)
+
+Discovers regulated assets and network configuration from the issuer's stellar.toml.
+
+```kotlin
+// In a coroutine scope
+val sep08 = Sep08Service.fromDomain("issuer.example.com")
+```
+
+The service resolves the network and Horizon URL in this order:
+1. Explicit parameters if provided
+2. `NETWORK_PASSPHRASE` and `HORIZON_URL` from stellar.toml
+3. Default Horizon URL for known networks (public, testnet, futurenet)
+
+### With Explicit Configuration
+
+```kotlin
+// In a coroutine scope
+val sep08 = Sep08Service.fromDomain(
+    domain = "issuer.example.com",
+    horizonUrl = "https://horizon-testnet.stellar.org",
+    network = Network.TESTNET
+)
+```
+
+### Direct Constructor
+
+When you already have the stellar.toml data and regulated asset list:
+
+```kotlin
+val sep08 = Sep08Service(
+    tomlData = stellarToml,
+    regulatedAssets = listOf(regulatedAsset),
+    network = Network.TESTNET,
+    horizonServer = HorizonServer("https://horizon-testnet.stellar.org")
+)
+```
+
+## Regulated Asset Discovery
+
+The service extracts regulated assets from the `[[CURRENCIES]]` entries in stellar.toml. An asset is considered regulated when it has `regulated = true`, a `code`, an `issuer`, and an `approval_server` defined.
+
+```kotlin
+// In a coroutine scope
+val sep08 = Sep08Service.fromDomain("issuer.example.com")
+
+sep08.regulatedAssets.forEach { asset ->
+    println("Code: ${asset.code}")
+    println("Issuer: ${asset.issuer}")
+    println("Approval server: ${asset.approvalServer}")
+    asset.approvalCriteria?.let { println("Criteria: $it") }
+    println("Asset type: ${asset.type}")
+}
+
+// Use the regulated asset in SDK operations
+val asset = sep08.regulatedAssets.first()
+val stellarAsset = asset.toAsset()  // Returns Asset (AlphaNum4 or AlphaNum12)
+val assetXdr = asset.toXdr()        // Returns AssetXdr
+```
+
+## Authorization Check
+
+Verify that the issuer account has both `auth_required` and `auth_revocable` flags set.
+
+```kotlin
+// In a coroutine scope
+val asset = sep08.regulatedAssets.first()
+val isConfigured = sep08.authorizationRequired(asset)
+
+if (isConfigured) {
+    println("${asset.code} requires transaction approval via ${asset.approvalServer}")
+} else {
+    println("${asset.code} issuer flags not properly configured for SEP-8")
+}
+```
+
+- `auth_required` ensures all trustlines must be approved by the issuer
+- `auth_revocable` allows the issuer to revoke authorization when needed
+
+## Transaction Approval Flow
+
+Build a transaction involving the regulated asset, sign it, and submit it to the approval server.
+
+```kotlin
+suspend fun approvalFlowExample() {
+    val sep08 = Sep08Service.fromDomain("issuer.example.com")
+    val asset = sep08.regulatedAssets.first()
+
+    // Build the transaction
+    val server = HorizonServer("https://horizon-testnet.stellar.org")
+    val senderKeyPair = KeyPair.fromSecretSeed("SCZANGBA5YHTNYVVV3C7CAZMTQDBJHJG6C34CBOEPVCBWVISXZ3DQHKP")
+    val sourceAccount = server.accounts().account(senderKeyPair.getAccountId())
+    val destination = "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"
+
+    val transaction = TransactionBuilder(sourceAccount, Network.TESTNET)
+        .addOperation(
+            PaymentOperation(destination, asset.toAsset(), "100")
+        )
+        .build()
+    transaction.sign(senderKeyPair)
+
+    // Submit to the approval server
+    val response = sep08.postTransaction(
+        tx = transaction.toEnvelopeXdrBase64(),
+        approvalServer = asset.approvalServer
+    )
+}
+```
+
+## Handling Responses
+
+The approval server returns one of five response types. Use a `when` expression to handle each one.
+
+### Success
+
+The transaction was approved without modifications. Submit `response.tx` to the Stellar network.
+
+```kotlin
+when (response) {
+    is Sep08PostTransactionResponse.Success -> {
+        // response.tx contains the approved (possibly co-signed) transaction XDR
+        response.message?.let { println("Message: $it") }
+
+        // Submit to Stellar network (response.tx is base64-encoded XDR)
+        val txResponse = server.submitTransaction(response.tx)
+        println("Submitted: ${txResponse.hash}")
+    }
+    // ... other branches
+}
+```
+
+### Revised
+
+The approval server modified the transaction (e.g., added compliance operations). Review the changes, sign the revised transaction, and submit it.
+
+```kotlin
+is Sep08PostTransactionResponse.Revised -> {
+    println("Revised: ${response.message}")
+    // response.tx contains the modified transaction XDR
+    // Review the changes, sign, and submit to the network
+}
+```
+
+### Pending
+
+The approval server needs more time. Wait and resubmit.
+
+```kotlin
+is Sep08PostTransactionResponse.Pending -> {
+    println("Pending - retry after ${response.timeout} milliseconds")
+    response.message?.let { println("Message: $it") }
+    // Wait response.timeout milliseconds, then resubmit the same transaction
+}
+```
+
+### Action Required
+
+The user must complete an action (e.g., KYC) before the transaction can be approved.
+
+```kotlin
+is Sep08PostTransactionResponse.ActionRequired -> {
+    println("Action required: ${response.message}")
+    println("URL: ${response.actionUrl}")
+    println("Method: ${response.actionMethod}")  // "GET" or "POST"
+    response.actionFields?.let { fields ->
+        println("Required fields: ${fields.joinToString()}")
+    }
+}
+```
+
+### Rejected
+
+The transaction was rejected and cannot be approved.
+
+```kotlin
+is Sep08PostTransactionResponse.Rejected -> {
+    println("Rejected: ${response.error}")
+}
+```
+
+### Exhaustive Handling
+
+```kotlin
+when (response) {
+    is Sep08PostTransactionResponse.Success -> {
+        server.submitTransaction(response.tx)
+    }
+    is Sep08PostTransactionResponse.Revised -> {
+        println("Revised: ${response.message}")
+        // Review, sign, and submit response.tx
+    }
+    is Sep08PostTransactionResponse.Pending -> {
+        delay(response.timeout.toLong())
+        // Resubmit the original transaction
+    }
+    is Sep08PostTransactionResponse.ActionRequired -> {
+        // See Action URL Handling section below
+        println("Action required: ${response.message}")
+        println("URL: ${response.actionUrl}")
+    }
+    is Sep08PostTransactionResponse.Rejected -> {
+        println("Rejected: ${response.error}")
+    }
+}
+```
+
+## Action URL Handling
+
+### GET Actions (Browser-Based)
+
+When `actionMethod` is `"GET"` (the default), open the URL in a browser or webview. After the user completes the action (e.g., a KYC form), resubmit the original transaction.
+
+```kotlin
+// In a coroutine scope
+val actionRequired = response as Sep08PostTransactionResponse.ActionRequired
+
+if (actionRequired.actionMethod == "GET") {
+    // Open actionRequired.actionUrl in a browser or webview
+    println("Direct user to: ${actionRequired.actionUrl}")
+
+    // After the user completes the action, resubmit the transaction
+    val retryResponse = sep08.postTransaction(
+        tx = transaction.toEnvelopeXdrBase64(),
+        approvalServer = asset.approvalServer
+    )
+}
+```
+
+### POST Actions (Programmatic)
+
+When `actionMethod` is `"POST"`, submit the required fields programmatically using `postAction()`.
+
+```kotlin
+// In a coroutine scope
+val actionRequired = response as Sep08PostTransactionResponse.ActionRequired
+
+if (actionRequired.actionMethod == "POST") {
+    val actionResponse = sep08.postAction(
+        url = actionRequired.actionUrl,
+        actionFields = mapOf(
+            "email_address" to "user@example.com",
+            "mobile_number" to "+1234567890"
+        )
+    )
+
+    when (actionResponse) {
+        is Sep08PostActionResponse.Done -> {
+            // Action complete - resubmit the original transaction
+            val retryResponse = sep08.postTransaction(
+                tx = transaction.toEnvelopeXdrBase64(),
+                approvalServer = asset.approvalServer
+            )
+        }
+        is Sep08PostActionResponse.NextUrl -> {
+            // Multi-step flow - direct user to the next URL
+            println("Next step: ${actionResponse.nextUrl}")
+            actionResponse.message?.let { println("Message: $it") }
+        }
+    }
+}
+```
+
+## Issuer Configuration
+
+For asset issuers configuring their accounts for SEP-8, the `AUTH_REQUIRED` and `AUTH_REVOCABLE` flags must be set using `SetOptionsOperation`.
+
+```kotlin
+import com.soneso.stellar.sdk.xdr.AccountFlagsXdr
+
+suspend fun configureIssuer() {
+    val issuerKeyPair = KeyPair.fromSecretSeed("SISSUER...")
+    val server = HorizonServer("https://horizon-testnet.stellar.org")
+    val issuerAccount = server.accounts().account(issuerKeyPair.getAccountId())
+
+    val setFlagsTransaction = TransactionBuilder(issuerAccount, Network.TESTNET)
+        .addOperation(
+            SetOptionsOperation(
+                setFlags = AccountFlagsXdr.AUTH_REQUIRED_FLAG.value or
+                    AccountFlagsXdr.AUTH_REVOCABLE_FLAG.value
+            )
+        )
+        .build()
+
+    setFlagsTransaction.sign(issuerKeyPair)
+    server.submitTransaction(setFlagsTransaction.toEnvelopeXdrBase64())
+}
+```
+
+The issuer must also publish the regulated asset in their stellar.toml with `regulated = true` and an `approval_server` URL.
+
+## Error Handling
+
+```kotlin
+import com.soneso.stellar.sdk.sep.sep08.exceptions.*
+
+suspend fun errorHandlingExample() {
+    try {
+        val sep08 = Sep08Service.fromDomain("issuer.example.com")
+        val asset = sep08.regulatedAssets.first()
+        val response = sep08.postTransaction(txXdr, asset.approvalServer)
+    } catch (e: Sep08IncompleteInitDataException) {
+        // Network passphrase or Horizon URL missing from stellar.toml
+        println("Missing configuration: ${e.message}")
+    } catch (e: Sep08InvalidTransactionResponseException) {
+        // Malformed or unexpected response from the approval server
+        println("Invalid approval server response: ${e.message}")
+    } catch (e: Sep08InvalidActionResponseException) {
+        // Malformed response from the action URL
+        println("Invalid action response: ${e.message}")
+    } catch (e: Sep08Exception) {
+        // Base SEP-8 exception
+        println("SEP-8 error: ${e.message}")
+    }
+}
+```
+
+## API Reference
+
+**Main Class**:
+- `Sep08Service` - SEP-8 Regulated Assets service client
+
+**Factory Methods**:
+- `Sep08Service.fromDomain(domain, horizonUrl?, network?)` - Initialize from stellar.toml
+
+**Constructor**:
+- `Sep08Service(tomlData, regulatedAssets, network, horizonServer)` - Direct initialization
+
+**Methods**:
+- `authorizationRequired(asset)` - Check if issuer has AUTH_REQUIRED and AUTH_REVOCABLE flags
+- `postTransaction(tx, approvalServer)` - Submit transaction XDR to approval server
+- `postAction(url, actionFields)` - Submit action fields to an action URL
+
+**Properties**:
+- `tomlData` - Parsed stellar.toml data (`StellarToml`)
+- `regulatedAssets` - List of regulated assets discovered from stellar.toml (`List<RegulatedAsset>`)
+
+**Data Classes**:
+- `RegulatedAsset` - Regulated asset with code, issuer, approval server, and optional criteria
+  - `code` - Asset code (1-12 characters)
+  - `issuer` - Issuer account ID (G... address)
+  - `approvalServer` - Approval server URL
+  - `approvalCriteria` - Optional approval criteria description
+  - `toAsset()` - Returns the underlying `Asset`
+  - `toXdr()` - Returns `AssetXdr` representation
+  - `type` - Asset type (`AssetTypeXdr`)
+
+**Response Classes**:
+- `Sep08PostTransactionResponse` (sealed class):
+  - `Success(tx, message?)` - Approved transaction XDR
+  - `Revised(tx, message)` - Modified transaction XDR with explanation
+  - `Pending(timeout, message?)` - Retry after timeout milliseconds
+  - `ActionRequired(message, actionUrl, actionMethod, actionFields?)` - User action needed
+  - `Rejected(error)` - Transaction rejected with reason
+- `Sep08PostActionResponse` (sealed class):
+  - `Done` - Action complete, resubmit transaction
+  - `NextUrl(nextUrl, message?)` - Multi-step flow, visit next URL
+
+**Exception Types**:
+- `Sep08Exception` - Base exception for SEP-8 errors
+- `Sep08IncompleteInitDataException` - Missing network passphrase or Horizon URL
+- `Sep08InvalidTransactionResponseException` - Malformed approval server response
+- `Sep08InvalidActionResponseException` - Malformed action URL response
+
+**Specification**: [SEP-8: Regulated Assets](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md)
+
+**Implementation**: `com.soneso.stellar.sdk.sep.sep08`
+
+**Last Updated**: 2026-02-10

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/RegulatedAsset.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/RegulatedAsset.kt
@@ -1,0 +1,113 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.sep.sep08
+
+import com.soneso.stellar.sdk.Asset
+import com.soneso.stellar.sdk.xdr.AssetTypeXdr
+import com.soneso.stellar.sdk.xdr.AssetXdr
+
+/**
+ * Represents a regulated asset on the Stellar network that requires approval before transactions
+ * can be submitted.
+ *
+ * Regulated assets (SEP-8) are issued assets that have the `auth_required` flag set and specify
+ * an `approval_server` in the issuer's stellar.toml file. Transactions involving these assets
+ * must be submitted to the approval server for authorization before they can be sent to
+ * the Stellar network.
+ *
+ * This class wraps a standard Stellar [Asset] (AlphaNum4 or AlphaNum12) and adds the
+ * approval server URL and optional approval criteria from the stellar.toml configuration.
+ *
+ * ## Usage
+ *
+ * ### Create a regulated asset
+ * ```kotlin
+ * val regulatedAsset = RegulatedAsset(
+ *     code = "GOAT",
+ *     issuer = "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
+ *     approvalServer = "https://example.com/tx_approve",
+ *     approvalCriteria = "Transactions must be below 500 GOAT per account per day"
+ * )
+ * ```
+ *
+ * ### Access the underlying asset
+ * ```kotlin
+ * val asset = regulatedAsset.toAsset()
+ * val xdr = regulatedAsset.toXdr()
+ * ```
+ *
+ * @property code The asset code (1-12 characters)
+ * @property issuer The issuer's account ID (G... address)
+ * @property approvalServer The URL of the approval server for this asset
+ * @property approvalCriteria Optional human-readable criteria describing the approval requirements
+ *
+ * @see <a href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md">SEP-0008 Specification</a>
+ */
+class RegulatedAsset(
+    val code: String,
+    val issuer: String,
+    val approvalServer: String,
+    val approvalCriteria: String? = null
+) : Comparable<RegulatedAsset> {
+
+    /**
+     * The underlying Stellar asset (AlphaNum4 or AlphaNum12).
+     */
+    private val asset: Asset = Asset.createNonNativeAsset(code, issuer)
+
+    /**
+     * Returns the asset type of the underlying asset.
+     */
+    val type: AssetTypeXdr
+        get() = asset.type
+
+    /**
+     * Converts the underlying asset to its XDR representation.
+     *
+     * @return The XDR Asset union representing this asset
+     */
+    fun toXdr(): AssetXdr = asset.toXdr()
+
+    /**
+     * Returns the underlying [Asset] instance.
+     *
+     * Use this method when you need to pass the asset to SDK methods that accept [Asset]
+     * parameters, such as transaction building or Horizon queries.
+     *
+     * @return The underlying Asset (AssetTypeCreditAlphaNum4 or AssetTypeCreditAlphaNum12)
+     */
+    fun toAsset(): Asset = asset
+
+    /**
+     * Returns the canonical string representation of this asset in "CODE:ISSUER" format.
+     */
+    override fun toString(): String = "$code:$issuer"
+
+    override fun compareTo(other: RegulatedAsset): Int {
+        return asset.compareTo(other.asset)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as RegulatedAsset
+
+        if (code != other.code) return false
+        if (issuer != other.issuer) return false
+        if (approvalServer != other.approvalServer) return false
+        if (approvalCriteria != other.approvalCriteria) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = code.hashCode()
+        result = 31 * result + issuer.hashCode()
+        result = 31 * result + approvalServer.hashCode()
+        result = 31 * result + (approvalCriteria?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/Sep08PostActionResponse.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/Sep08PostActionResponse.kt
@@ -1,0 +1,114 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.sep.sep08
+
+import com.soneso.stellar.sdk.sep.sep08.exceptions.Sep08InvalidActionResponseException
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Represents the response from a SEP-8 action URL after the user completes a required action
+ * (e.g., KYC verification) via the postAction endpoint.
+ *
+ * When the approval server returns an [Sep08PostTransactionResponse.ActionRequired] response,
+ * the client directs the user to the action URL. After the action is completed, the action URL
+ * returns one of two possible outcomes, each modeled as a subclass of this sealed class. The
+ * response type is determined by the `result` field in the JSON response.
+ *
+ * ## Response Types
+ *
+ * - [Done]: No further action is required. The client should resubmit the original transaction
+ *   to the approval server.
+ * - [NextUrl]: The user must visit another URL to continue the process (e.g., a multi-step
+ *   verification flow).
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val json = Json.parseToJsonElement(responseBody).jsonObject
+ * val response = Sep08PostActionResponse.fromJson(json)
+ *
+ * when (response) {
+ *     is Sep08PostActionResponse.Done -> {
+ *         // Resubmit the original transaction to the approval server
+ *     }
+ *     is Sep08PostActionResponse.NextUrl -> {
+ *         // Direct the user to response.nextUrl
+ *     }
+ * }
+ * ```
+ *
+ * @see <a href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md">SEP-0008 Specification</a>
+ */
+sealed class Sep08PostActionResponse {
+
+    /**
+     * No further action is required from the user.
+     *
+     * The client should resubmit the original transaction to the approval server for
+     * re-evaluation. The approval server may now approve the transaction since the
+     * required action has been completed.
+     */
+    data object Done : Sep08PostActionResponse()
+
+    /**
+     * The user must visit another URL to continue the action flow.
+     *
+     * This occurs in multi-step verification flows where the action URL redirects the
+     * user through additional steps. The client should direct the user to [nextUrl]
+     * to continue.
+     *
+     * @property nextUrl The URL the user should visit next to continue the action flow
+     * @property message Optional human-readable message providing context about the next step
+     */
+    data class NextUrl(
+        val nextUrl: String,
+        val message: String? = null
+    ) : Sep08PostActionResponse()
+
+    companion object {
+
+        private const val RESULT_NO_FURTHER_ACTION = "no_further_action_required"
+        private const val RESULT_FOLLOW_NEXT_URL = "follow_next_url"
+
+        /**
+         * Parses a JSON response from a SEP-8 action URL into the appropriate
+         * [Sep08PostActionResponse] variant.
+         *
+         * The JSON must contain a `result` field with one of the recognized values:
+         * `"no_further_action_required"` or `"follow_next_url"`. Required fields are
+         * validated based on the result type.
+         *
+         * @param json The JSON object returned by the action URL
+         * @return The parsed response as the appropriate sealed class variant
+         * @throws Sep08InvalidActionResponseException if the result field is missing
+         *   or unrecognized, or if required fields for the given result are missing
+         */
+        fun fromJson(json: JsonObject): Sep08PostActionResponse {
+            val result = json["result"]?.jsonPrimitive?.contentOrNull
+                ?: throw Sep08InvalidActionResponseException(
+                    "Missing 'result' field in action URL response"
+                )
+
+            return when (result) {
+                RESULT_NO_FURTHER_ACTION -> Done
+                RESULT_FOLLOW_NEXT_URL -> parseNextUrl(json)
+                else -> throw Sep08InvalidActionResponseException(
+                    "Unknown result '$result' in action URL response"
+                )
+            }
+        }
+
+        private fun parseNextUrl(json: JsonObject): NextUrl {
+            val nextUrl = json["next_url"]?.jsonPrimitive?.contentOrNull
+                ?: throw Sep08InvalidActionResponseException(
+                    "Missing required 'next_url' field in 'follow_next_url' response"
+                )
+            val message = json["message"]?.jsonPrimitive?.contentOrNull
+            return NextUrl(nextUrl = nextUrl, message = message)
+        }
+    }
+}

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/Sep08PostTransactionResponse.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/Sep08PostTransactionResponse.kt
@@ -1,0 +1,240 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.sep.sep08
+
+import com.soneso.stellar.sdk.sep.sep08.exceptions.Sep08InvalidTransactionResponseException
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Represents the response from a SEP-8 approval server when a transaction is submitted
+ * for regulatory approval via the postTransaction endpoint.
+ *
+ * The approval server evaluates the submitted transaction and returns one of five possible
+ * outcomes, each modeled as a subclass of this sealed class. The response type is determined
+ * by the `status` field in the JSON response.
+ *
+ * ## Response Types
+ *
+ * - [Success]: The transaction was approved and is ready for submission to the network.
+ * - [Revised]: The transaction was modified by the approval server (e.g., additional operations
+ *   added) and the revised version should be submitted instead.
+ * - [Pending]: The approval server needs more time to evaluate the transaction. The client
+ *   should resubmit after the specified timeout.
+ * - [ActionRequired]: The user must complete an additional action (e.g., KYC verification)
+ *   before the transaction can be approved.
+ * - [Rejected]: The transaction was rejected and cannot be approved.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val json = Json.parseToJsonElement(responseBody).jsonObject
+ * val response = Sep08PostTransactionResponse.fromJson(json)
+ *
+ * when (response) {
+ *     is Sep08PostTransactionResponse.Success -> {
+ *         // Submit response.tx to the Stellar network
+ *     }
+ *     is Sep08PostTransactionResponse.Revised -> {
+ *         // Review response.tx and response.message, then submit
+ *     }
+ *     is Sep08PostTransactionResponse.Pending -> {
+ *         // Wait response.timeout milliseconds, then resubmit
+ *     }
+ *     is Sep08PostTransactionResponse.ActionRequired -> {
+ *         // Direct user to response.actionUrl
+ *     }
+ *     is Sep08PostTransactionResponse.Rejected -> {
+ *         // Display response.error to the user
+ *     }
+ * }
+ * ```
+ *
+ * @see <a href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md">SEP-0008 Specification</a>
+ */
+sealed class Sep08PostTransactionResponse {
+
+    /**
+     * The transaction was approved by the approval server without modifications.
+     *
+     * The [tx] field contains the signed transaction XDR envelope that is ready to be
+     * submitted to the Stellar network. The approval server may have added its signature
+     * to the transaction.
+     *
+     * @property tx The approved transaction as a base64-encoded XDR transaction envelope
+     * @property message Optional human-readable message from the approval server
+     */
+    data class Success(
+        val tx: String,
+        val message: String? = null
+    ) : Sep08PostTransactionResponse()
+
+    /**
+     * The transaction was revised by the approval server.
+     *
+     * The approval server modified the original transaction (e.g., added compliance-related
+     * operations) and returned a revised version. The [tx] field contains the modified
+     * transaction XDR that the client should sign and submit instead of the original.
+     *
+     * The [message] field explains what changes were made and why.
+     *
+     * @property tx The revised transaction as a base64-encoded XDR transaction envelope
+     * @property message Human-readable explanation of the revisions made
+     */
+    data class Revised(
+        val tx: String,
+        val message: String
+    ) : Sep08PostTransactionResponse()
+
+    /**
+     * The approval server needs more time to process the transaction.
+     *
+     * The client should wait for [timeout] milliseconds and then resubmit the same transaction
+     * to the approval server. This status may indicate that the server is performing
+     * asynchronous checks (e.g., compliance verification).
+     *
+     * @property timeout Number of milliseconds the client should wait before resubmitting (default 0)
+     * @property message Optional human-readable message explaining the delay
+     */
+    data class Pending(
+        val timeout: Int = 0,
+        val message: String? = null
+    ) : Sep08PostTransactionResponse()
+
+    /**
+     * The user must complete an action before the transaction can be approved.
+     *
+     * The approval server requires additional information or verification from the user.
+     * The client should direct the user to the [actionUrl] to complete the required action
+     * (e.g., KYC verification, identity confirmation).
+     *
+     * If [actionMethod] is "POST", the client should submit the [actionFields] to the
+     * [actionUrl] as form data. If "GET" (the default), the client should open the URL
+     * in a browser or webview.
+     *
+     * @property message Human-readable message explaining what action is required
+     * @property actionUrl URL where the user should complete the required action
+     * @property actionMethod HTTP method to use when accessing the action URL (default "GET")
+     * @property actionFields List of field names that should be submitted to the action URL
+     *   when [actionMethod] is "POST"
+     */
+    data class ActionRequired(
+        val message: String,
+        val actionUrl: String,
+        val actionMethod: String = "GET",
+        val actionFields: List<String>? = null
+    ) : Sep08PostTransactionResponse()
+
+    /**
+     * The transaction was rejected by the approval server.
+     *
+     * The transaction cannot be approved. The [error] field contains a human-readable
+     * explanation of why the transaction was rejected.
+     *
+     * @property error Human-readable error message explaining the rejection reason
+     */
+    data class Rejected(
+        val error: String
+    ) : Sep08PostTransactionResponse()
+
+    companion object {
+
+        private const val STATUS_SUCCESS = "success"
+        private const val STATUS_REVISED = "revised"
+        private const val STATUS_PENDING = "pending"
+        private const val STATUS_ACTION_REQUIRED = "action_required"
+        private const val STATUS_REJECTED = "rejected"
+
+        /**
+         * Parses a JSON response from the SEP-8 approval server into the appropriate
+         * [Sep08PostTransactionResponse] variant.
+         *
+         * The JSON must contain a `status` field with one of the recognized values:
+         * `"success"`, `"revised"`, `"pending"`, `"action_required"`, or `"rejected"`.
+         * Required fields are validated based on the status type.
+         *
+         * @param json The JSON object returned by the approval server
+         * @return The parsed response as the appropriate sealed class variant
+         * @throws Sep08InvalidTransactionResponseException if the status field is missing
+         *   or unrecognized, or if required fields for the given status are missing
+         */
+        fun fromJson(json: JsonObject): Sep08PostTransactionResponse {
+            val status = json["status"]?.jsonPrimitive?.contentOrNull
+                ?: throw Sep08InvalidTransactionResponseException(
+                    "Missing 'status' field in approval server response"
+                )
+
+            return when (status) {
+                STATUS_SUCCESS -> parseSuccess(json)
+                STATUS_REVISED -> parseRevised(json)
+                STATUS_PENDING -> parsePending(json)
+                STATUS_ACTION_REQUIRED -> parseActionRequired(json)
+                STATUS_REJECTED -> parseRejected(json)
+                else -> throw Sep08InvalidTransactionResponseException(
+                    "Unknown status '$status' in approval server response"
+                )
+            }
+        }
+
+        private fun parseSuccess(json: JsonObject): Success {
+            val tx = json["tx"]?.jsonPrimitive?.contentOrNull
+                ?: throw Sep08InvalidTransactionResponseException(
+                    "Missing required 'tx' field in 'success' response"
+                )
+            val message = json["message"]?.jsonPrimitive?.contentOrNull
+            return Success(tx = tx, message = message)
+        }
+
+        private fun parseRevised(json: JsonObject): Revised {
+            val tx = json["tx"]?.jsonPrimitive?.contentOrNull
+                ?: throw Sep08InvalidTransactionResponseException(
+                    "Missing required 'tx' field in 'revised' response"
+                )
+            val message = json["message"]?.jsonPrimitive?.contentOrNull
+                ?: throw Sep08InvalidTransactionResponseException(
+                    "Missing required 'message' field in 'revised' response"
+                )
+            return Revised(tx = tx, message = message)
+        }
+
+        private fun parsePending(json: JsonObject): Pending {
+            val timeout = json["timeout"]?.jsonPrimitive?.intOrNull ?: 0
+            val message = json["message"]?.jsonPrimitive?.contentOrNull
+            return Pending(timeout = timeout, message = message)
+        }
+
+        private fun parseActionRequired(json: JsonObject): ActionRequired {
+            val message = json["message"]?.jsonPrimitive?.contentOrNull
+                ?: throw Sep08InvalidTransactionResponseException(
+                    "Missing required 'message' field in 'action_required' response"
+                )
+            val actionUrl = json["action_url"]?.jsonPrimitive?.contentOrNull
+                ?: throw Sep08InvalidTransactionResponseException(
+                    "Missing required 'action_url' field in 'action_required' response"
+                )
+            val actionMethod = json["action_method"]?.jsonPrimitive?.contentOrNull ?: "GET"
+            val actionFields = json["action_fields"]?.jsonArray?.map {
+                it.jsonPrimitive.content
+            }
+            return ActionRequired(
+                message = message,
+                actionUrl = actionUrl,
+                actionMethod = actionMethod,
+                actionFields = actionFields
+            )
+        }
+
+        private fun parseRejected(json: JsonObject): Rejected {
+            val error = json["error"]?.jsonPrimitive?.contentOrNull
+                ?: throw Sep08InvalidTransactionResponseException(
+                    "Missing required 'error' field in 'rejected' response"
+                )
+            return Rejected(error = error)
+        }
+    }
+}

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/Sep08Service.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/Sep08Service.kt
@@ -1,0 +1,480 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.sep.sep08
+
+import com.soneso.stellar.sdk.Network
+import com.soneso.stellar.sdk.horizon.HorizonServer
+import com.soneso.stellar.sdk.sep.sep01.StellarToml
+import com.soneso.stellar.sdk.sep.sep08.exceptions.Sep08IncompleteInitDataException
+import com.soneso.stellar.sdk.sep.sep08.exceptions.Sep08InvalidActionResponseException
+import com.soneso.stellar.sdk.sep.sep08.exceptions.Sep08InvalidTransactionResponseException
+import io.ktor.client.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * SEP-8 Regulated Assets service client.
+ *
+ * Provides support for regulated assets on the Stellar network. Regulated assets are assets
+ * that require issuer approval before transactions involving them can be submitted. The issuer
+ * publishes an approval server URL in their stellar.toml file, and all transactions involving
+ * the regulated asset must be submitted to the approval server for authorization.
+ *
+ * This service handles:
+ * - Discovering regulated assets and their approval servers from stellar.toml
+ * - Checking whether an issuer account has authorization required and revocable flags set
+ * - Submitting transactions to approval servers for regulatory approval
+ * - Completing action flows when additional user interaction is required (e.g., KYC)
+ *
+ * Typical workflow:
+ * 1. Create service instance via [fromDomain]
+ * 2. Check available regulated assets via [regulatedAssets]
+ * 3. Build a transaction involving the regulated asset
+ * 4. Submit the transaction to the approval server via [postTransaction]
+ * 5. Handle the response (approved, revised, pending, action required, or rejected)
+ * 6. If action required, complete the action via [postAction] and resubmit
+ *
+ * Example - Discover regulated assets:
+ * ```kotlin
+ * val sep08 = Sep08Service.fromDomain("example.com")
+ *
+ * sep08.regulatedAssets.forEach { asset ->
+ *     println("${asset.code}:${asset.issuer}")
+ *     println("Approval server: ${asset.approvalServer}")
+ *     asset.approvalCriteria?.let { println("Criteria: $it") }
+ * }
+ * ```
+ *
+ * Example - Submit transaction for approval:
+ * ```kotlin
+ * val sep08 = Sep08Service.fromDomain("example.com")
+ * val asset = sep08.regulatedAssets.first()
+ *
+ * // Build and sign a payment transaction involving the regulated asset
+ * val tx = TransactionBuilder(sourceAccount, network)
+ *     .addOperation(PaymentOperation.Builder(destination, asset.toAsset(), "100").build())
+ *     .setTimeout(180)
+ *     .setBaseFee(100)
+ *     .build()
+ * tx.sign(senderKeyPair)
+ *
+ * // Submit to approval server
+ * val response = sep08.postTransaction(tx.toEnvelopeXdrBase64(), asset.approvalServer)
+ *
+ * when (response) {
+ *     is Sep08PostTransactionResponse.Success -> {
+ *         // Submit response.tx to the Stellar network
+ *         horizonServer.submitTransaction(response.tx)
+ *     }
+ *     is Sep08PostTransactionResponse.Revised -> {
+ *         // Review and sign the revised transaction, then submit
+ *         println("Revised: ${response.message}")
+ *     }
+ *     is Sep08PostTransactionResponse.Pending -> {
+ *         // Wait and retry after response.timeout milliseconds
+ *     }
+ *     is Sep08PostTransactionResponse.ActionRequired -> {
+ *         // Direct user to response.actionUrl
+ *     }
+ *     is Sep08PostTransactionResponse.Rejected -> {
+ *         // Transaction rejected: response.error
+ *     }
+ * }
+ * ```
+ *
+ * Example - Handle action required flow:
+ * ```kotlin
+ * val actionResponse = sep08.postAction(
+ *     url = response.actionUrl,
+ *     actionFields = mapOf("email_address" to "user@example.com")
+ * )
+ *
+ * when (actionResponse) {
+ *     is Sep08PostActionResponse.Done -> {
+ *         // Resubmit the original transaction
+ *         val retryResponse = sep08.postTransaction(tx, asset.approvalServer)
+ *     }
+ *     is Sep08PostActionResponse.NextUrl -> {
+ *         // Direct user to actionResponse.nextUrl
+ *     }
+ * }
+ * ```
+ *
+ * See also:
+ * - [fromDomain] for automatic configuration from stellar.toml
+ * - [Sep08PostTransactionResponse] for approval server response types
+ * - [Sep08PostActionResponse] for action URL response types
+ * - [RegulatedAsset] for regulated asset details
+ * - [SEP-0008 Specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md)
+ *
+ * @property tomlData The parsed stellar.toml data for the issuer's domain
+ * @property regulatedAssets List of regulated assets discovered from the stellar.toml
+ * @property network The Stellar network this service operates on
+ * @property horizonServer The Horizon server instance used for account queries
+ */
+class Sep08Service(
+    val tomlData: StellarToml,
+    val regulatedAssets: List<RegulatedAsset>,
+    private val network: Network,
+    private val horizonServer: HorizonServer,
+    private val httpClient: HttpClient? = null,
+    private val httpRequestHeaders: Map<String, String>? = null
+) {
+    /**
+     * JSON configuration for parsing server responses.
+     */
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    companion object {
+        /**
+         * Creates a Sep08Service by discovering regulated assets from stellar.toml.
+         *
+         * Fetches the stellar.toml file from the specified domain and extracts all regulated
+         * asset entries. The network and Horizon URL are resolved from the provided parameters
+         * or from the stellar.toml configuration.
+         *
+         * Resolution order for network:
+         * 1. Explicit [network] parameter if provided
+         * 2. NETWORK_PASSPHRASE from stellar.toml, mapped to known networks or created as custom
+         *
+         * Resolution order for Horizon URL:
+         * 1. Explicit [horizonUrl] parameter if provided
+         * 2. HORIZON_URL from stellar.toml
+         * 3. Default Horizon URL for the resolved network (public, testnet, or futurenet)
+         *
+         * @param domain The domain name (without protocol). E.g., "example.com"
+         * @param horizonUrl Optional Horizon server URL override
+         * @param network Optional network override
+         * @param httpClient Optional custom HTTP client for testing
+         * @param httpRequestHeaders Optional custom headers for requests
+         * @return Sep08Service configured with regulated assets from the domain's stellar.toml
+         * @throws Sep08IncompleteInitDataException If the network passphrase or Horizon URL
+         *   cannot be determined
+         *
+         * Example:
+         * ```kotlin
+         * // Auto-configure from stellar.toml
+         * val sep08 = Sep08Service.fromDomain("example.com")
+         *
+         * // With explicit network and Horizon URL
+         * val sep08Testnet = Sep08Service.fromDomain(
+         *     domain = "testanchor.example.com",
+         *     horizonUrl = "https://horizon-testnet.stellar.org",
+         *     network = Network.TESTNET
+         * )
+         * ```
+         */
+        suspend fun fromDomain(
+            domain: String,
+            horizonUrl: String? = null,
+            network: Network? = null,
+            httpClient: HttpClient? = null,
+            httpRequestHeaders: Map<String, String>? = null
+        ): Sep08Service {
+            val tomlData = StellarToml.fromDomain(
+                domain = domain,
+                httpClient = httpClient,
+                httpRequestHeaders = httpRequestHeaders
+            )
+
+            // Resolve network
+            val resolvedNetwork = if (network != null) {
+                network
+            } else {
+                val passphrase = tomlData.generalInformation.networkPassphrase
+                    ?: throw Sep08IncompleteInitDataException(
+                        "Network passphrase not found in stellar.toml for domain: $domain"
+                    )
+                when (passphrase) {
+                    Network.PUBLIC.networkPassphrase -> Network.PUBLIC
+                    Network.TESTNET.networkPassphrase -> Network.TESTNET
+                    Network.FUTURENET.networkPassphrase -> Network.FUTURENET
+                    Network.STANDALONE.networkPassphrase -> Network.STANDALONE
+                    Network.SANDBOX.networkPassphrase -> Network.SANDBOX
+                    else -> Network(passphrase)
+                }
+            }
+
+            // Resolve Horizon URL
+            val resolvedHorizonUrl = if (horizonUrl != null) {
+                horizonUrl
+            } else if (tomlData.generalInformation.horizonUrl != null) {
+                tomlData.generalInformation.horizonUrl
+            } else {
+                when (resolvedNetwork.networkPassphrase) {
+                    Network.PUBLIC.networkPassphrase -> "https://horizon.stellar.org"
+                    Network.TESTNET.networkPassphrase -> "https://horizon-testnet.stellar.org"
+                    Network.FUTURENET.networkPassphrase -> "https://horizon-futurenet.stellar.org"
+                    else -> throw Sep08IncompleteInitDataException(
+                        "Horizon URL could not be determined for domain: $domain"
+                    )
+                }
+            }
+
+            val horizonServer = HorizonServer(resolvedHorizonUrl)
+
+            // Extract regulated assets from currencies
+            val regulatedAssets = tomlData.currencies
+                ?.filter { currency ->
+                    currency.regulated == true &&
+                        currency.code != null &&
+                        currency.issuer != null &&
+                        currency.approvalServer != null
+                }
+                ?.map { currency ->
+                    RegulatedAsset(
+                        code = currency.code!!,
+                        issuer = currency.issuer!!,
+                        approvalServer = currency.approvalServer!!,
+                        approvalCriteria = currency.approvalCriteria
+                    )
+                }
+                ?: emptyList()
+
+            return Sep08Service(
+                tomlData = tomlData,
+                regulatedAssets = regulatedAssets,
+                network = resolvedNetwork,
+                horizonServer = horizonServer,
+                httpClient = httpClient,
+                httpRequestHeaders = httpRequestHeaders
+            )
+        }
+    }
+
+    /**
+     * Checks whether the issuer of a regulated asset has the `auth_required` and
+     * `auth_revocable` flags set on their account.
+     *
+     * Both flags must be set for an asset to be properly configured as a regulated asset
+     * per SEP-8. The `auth_required` flag ensures all trustlines must be approved, and the
+     * `auth_revocable` flag allows the issuer to revoke authorization when needed.
+     *
+     * @param asset The regulated asset to check
+     * @return `true` if both `auth_required` and `auth_revocable` are set, `false` otherwise
+     * @throws com.soneso.stellar.sdk.horizon.exceptions.BadRequestException If the issuer
+     *   account does not exist on the network
+     * @throws com.soneso.stellar.sdk.horizon.exceptions.NetworkException On network errors
+     *
+     * Example:
+     * ```kotlin
+     * val asset = sep08.regulatedAssets.first()
+     * if (sep08.authorizationRequired(asset)) {
+     *     println("${asset.code} requires transaction approval")
+     * } else {
+     *     println("${asset.code} issuer flags not properly configured for SEP-8")
+     * }
+     * ```
+     */
+    suspend fun authorizationRequired(asset: RegulatedAsset): Boolean {
+        val account = horizonServer.accounts().account(asset.issuer)
+        return account.flags.authRequired && account.flags.authRevocable
+    }
+
+    /**
+     * Submits a transaction to the approval server for regulatory review.
+     *
+     * The transaction XDR envelope is sent as a JSON payload to the specified approval server.
+     * The server evaluates the transaction against its compliance rules and returns one of
+     * five possible outcomes (success, revised, pending, action_required, or rejected).
+     *
+     * @param tx The base64-encoded transaction envelope XDR to submit for approval
+     * @param approvalServer The URL of the SEP-8 approval server
+     * @return [Sep08PostTransactionResponse] containing the approval server's decision
+     * @throws Sep08InvalidTransactionResponseException If the server returns a malformed
+     *   response or an unexpected HTTP status code
+     *
+     * Example:
+     * ```kotlin
+     * val asset = sep08.regulatedAssets.first()
+     * val response = sep08.postTransaction(
+     *     tx = transaction.toEnvelopeXdrBase64(),
+     *     approvalServer = asset.approvalServer
+     * )
+     *
+     * when (response) {
+     *     is Sep08PostTransactionResponse.Success -> {
+     *         // Approved - submit response.tx to the network
+     *     }
+     *     is Sep08PostTransactionResponse.Revised -> {
+     *         // Revised - review response.tx and response.message
+     *     }
+     *     is Sep08PostTransactionResponse.Pending -> {
+     *         // Pending - retry after response.timeout milliseconds
+     *     }
+     *     is Sep08PostTransactionResponse.ActionRequired -> {
+     *         // Action needed - direct user to response.actionUrl
+     *     }
+     *     is Sep08PostTransactionResponse.Rejected -> {
+     *         // Rejected - display response.error
+     *     }
+     * }
+     * ```
+     */
+    suspend fun postTransaction(
+        tx: String,
+        approvalServer: String
+    ): Sep08PostTransactionResponse = withHttpClient { client ->
+        val headers = buildHeaders()
+
+        val response = client.post(approvalServer) {
+            headers.forEach { (key, value) -> header(key, value) }
+            contentType(ContentType.Application.Json)
+            setBody(mapOf("tx" to tx))
+        }
+
+        val body = response.bodyAsText()
+
+        when (response.status.value) {
+            200 -> {
+                val jsonObject = json.decodeFromString<JsonObject>(body)
+                Sep08PostTransactionResponse.fromJson(jsonObject)
+            }
+            400 -> {
+                try {
+                    val jsonObject = json.decodeFromString<JsonObject>(body)
+                    val status = jsonObject["status"]?.jsonPrimitive?.contentOrNull
+                    if (status == "rejected") {
+                        Sep08PostTransactionResponse.fromJson(jsonObject)
+                    } else {
+                        throw Sep08InvalidTransactionResponseException(
+                            "Unexpected HTTP status: ${response.status.value}, body: $body"
+                        )
+                    }
+                } catch (e: Sep08InvalidTransactionResponseException) {
+                    throw e
+                } catch (e: Exception) {
+                    throw Sep08InvalidTransactionResponseException(
+                        "Unexpected HTTP status: ${response.status.value}, body: $body"
+                    )
+                }
+            }
+            else -> {
+                throw Sep08InvalidTransactionResponseException(
+                    "Unexpected HTTP status: ${response.status.value}, body: $body"
+                )
+            }
+        }
+    }
+
+    /**
+     * Submits action fields to an action URL provided by the approval server.
+     *
+     * When the approval server returns an [Sep08PostTransactionResponse.ActionRequired] response
+     * with `actionMethod = "POST"`, the client must submit the required fields to the action URL.
+     * This method handles that POST request and parses the response.
+     *
+     * The action URL may return either a "done" response (indicating the client should resubmit
+     * the original transaction) or a "next_url" response (indicating additional steps are needed).
+     *
+     * @param url The action URL from the [Sep08PostTransactionResponse.ActionRequired] response
+     * @param actionFields Map of field names to values as required by the action URL
+     * @return [Sep08PostActionResponse] indicating whether the action is complete or more steps
+     *   are needed
+     * @throws Sep08InvalidActionResponseException If the action URL returns a malformed response
+     *   or an unexpected HTTP status code
+     *
+     * Example:
+     * ```kotlin
+     * // After receiving an ActionRequired response
+     * val actionResponse = sep08.postAction(
+     *     url = actionRequired.actionUrl,
+     *     actionFields = mapOf(
+     *         "email_address" to "user@example.com",
+     *         "mobile_number" to "+1234567890"
+     *     )
+     * )
+     *
+     * when (actionResponse) {
+     *     is Sep08PostActionResponse.Done -> {
+     *         // Resubmit the original transaction to the approval server
+     *         val retryResponse = sep08.postTransaction(tx, approvalServer)
+     *     }
+     *     is Sep08PostActionResponse.NextUrl -> {
+     *         // Direct user to actionResponse.nextUrl
+     *         println("Next step: ${actionResponse.message}")
+     *     }
+     * }
+     * ```
+     */
+    suspend fun postAction(
+        url: String,
+        actionFields: Map<String, String>
+    ): Sep08PostActionResponse = withHttpClient { client ->
+        val headers = buildHeaders()
+
+        val response = client.post(url) {
+            headers.forEach { (key, value) -> header(key, value) }
+            contentType(ContentType.Application.Json)
+            setBody(actionFields)
+        }
+
+        val body = response.bodyAsText()
+
+        when (response.status.value) {
+            200 -> {
+                val jsonObject = json.decodeFromString<JsonObject>(body)
+                Sep08PostActionResponse.fromJson(jsonObject)
+            }
+            else -> {
+                throw Sep08InvalidActionResponseException(
+                    "Unexpected HTTP status: ${response.status.value}, body: $body"
+                )
+            }
+        }
+    }
+
+    // ========== Private HTTP Utilities ==========
+
+    /**
+     * Executes a block with an HTTP client, managing lifecycle properly.
+     *
+     * If a custom [httpClient] was provided at construction time, it is reused and not closed.
+     * Otherwise, a temporary client is created with standard timeout settings and closed
+     * after the block completes.
+     */
+    private suspend fun <T> withHttpClient(block: suspend (HttpClient) -> T): T {
+        val client = httpClient ?: HttpClient {
+            install(ContentNegotiation) {
+                json(json)
+            }
+            install(HttpTimeout) {
+                connectTimeoutMillis = 10_000
+                requestTimeoutMillis = 30_000
+            }
+        }
+
+        return try {
+            block(client)
+        } finally {
+            if (httpClient == null) {
+                client.close()
+            }
+        }
+    }
+
+    /**
+     * Builds request headers from custom headers.
+     *
+     * SEP-8 does not use JWT authentication (unlike SEP-6/SEP-24), so this method
+     * only merges the custom headers provided at construction time.
+     */
+    private fun buildHeaders(): Map<String, String> {
+        val headers = mutableMapOf<String, String>()
+        httpRequestHeaders?.let { headers.putAll(it) }
+        return headers
+    }
+}

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/exceptions/Sep08Exception.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/exceptions/Sep08Exception.kt
@@ -1,0 +1,49 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.sep.sep08.exceptions
+
+/**
+ * Base exception class for SEP-8 Regulated Assets errors.
+ *
+ * All SEP-8-specific exceptions extend this class to enable unified error handling
+ * while providing specific error types for different failure scenarios.
+ *
+ * This exception hierarchy allows applications to handle regulated asset errors at different levels:
+ * - Catch Sep08Exception for general SEP-8 error handling
+ * - Catch specific subclasses for precise error recovery
+ *
+ * Common error scenarios:
+ * - [Sep08IncompleteInitDataException]: Network passphrase or Horizon URL missing during initialization
+ * - [Sep08InvalidTransactionResponseException]: Malformed approval server response to postTransaction
+ * - [Sep08InvalidActionResponseException]: Malformed action URL response to postAction
+ *
+ * Example - General error handling:
+ * ```kotlin
+ * try {
+ *     val response = sep08Service.postTransaction(tx)
+ * } catch (e: Sep08InvalidTransactionResponseException) {
+ *     println("Invalid response from approval server: ${e.message}")
+ * } catch (e: Sep08Exception) {
+ *     println("SEP-8 error: ${e.message}")
+ * }
+ * ```
+ *
+ * See also:
+ * - [Sep08IncompleteInitDataException] for initialization data errors
+ * - [Sep08InvalidTransactionResponseException] for malformed postTransaction responses
+ * - [Sep08InvalidActionResponseException] for malformed postAction responses
+ * - [SEP-0008 Specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md)
+ *
+ * @property message Human-readable error description
+ * @property cause Optional underlying cause of the error
+ */
+open class Sep08Exception(
+    message: String,
+    cause: Throwable? = null
+) : Exception(message, cause) {
+    override fun toString(): String {
+        return "SEP-08 error: $message"
+    }
+}

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/exceptions/Sep08IncompleteInitDataException.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/exceptions/Sep08IncompleteInitDataException.kt
@@ -1,0 +1,43 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.sep.sep08.exceptions
+
+/**
+ * Exception thrown when required initialization data is missing for the SEP-8 service.
+ *
+ * Indicates that the network passphrase or Horizon server URL could not be determined
+ * during service initialization. This typically occurs when:
+ * - The stellar.toml file does not contain a NETWORK_PASSPHRASE entry
+ * - The stellar.toml file does not contain a HORIZON_URL entry
+ * - The stellar.toml file cannot be resolved from the asset issuer's domain
+ *
+ * Recovery actions:
+ * - Verify the issuer's stellar.toml contains NETWORK_PASSPHRASE and HORIZON_URL
+ * - Provide the network passphrase and Horizon URL explicitly during initialization
+ * - Ensure the issuer's home domain is correctly configured
+ *
+ * Example - Handle missing init data:
+ * ```kotlin
+ * try {
+ *     val service = Sep08Service.forDomain("example.com")
+ * } catch (e: Sep08IncompleteInitDataException) {
+ *     println("Missing configuration: ${e.message}")
+ *     // Fall back to explicit configuration
+ * }
+ * ```
+ *
+ * See also:
+ * - [Sep08Exception] base class
+ * - [SEP-0008 Specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md)
+ *
+ * @param message Detailed error message describing the missing initialization data
+ */
+class Sep08IncompleteInitDataException(
+    message: String
+) : Sep08Exception(message) {
+    override fun toString(): String {
+        return "SEP-08 incomplete init data: $message"
+    }
+}

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/exceptions/Sep08InvalidActionResponseException.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/exceptions/Sep08InvalidActionResponseException.kt
@@ -1,0 +1,49 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.sep.sep08.exceptions
+
+/**
+ * Exception thrown when the action URL returns a malformed or unexpected response
+ * to a post-action request (postAction).
+ *
+ * Indicates that the response from the action URL could not be parsed or does not
+ * conform to the SEP-8 specification. This typically occurs when:
+ * - The response JSON is malformed or missing required fields
+ * - The response does not contain a valid result field
+ * - The action URL returned an unexpected HTTP status code
+ * - The next_url field is present but invalid
+ *
+ * Action URLs are provided by the approval server when a transaction requires
+ * additional steps (e.g., KYC verification) before it can be approved. The client
+ * submits required fields to the action URL and processes the response.
+ *
+ * Recovery actions:
+ * - Verify all required fields were submitted to the action URL
+ * - Check the action URL is accessible and returning valid JSON
+ * - Ensure the request content type matches what the server expects
+ * - Contact the asset issuer if the problem persists
+ *
+ * Example - Handle invalid action response:
+ * ```kotlin
+ * try {
+ *     val response = sep08Service.postAction(actionUrl, actionFields)
+ * } catch (e: Sep08InvalidActionResponseException) {
+ *     println("Action URL returned invalid response: ${e.message}")
+ * }
+ * ```
+ *
+ * See also:
+ * - [Sep08Exception] base class
+ * - [SEP-0008 Specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md)
+ *
+ * @param message Detailed error message describing the response parsing failure
+ */
+class Sep08InvalidActionResponseException(
+    message: String
+) : Sep08Exception(message) {
+    override fun toString(): String {
+        return "SEP-08 invalid action response: $message"
+    }
+}

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/exceptions/Sep08InvalidTransactionResponseException.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep08/exceptions/Sep08InvalidTransactionResponseException.kt
@@ -1,0 +1,47 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.sep.sep08.exceptions
+
+/**
+ * Exception thrown when the approval server returns a malformed or unexpected response
+ * to a transaction approval request (postTransaction).
+ *
+ * Indicates that the response from the approval server could not be parsed or does not
+ * conform to the SEP-8 specification. This typically occurs when:
+ * - The response JSON is malformed or missing required fields
+ * - The response status field contains an unrecognized value
+ * - A "revised" response is missing the required tx field
+ * - A "rejected" response is missing the required error field
+ * - An "action_required" response is missing the required action_url field
+ * - The response HTTP status code is unexpected
+ *
+ * Recovery actions:
+ * - Verify the approval server URL is correct
+ * - Check the approval server logs for errors
+ * - Ensure the transaction XDR is well-formed before submission
+ * - Contact the asset issuer if the problem persists
+ *
+ * Example - Handle invalid response:
+ * ```kotlin
+ * try {
+ *     val response = sep08Service.postTransaction(signedTxXdr)
+ * } catch (e: Sep08InvalidTransactionResponseException) {
+ *     println("Approval server returned invalid response: ${e.message}")
+ * }
+ * ```
+ *
+ * See also:
+ * - [Sep08Exception] base class
+ * - [SEP-0008 Specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md)
+ *
+ * @param message Detailed error message describing the response parsing failure
+ */
+class Sep08InvalidTransactionResponseException(
+    message: String
+) : Sep08Exception(message) {
+    override fun toString(): String {
+        return "SEP-08 invalid transaction response: $message"
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/sep/sep08/Sep08IntegrationTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/sep/sep08/Sep08IntegrationTest.kt
@@ -1,0 +1,1187 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.integrationTests.sep.sep08
+
+import com.soneso.stellar.sdk.*
+import com.soneso.stellar.sdk.horizon.HorizonServer
+import com.soneso.stellar.sdk.integrationTests.realDelay
+import com.soneso.stellar.sdk.sep.sep01.StellarToml
+import com.soneso.stellar.sdk.sep.sep08.RegulatedAsset
+import com.soneso.stellar.sdk.sep.sep08.Sep08PostActionResponse
+import com.soneso.stellar.sdk.sep.sep08.Sep08PostTransactionResponse
+import com.soneso.stellar.sdk.sep.sep08.Sep08Service
+import com.soneso.stellar.sdk.xdr.AccountFlagsXdr
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Integration tests for SEP-8 Regulated Assets service.
+ *
+ * These tests validate SEP-8 functionality including:
+ * - Authorization flag checking against live Stellar testnet accounts
+ * - Stellar TOML regulated asset parsing
+ * - Transaction approval flows using mock approval servers (all 5 response types)
+ * - Request body validation for postTransaction and postAction
+ * - Action URL response handling
+ * - fromDomain construction with mock HTTP
+ * - Realistic regulated transaction pattern (SetTrustLineFlags sandwich)
+ *
+ * Tests 1 and 2 interact with the live Stellar testnet (FriendBot funding,
+ * SetOptions transactions). Tests 3-14 use mock HTTP clients and do not
+ * require network access.
+ *
+ * Reference:
+ * - SEP-8 Specification: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md
+ */
+class Sep08IntegrationTest {
+
+    private val network = Network.TESTNET
+    private val horizonUrl = "https://horizon-testnet.stellar.org"
+    private val horizonServer = HorizonServer(horizonUrl)
+
+    private val jsonConfig = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    /**
+     * Shared TOML content used across multiple tests. Matches the pattern from
+     * the Flutter and PHP SDKs with two regulated assets (GOAT, JACK) and one
+     * non-regulated asset (NOP).
+     */
+    private val anchorToml = """
+        # Sample stellar.toml
+        VERSION="2.0.0"
+
+        NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+        WEB_AUTH_ENDPOINT="https://api.anchor.org/auth"
+        TRANSFER_SERVER_SEP0024="http://api.stellar.org/transfer-sep24/"
+        ANCHOR_QUOTE_SERVER="http://api.stellar.org/quotes-sep38/"
+        SIGNING_KEY="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+
+        [[CURRENCIES]]
+        code="GOAT"
+        regulated=true
+        approval_server="https://goat.io/tx_approve"
+        approval_criteria="The goat approval server will ensure that transactions are compliant with NFO regulation"
+
+        [[CURRENCIES]]
+        code="NOP"
+        issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+        display_decimals=2
+
+        [[CURRENCIES]]
+        code="JACK"
+        regulated=true
+        approval_server="https://jack.io/tx_approve"
+        approval_criteria="The jack approval server will ensure that transactions are compliant with NFO regulation"
+    """.trimIndent()
+
+    /**
+     * Funds a testnet account via FriendBot and waits for the funding to settle.
+     */
+    private suspend fun fundAccount(accountId: String) {
+        val funded = FriendBot.fundTestnetAccount(accountId)
+        assertTrue(funded, "Account funding should succeed")
+        realDelay(5000)
+    }
+
+    /**
+     * Sets AUTH_REQUIRED and AUTH_REVOCABLE flags on an issuer account.
+     *
+     * Loads the account from Horizon, builds and signs a SetOptions transaction
+     * with the combined flag value, submits it, and waits for processing.
+     */
+    private suspend fun setAuthFlags(issuerKeyPair: KeyPair) {
+        val issuerId = issuerKeyPair.getAccountId()
+        val issuerAccount = horizonServer.accounts().account(issuerId)
+
+        val setFlagsValue = AccountFlagsXdr.AUTH_REQUIRED_FLAG.value or
+            AccountFlagsXdr.AUTH_REVOCABLE_FLAG.value
+
+        val transaction = TransactionBuilder(
+            sourceAccount = Account(issuerId, issuerAccount.sequenceNumber),
+            network = network
+        )
+            .addOperation(SetOptionsOperation(setFlags = setFlagsValue))
+            .setTimeout(TransactionPreconditions.TIMEOUT_INFINITE)
+            .setBaseFee(AbstractTransaction.MIN_BASE_FEE)
+            .build()
+
+        transaction.sign(issuerKeyPair)
+
+        val response = horizonServer.submitTransaction(transaction.toEnvelopeXdrBase64())
+        assertTrue(response.successful, "SetOptions transaction should succeed")
+
+        realDelay(5000)
+    }
+
+    /**
+     * Creates a Sep08Service instance using a mock HTTP client.
+     *
+     * The returned service has an empty regulated assets list and empty TOML data.
+     * It is intended for testing postTransaction and postAction flows where the
+     * TOML content is irrelevant.
+     */
+    private fun createServiceWithMockClient(mockClient: HttpClient): Sep08Service {
+        val emptyToml = StellarToml.parse("")
+        return Sep08Service(
+            tomlData = emptyToml,
+            regulatedAssets = emptyList(),
+            network = network,
+            horizonServer = horizonServer,
+            httpClient = mockClient
+        )
+    }
+
+    /**
+     * Creates a mock HttpClient with ContentNegotiation installed.
+     */
+    private fun createMockHttpClient(mockEngine: MockEngine): HttpClient {
+        return HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(jsonConfig)
+            }
+        }
+    }
+
+    /**
+     * Builds a canonical SEP-8 regulated transaction with the approval server
+     * sandwich pattern:
+     * - Op 1: SetTrustLineFlags - authorize the trustor for the regulated asset
+     * - Op 2: ManageBuyOffer - the user's actual operation
+     * - Op 3: SetTrustLineFlags - set trustor to AUTHORIZED_TO_MAINTAIN_LIABILITIES
+     *
+     * This is the pattern used by the Flutter and PHP SDK integration tests.
+     *
+     * @param sourceAccountId The source account for the transaction
+     * @param sourceSequence The current sequence number of the source account
+     * @param trustorId The account whose trustline flags are being modified
+     * @param regulatedAsset The regulated asset for the operations
+     * @param issuerId The issuer account ID (source for SetTrustLineFlags ops)
+     * @return The built (unsigned) Transaction
+     */
+    private fun buildRegulatedTransaction(
+        sourceAccountId: String,
+        sourceSequence: Long,
+        trustorId: String,
+        regulatedAsset: Asset,
+        issuerId: String
+    ): Transaction {
+        // Op 1: Issuer fully authorizes the trustor for the regulated asset
+        val op1 = SetTrustLineFlagsOperation(
+            trustor = trustorId,
+            asset = regulatedAsset,
+            clearFlags = 0,
+            setFlags = SetTrustLineFlagsOperation.AUTHORIZED_FLAG
+        ).apply { sourceAccount = issuerId }
+
+        // Op 2: The user's actual operation (buy the regulated asset)
+        val op2 = ManageBuyOfferOperation(
+            selling = AssetTypeNative,
+            buying = regulatedAsset,
+            buyAmount = "10",
+            price = Price(1, 10) // 0.1
+        )
+
+        // Op 3: Issuer sets trustor to AUTHORIZED_TO_MAINTAIN_LIABILITIES
+        val op3 = SetTrustLineFlagsOperation(
+            trustor = trustorId,
+            asset = regulatedAsset,
+            clearFlags = SetTrustLineFlagsOperation.AUTHORIZED_FLAG,
+            setFlags = SetTrustLineFlagsOperation.AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG
+        ).apply { sourceAccount = issuerId }
+
+        return TransactionBuilder(
+            sourceAccount = Account(sourceAccountId, sourceSequence),
+            network = network
+        )
+            .addOperation(op1)
+            .addOperation(op2)
+            .addOperation(op3)
+            .setTimeout(TransactionPreconditions.TIMEOUT_INFINITE)
+            .setBaseFee(AbstractTransaction.MIN_BASE_FEE)
+            .build()
+    }
+
+    // ==================== Live Testnet Tests ====================
+
+    /**
+     * Verifies that authorizationRequired returns true for an issuer account
+     * with AUTH_REQUIRED and AUTH_REVOCABLE flags set.
+     *
+     * Steps:
+     * 1. Generate random keypair for issuer
+     * 2. Fund via FriendBot
+     * 3. Set AUTH_REQUIRED + AUTH_REVOCABLE flags via SetOptionsOperation
+     * 4. Create RegulatedAsset referencing the issuer
+     * 5. Call authorizationRequired and assert it returns true
+     */
+    @Test
+    fun testAuthorizationRequiredWithRegulatedIssuer() = runTest(timeout = 120.seconds) {
+        val issuerKeyPair = KeyPair.random()
+        val issuerId = issuerKeyPair.getAccountId()
+
+        println("Issuer account: $issuerId")
+
+        fundAccount(issuerId)
+        setAuthFlags(issuerKeyPair)
+
+        // Verify flags were set on the account
+        val updatedAccount = horizonServer.accounts().account(issuerId)
+        assertTrue(updatedAccount.flags.authRequired, "AUTH_REQUIRED should be set")
+        assertTrue(updatedAccount.flags.authRevocable, "AUTH_REVOCABLE should be set")
+
+        val regulatedAsset = RegulatedAsset(
+            code = "REG",
+            issuer = issuerId,
+            approvalServer = "https://example.com/tx_approve"
+        )
+
+        val emptyToml = StellarToml.parse("")
+        val sep08Service = Sep08Service(
+            tomlData = emptyToml,
+            regulatedAssets = listOf(regulatedAsset),
+            network = network,
+            horizonServer = horizonServer
+        )
+
+        val result = sep08Service.authorizationRequired(regulatedAsset)
+        assertTrue(result, "authorizationRequired should return true for regulated issuer")
+
+        println("authorizationRequired correctly returned true for regulated issuer")
+    }
+
+    /**
+     * Verifies that authorizationRequired returns false for an account
+     * without authorization flags.
+     *
+     * Steps:
+     * 1. Generate random keypair
+     * 2. Fund via FriendBot (no auth flags set)
+     * 3. Create RegulatedAsset referencing the account as issuer
+     * 4. Call authorizationRequired and assert it returns false
+     */
+    @Test
+    fun testAuthorizationNotRequiredWithoutFlags() = runTest(timeout = 60.seconds) {
+        val keyPair = KeyPair.random()
+        val accountId = keyPair.getAccountId()
+
+        println("Account without flags: $accountId")
+
+        fundAccount(accountId)
+
+        // Verify flags are not set
+        val account = horizonServer.accounts().account(accountId)
+        assertFalse(account.flags.authRequired, "AUTH_REQUIRED should not be set")
+        assertFalse(account.flags.authRevocable, "AUTH_REVOCABLE should not be set")
+
+        val regulatedAsset = RegulatedAsset(
+            code = "TEST",
+            issuer = accountId,
+            approvalServer = "https://example.com/tx_approve"
+        )
+
+        val emptyToml = StellarToml.parse("")
+        val sep08Service = Sep08Service(
+            tomlData = emptyToml,
+            regulatedAssets = listOf(regulatedAsset),
+            network = network,
+            horizonServer = horizonServer
+        )
+
+        val result = sep08Service.authorizationRequired(regulatedAsset)
+        assertFalse(result, "authorizationRequired should return false without auth flags")
+
+        println("authorizationRequired correctly returned false for unregulated issuer")
+    }
+
+    // ==================== TOML Parsing Test ====================
+
+    /**
+     * Verifies that regulated asset entries are correctly parsed from stellar.toml
+     * content and that Sep08Service can be constructed from the parsed data.
+     *
+     * Steps:
+     * 1. Create a TOML string with regulated and non-regulated currencies
+     * 2. Parse with StellarToml.parse()
+     * 3. Verify currency fields (regulated, approvalServer, approvalCriteria)
+     * 4. Create Sep08Service from the parsed TOML data
+     * 5. Verify regulatedAssets list contains the correct entries
+     */
+    @Test
+    fun testStellarTomlRegulatedAssetParsing() = runTest {
+        val toml = """
+            NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
+            HORIZON_URL = "https://horizon-testnet.stellar.org"
+
+            [[CURRENCIES]]
+            code = "GOAT"
+            issuer = "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"
+            regulated = true
+            approval_server = "https://goat.example.com/tx_approve"
+            approval_criteria = "Transactions must be below 500 GOAT per account per day"
+            status = "live"
+            name = "Goat Token"
+
+            [[CURRENCIES]]
+            code = "USD"
+            issuer = "GCZJM35NKGVK47BB4SPBDV25477PBER2BAJVZL5A6BQFTDWCYUSEROCI"
+            status = "live"
+            name = "US Dollar"
+
+            [[CURRENCIES]]
+            code = "REG2"
+            issuer = "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"
+            regulated = true
+            approval_server = "https://reg2.example.com/approve"
+            status = "test"
+            name = "Regulated Token Two"
+        """.trimIndent()
+
+        val stellarToml = StellarToml.parse(toml)
+
+        // Verify all currencies were parsed
+        assertNotNull(stellarToml.currencies, "Currencies should be parsed")
+        assertEquals(3, stellarToml.currencies!!.size, "Should have 3 currencies")
+
+        // Verify GOAT (regulated)
+        val goat = stellarToml.currencies!![0]
+        assertEquals("GOAT", goat.code)
+        assertEquals("GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX", goat.issuer)
+        assertTrue(goat.regulated == true, "GOAT should be regulated")
+        assertEquals("https://goat.example.com/tx_approve", goat.approvalServer)
+        assertEquals("Transactions must be below 500 GOAT per account per day", goat.approvalCriteria)
+
+        // Verify USD (not regulated)
+        val usd = stellarToml.currencies!![1]
+        assertEquals("USD", usd.code)
+        assertNull(usd.regulated, "USD should not have regulated flag")
+        assertNull(usd.approvalServer, "USD should not have approval server")
+        assertNull(usd.approvalCriteria, "USD should not have approval criteria")
+
+        // Verify REG2 (regulated, no criteria)
+        val reg2 = stellarToml.currencies!![2]
+        assertEquals("REG2", reg2.code)
+        assertTrue(reg2.regulated == true, "REG2 should be regulated")
+        assertEquals("https://reg2.example.com/approve", reg2.approvalServer)
+        assertNull(reg2.approvalCriteria, "REG2 should not have approval criteria")
+
+        // Create Sep08Service from parsed TOML with explicit network and horizonUrl
+        val regulatedAssets = stellarToml.currencies!!
+            .filter { it.regulated == true && it.code != null && it.issuer != null && it.approvalServer != null }
+            .map { currency ->
+                RegulatedAsset(
+                    code = currency.code!!,
+                    issuer = currency.issuer!!,
+                    approvalServer = currency.approvalServer!!,
+                    approvalCriteria = currency.approvalCriteria
+                )
+            }
+
+        val sep08Service = Sep08Service(
+            tomlData = stellarToml,
+            regulatedAssets = regulatedAssets,
+            network = network,
+            horizonServer = horizonServer
+        )
+
+        assertEquals(2, sep08Service.regulatedAssets.size, "Should have 2 regulated assets")
+
+        val goatAsset = sep08Service.regulatedAssets[0]
+        assertEquals("GOAT", goatAsset.code)
+        assertEquals("GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX", goatAsset.issuer)
+        assertEquals("https://goat.example.com/tx_approve", goatAsset.approvalServer)
+        assertEquals("Transactions must be below 500 GOAT per account per day", goatAsset.approvalCriteria)
+
+        val reg2Asset = sep08Service.regulatedAssets[1]
+        assertEquals("REG2", reg2Asset.code)
+        assertEquals("https://reg2.example.com/approve", reg2Asset.approvalServer)
+        assertNull(reg2Asset.approvalCriteria)
+
+        println("TOML parsing validated: ${sep08Service.regulatedAssets.size} regulated assets found")
+    }
+
+    // ==================== Mock Approval Server Tests ====================
+
+    /**
+     * Verifies that postTransaction correctly parses a "success" response
+     * from the approval server using a realistic regulated transaction with
+     * the SetTrustLineFlags sandwich pattern.
+     *
+     * Steps:
+     * 1. Fund accounts for the issuer and user
+     * 2. Set AUTH_REQUIRED + AUTH_REVOCABLE flags on the issuer
+     * 3. Build a regulated transaction (authorize, buy offer, deauthorize)
+     * 4. Create a mock HTTP client returning a success response
+     * 5. Verify the request body contains the "tx" field with correct XDR
+     * 6. Verify response is Sep08PostTransactionResponse.Success
+     */
+    @Test
+    fun testPostTransactionWithMockApprovalServer() = runTest(timeout = 120.seconds) {
+        val issuerKeyPair = KeyPair.random()
+        val userKeyPair = KeyPair.random()
+        val issuerId = issuerKeyPair.getAccountId()
+        val userId = userKeyPair.getAccountId()
+
+        fundAccount(issuerId)
+        fundAccount(userId)
+        setAuthFlags(issuerKeyPair)
+
+        val regulatedAsset = AssetTypeCreditAlphaNum4("GOAT", issuerId)
+
+        // Build the canonical SEP-8 sandwich transaction
+        val userAccount = horizonServer.accounts().account(userId)
+        val transaction = buildRegulatedTransaction(
+            sourceAccountId = userId,
+            sourceSequence = userAccount.sequenceNumber,
+            trustorId = userId,
+            regulatedAsset = regulatedAsset,
+            issuerId = issuerId
+        )
+        val txXdr = transaction.toEnvelopeXdrBase64()
+
+        // Capture and verify the request body
+        var capturedRequestBody: String? = null
+        var capturedMethod: HttpMethod? = null
+        val mockEngine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedRequestBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = """{"status": "success", "tx": "$txXdr", "message": "Transaction approved"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = createMockHttpClient(mockEngine)
+
+        val sep08Service = createServiceWithMockClient(mockClient)
+        val response = sep08Service.postTransaction(txXdr, "https://goat.io/tx_approve")
+
+        // Verify request
+        assertEquals(HttpMethod.Post, capturedMethod, "Request method should be POST")
+        assertNotNull(capturedRequestBody, "Request body should not be null")
+        assertTrue(capturedRequestBody!!.contains("\"tx\""), "Request body should contain 'tx' field")
+        assertTrue(capturedRequestBody!!.contains(txXdr), "Request body should contain the transaction XDR")
+
+        // Verify response
+        assertTrue(response is Sep08PostTransactionResponse.Success, "Response should be Success")
+        val success = response as Sep08PostTransactionResponse.Success
+        assertEquals(txXdr, success.tx, "Approved tx should match")
+        assertEquals("Transaction approved", success.message)
+
+        println("postTransaction success flow verified with regulated transaction pattern")
+    }
+
+    /**
+     * Verifies that postTransaction correctly parses a "revised" response
+     * from the approval server using a realistic regulated transaction.
+     *
+     * Steps:
+     * 1. Fund accounts and set auth flags on issuer
+     * 2. Build a regulated transaction (sandwich pattern)
+     * 3. Create mock returning a revised response with modified tx
+     * 4. Verify request body contains "tx" field
+     * 5. Verify response is Sep08PostTransactionResponse.Revised
+     */
+    @Test
+    fun testPostTransactionRevisedFlow() = runTest(timeout = 120.seconds) {
+        val issuerKeyPair = KeyPair.random()
+        val userKeyPair = KeyPair.random()
+        val issuerId = issuerKeyPair.getAccountId()
+        val userId = userKeyPair.getAccountId()
+
+        fundAccount(issuerId)
+        fundAccount(userId)
+        setAuthFlags(issuerKeyPair)
+
+        val regulatedAsset = AssetTypeCreditAlphaNum4("GOAT", issuerId)
+
+        val userAccount = horizonServer.accounts().account(userId)
+        val transaction = buildRegulatedTransaction(
+            sourceAccountId = userId,
+            sourceSequence = userAccount.sequenceNumber,
+            trustorId = userId,
+            regulatedAsset = regulatedAsset,
+            issuerId = issuerId
+        )
+        val txXdr = transaction.toEnvelopeXdrBase64()
+
+        // Mock returns "revised" with a modified tx (concatenated to simulate modification)
+        val revisedTxXdr = txXdr + txXdr
+        var capturedRequestBody: String? = null
+        val mockEngine = MockEngine { request ->
+            capturedRequestBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = """{"status": "revised", "tx": "$revisedTxXdr", "message": "Compliance operations added by approval server"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = createMockHttpClient(mockEngine)
+
+        val sep08Service = createServiceWithMockClient(mockClient)
+        val response = sep08Service.postTransaction(txXdr, "https://goat.io/tx_approve")
+
+        // Verify request body
+        assertNotNull(capturedRequestBody, "Request body should not be null")
+        assertTrue(capturedRequestBody!!.contains("\"tx\""), "Request body should contain 'tx' field")
+        assertTrue(capturedRequestBody!!.contains(txXdr), "Request body should contain the transaction XDR")
+
+        // Verify response
+        assertTrue(response is Sep08PostTransactionResponse.Revised, "Response should be Revised")
+        val revised = response as Sep08PostTransactionResponse.Revised
+        assertEquals(revisedTxXdr, revised.tx, "Revised tx should match")
+        assertEquals("Compliance operations added by approval server", revised.message)
+
+        println("postTransaction revised flow verified")
+    }
+
+    /**
+     * Verifies that postTransaction correctly parses a "pending" response
+     * from the approval server.
+     *
+     * The approval server returns HTTP 200 with status "pending", a timeout value,
+     * and a message. This indicates the server needs more time to evaluate the
+     * transaction and the client should resubmit after the timeout period.
+     *
+     * Steps:
+     * 1. Fund accounts and set auth flags on issuer
+     * 2. Build a regulated transaction (sandwich pattern)
+     * 3. Create mock returning a pending response with timeout=3
+     * 4. Verify request body contains "tx" field
+     * 5. Verify response is Sep08PostTransactionResponse.Pending with correct fields
+     */
+    @Test
+    fun testPostTransactionPendingFlow() = runTest(timeout = 120.seconds) {
+        val issuerKeyPair = KeyPair.random()
+        val userKeyPair = KeyPair.random()
+        val issuerId = issuerKeyPair.getAccountId()
+        val userId = userKeyPair.getAccountId()
+
+        fundAccount(issuerId)
+        fundAccount(userId)
+        setAuthFlags(issuerKeyPair)
+
+        val regulatedAsset = AssetTypeCreditAlphaNum4("GOAT", issuerId)
+
+        val userAccount = horizonServer.accounts().account(userId)
+        val transaction = buildRegulatedTransaction(
+            sourceAccountId = userId,
+            sourceSequence = userAccount.sequenceNumber,
+            trustorId = userId,
+            regulatedAsset = regulatedAsset,
+            issuerId = issuerId
+        )
+        val txXdr = transaction.toEnvelopeXdrBase64()
+
+        var capturedRequestBody: String? = null
+        val mockEngine = MockEngine { request ->
+            capturedRequestBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = """{"status": "pending", "timeout": 3, "message": "Verifications are pending."}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = createMockHttpClient(mockEngine)
+
+        val sep08Service = createServiceWithMockClient(mockClient)
+        val response = sep08Service.postTransaction(txXdr, "https://goat.io/tx_approve")
+
+        // Verify request body
+        assertNotNull(capturedRequestBody, "Request body should not be null")
+        assertTrue(capturedRequestBody!!.contains("\"tx\""), "Request body should contain 'tx' field")
+        assertTrue(capturedRequestBody!!.contains(txXdr), "Request body should contain the transaction XDR")
+
+        // Verify response
+        assertTrue(response is Sep08PostTransactionResponse.Pending, "Response should be Pending")
+        val pending = response as Sep08PostTransactionResponse.Pending
+        assertEquals(3, pending.timeout, "Timeout should be 3 milliseconds")
+        assertEquals("Verifications are pending.", pending.message)
+
+        println("postTransaction pending flow verified")
+        println("  Timeout: ${pending.timeout}")
+        println("  Message: ${pending.message}")
+    }
+
+    /**
+     * Verifies that postTransaction correctly parses a "rejected" response
+     * from the approval server.
+     *
+     * The approval server returns HTTP 400 with status "rejected" and an error
+     * message. This indicates the transaction cannot be approved.
+     *
+     * Steps:
+     * 1. Fund accounts and set auth flags on issuer
+     * 2. Build a regulated transaction (sandwich pattern)
+     * 3. Create mock returning HTTP 400 with rejected status
+     * 4. Verify request body contains "tx" field
+     * 5. Verify response is Sep08PostTransactionResponse.Rejected with error
+     */
+    @Test
+    fun testPostTransactionRejectedFlow() = runTest(timeout = 120.seconds) {
+        val issuerKeyPair = KeyPair.random()
+        val userKeyPair = KeyPair.random()
+        val issuerId = issuerKeyPair.getAccountId()
+        val userId = userKeyPair.getAccountId()
+
+        fundAccount(issuerId)
+        fundAccount(userId)
+        setAuthFlags(issuerKeyPair)
+
+        val regulatedAsset = AssetTypeCreditAlphaNum4("GOAT", issuerId)
+
+        val userAccount = horizonServer.accounts().account(userId)
+        val transaction = buildRegulatedTransaction(
+            sourceAccountId = userId,
+            sourceSequence = userAccount.sequenceNumber,
+            trustorId = userId,
+            regulatedAsset = regulatedAsset,
+            issuerId = issuerId
+        )
+        val txXdr = transaction.toEnvelopeXdrBase64()
+
+        var capturedRequestBody: String? = null
+        val mockEngine = MockEngine { request ->
+            capturedRequestBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = """{"status": "rejected", "error": "Destination account is blocked."}""",
+                status = HttpStatusCode.BadRequest,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = createMockHttpClient(mockEngine)
+
+        val sep08Service = createServiceWithMockClient(mockClient)
+        val response = sep08Service.postTransaction(txXdr, "https://goat.io/tx_approve")
+
+        // Verify request body
+        assertNotNull(capturedRequestBody, "Request body should not be null")
+        assertTrue(capturedRequestBody!!.contains("\"tx\""), "Request body should contain 'tx' field")
+        assertTrue(capturedRequestBody!!.contains(txXdr), "Request body should contain the transaction XDR")
+
+        // Verify response
+        assertTrue(response is Sep08PostTransactionResponse.Rejected, "Response should be Rejected")
+        val rejected = response as Sep08PostTransactionResponse.Rejected
+        assertEquals("Destination account is blocked.", rejected.error)
+
+        println("postTransaction rejected flow verified")
+        println("  Error: ${rejected.error}")
+    }
+
+    /**
+     * Verifies that postTransaction correctly parses an "action_required" response
+     * from the approval server.
+     *
+     * The approval server returns HTTP 200 with status "action_required", an action URL,
+     * action method, action fields, and a message. This indicates the user must complete
+     * an action (e.g., KYC) before the transaction can be approved.
+     *
+     * Steps:
+     * 1. Fund accounts and set auth flags on issuer
+     * 2. Build a regulated transaction (sandwich pattern)
+     * 3. Create mock returning action_required with URL, method, and fields
+     * 4. Verify request body contains "tx" field
+     * 5. Verify response is Sep08PostTransactionResponse.ActionRequired with all fields
+     */
+    @Test
+    fun testPostTransactionActionRequiredFlow() = runTest(timeout = 120.seconds) {
+        val issuerKeyPair = KeyPair.random()
+        val userKeyPair = KeyPair.random()
+        val issuerId = issuerKeyPair.getAccountId()
+        val userId = userKeyPair.getAccountId()
+
+        fundAccount(issuerId)
+        fundAccount(userId)
+        setAuthFlags(issuerKeyPair)
+
+        val regulatedAsset = AssetTypeCreditAlphaNum4("GOAT", issuerId)
+
+        val userAccount = horizonServer.accounts().account(userId)
+        val transaction = buildRegulatedTransaction(
+            sourceAccountId = userId,
+            sourceSequence = userAccount.sequenceNumber,
+            trustorId = userId,
+            regulatedAsset = regulatedAsset,
+            issuerId = issuerId
+        )
+        val txXdr = transaction.toEnvelopeXdrBase64()
+
+        val actionUrl = "https://goat.io/kyc?account=$userId"
+        var capturedRequestBody: String? = null
+        val mockEngine = MockEngine { request ->
+            capturedRequestBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = """{
+                    "status": "action_required",
+                    "message": "Please provide your email address and mobile number.",
+                    "action_url": "$actionUrl",
+                    "action_method": "POST",
+                    "action_fields": ["email_address", "mobile_number"]
+                }""".trimIndent(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = createMockHttpClient(mockEngine)
+
+        val sep08Service = createServiceWithMockClient(mockClient)
+        val response = sep08Service.postTransaction(txXdr, "https://goat.io/tx_approve")
+
+        // Verify request body
+        assertNotNull(capturedRequestBody, "Request body should not be null")
+        assertTrue(capturedRequestBody!!.contains("\"tx\""), "Request body should contain 'tx' field")
+        assertTrue(capturedRequestBody!!.contains(txXdr), "Request body should contain the transaction XDR")
+
+        // Verify response
+        assertTrue(
+            response is Sep08PostTransactionResponse.ActionRequired,
+            "Response should be ActionRequired"
+        )
+        val actionRequired = response as Sep08PostTransactionResponse.ActionRequired
+        assertEquals(
+            "Please provide your email address and mobile number.",
+            actionRequired.message
+        )
+        assertEquals(actionUrl, actionRequired.actionUrl)
+        assertEquals("POST", actionRequired.actionMethod)
+        assertNotNull(actionRequired.actionFields, "Action fields should be present")
+        assertTrue(
+            actionRequired.actionFields!!.contains("email_address"),
+            "Action fields should contain email_address"
+        )
+        assertTrue(
+            actionRequired.actionFields!!.contains("mobile_number"),
+            "Action fields should contain mobile_number"
+        )
+
+        println("postTransaction action_required flow verified")
+        println("  Message: ${actionRequired.message}")
+        println("  Action URL: ${actionRequired.actionUrl}")
+        println("  Action method: ${actionRequired.actionMethod}")
+        println("  Action fields: ${actionRequired.actionFields}")
+    }
+
+    /**
+     * Verifies that postAction correctly parses a "no_further_action_required"
+     * response and validates the request body contains the action fields.
+     *
+     * Steps:
+     * 1. Create mock client that captures the request body
+     * 2. Call postAction with action fields (email, mobile)
+     * 3. Verify request method is POST
+     * 4. Verify request body contains email_address and mobile_number
+     * 5. Verify response is Sep08PostActionResponse.Done
+     */
+    @Test
+    fun testPostActionDoneWithRequestBodyValidation() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedRequestBody: String? = null
+        val mockEngine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedRequestBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = """{"result": "no_further_action_required"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = createMockHttpClient(mockEngine)
+
+        val service = createServiceWithMockClient(mockClient)
+        val response = service.postAction(
+            url = "https://goat.io/action",
+            actionFields = mapOf(
+                "email_address" to "test@mail.com",
+                "mobile_number" to "+3472829839222"
+            )
+        )
+
+        // Verify request
+        assertEquals(HttpMethod.Post, capturedMethod, "Request method should be POST")
+        assertNotNull(capturedRequestBody, "Request body should not be null")
+        assertTrue(
+            capturedRequestBody!!.contains("test@mail.com"),
+            "Request body should contain email_address value"
+        )
+        assertTrue(
+            capturedRequestBody!!.contains("+3472829839222"),
+            "Request body should contain mobile_number value"
+        )
+
+        // Verify response
+        assertTrue(response is Sep08PostActionResponse.Done, "Response should be Done")
+
+        println("postAction 'no_further_action_required' flow verified with request body validation")
+    }
+
+    /**
+     * Verifies that postAction correctly parses a "follow_next_url" response
+     * and validates the request body.
+     *
+     * Steps:
+     * 1. Create mock client returning follow_next_url with URL and message
+     * 2. Call postAction with action fields
+     * 3. Verify request body contains the action fields
+     * 4. Verify response is Sep08PostActionResponse.NextUrl with correct fields
+     */
+    @Test
+    fun testPostActionNextUrlWithRequestBodyValidation() = runTest {
+        val actionUrl = "https://goat.io/action"
+        var capturedMethod: HttpMethod? = null
+        var capturedRequestBody: String? = null
+        val mockEngine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedRequestBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = """{
+                    "result": "follow_next_url",
+                    "next_url": "$actionUrl",
+                    "message": "Please submit mobile number"
+                }""".trimIndent(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = createMockHttpClient(mockEngine)
+
+        val service = createServiceWithMockClient(mockClient)
+        val response = service.postAction(
+            url = actionUrl,
+            actionFields = mapOf("email_address" to "test@mail.com")
+        )
+
+        // Verify request
+        assertEquals(HttpMethod.Post, capturedMethod, "Request method should be POST")
+        assertNotNull(capturedRequestBody, "Request body should not be null")
+        assertTrue(
+            capturedRequestBody!!.contains("test@mail.com"),
+            "Request body should contain email_address value"
+        )
+
+        // Verify response
+        assertTrue(response is Sep08PostActionResponse.NextUrl, "Response should be NextUrl")
+        val nextUrl = response as Sep08PostActionResponse.NextUrl
+        assertEquals(actionUrl, nextUrl.nextUrl)
+        assertEquals("Please submit mobile number", nextUrl.message)
+
+        println("postAction 'follow_next_url' flow verified with request body validation")
+        println("  Next URL: ${nextUrl.nextUrl}")
+        println("  Message: ${nextUrl.message}")
+    }
+
+    // ==================== fromDomain Tests ====================
+
+    /**
+     * Verifies that Sep08Service.fromDomain correctly fetches and parses
+     * the stellar.toml from a domain, resolves the network passphrase, and
+     * extracts regulated assets.
+     *
+     * Since the TOML currencies lack an issuer field, no regulated assets
+     * will be extracted (matching Flutter/PHP behavior). The network passphrase
+     * should be resolved from the TOML.
+     *
+     * Steps:
+     * 1. Create mock HTTP client that serves stellar.toml at the well-known path
+     * 2. Call Sep08Service.fromDomain with the mock client
+     * 3. Verify the network passphrase matches testnet
+     * 4. Verify regulated assets list is empty (currencies have no issuer)
+     */
+    @Test
+    fun testFromDomainWithMockHttpClient() = runTest {
+        val mockEngine = MockEngine { request ->
+            if (request.url.toString().contains("api.anchor.org") &&
+                request.url.toString().contains("stellar.toml")
+            ) {
+                respond(
+                    content = anchorToml,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "text/plain")
+                )
+            } else {
+                respond(
+                    content = """{"error": "Bad request"}""",
+                    status = HttpStatusCode.BadRequest,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            }
+        }
+
+        val mockClient = HttpClient(mockEngine)
+
+        val service = Sep08Service.fromDomain(
+            domain = "api.anchor.org",
+            httpClient = mockClient
+        )
+
+        // Verify network passphrase was resolved from TOML
+        assertEquals(
+            Network.TESTNET.networkPassphrase,
+            service.tomlData.generalInformation.networkPassphrase,
+            "Network passphrase in TOML should match testnet"
+        )
+
+        // Currencies in the TOML have no issuer field, so no regulated assets are extracted
+        assertEquals(
+            0,
+            service.regulatedAssets.size,
+            "Should have 0 regulated assets (currencies lack issuer field)"
+        )
+
+        println("fromDomain test verified: network resolved, ${service.regulatedAssets.size} regulated assets")
+    }
+
+    /**
+     * Verifies that Sep08Service.fromDomain correctly extracts regulated assets
+     * when the stellar.toml currencies include issuer fields.
+     *
+     * Steps:
+     * 1. Create a TOML with fully-specified regulated currencies (including issuers)
+     * 2. Serve it via mock HTTP client
+     * 3. Call Sep08Service.fromDomain
+     * 4. Verify regulated assets are correctly extracted
+     * 5. Verify network passphrase propagation
+     */
+    @Test
+    fun testFromDomainWithRegulatedAssetsAndNetworkPropagation() = runTest {
+        val tomlWithIssuers = """
+            NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+            HORIZON_URL="https://horizon-testnet.stellar.org"
+
+            [[CURRENCIES]]
+            code="GOAT"
+            issuer="GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"
+            regulated=true
+            approval_server="https://goat.io/tx_approve"
+            approval_criteria="Goat approval criteria"
+
+            [[CURRENCIES]]
+            code="NOP"
+            issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+            display_decimals=2
+        """.trimIndent()
+
+        val mockEngine = MockEngine { request ->
+            if (request.url.toString().contains("stellar.toml")) {
+                respond(
+                    content = tomlWithIssuers,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "text/plain")
+                )
+            } else {
+                respond(
+                    content = """{"error": "Not found"}""",
+                    status = HttpStatusCode.NotFound,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            }
+        }
+
+        val mockClient = HttpClient(mockEngine)
+
+        val service = Sep08Service.fromDomain(
+            domain = "example.com",
+            httpClient = mockClient
+        )
+
+        // Verify network was resolved from TOML NETWORK_PASSPHRASE
+        assertEquals(
+            Network.TESTNET.networkPassphrase,
+            service.tomlData.generalInformation.networkPassphrase,
+            "Network passphrase in TOML should match testnet"
+        )
+
+        // Verify regulated assets were extracted
+        assertEquals(1, service.regulatedAssets.size, "Should have 1 regulated asset")
+        val goatAsset = service.regulatedAssets[0]
+        assertEquals("GOAT", goatAsset.code)
+        assertEquals("GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX", goatAsset.issuer)
+        assertEquals("https://goat.io/tx_approve", goatAsset.approvalServer)
+        assertEquals("Goat approval criteria", goatAsset.approvalCriteria)
+
+        println("fromDomain with regulated assets verified: ${service.regulatedAssets.size} assets found")
+    }
+
+    // ==================== Full Regulated Transaction Pattern Test ====================
+
+    /**
+     * Verifies the complete SEP-8 flow using the canonical regulated transaction
+     * pattern (SetTrustLineFlags sandwich) with all five response types exercised
+     * sequentially.
+     *
+     * This test mirrors the monolithic test pattern from the Flutter and PHP SDKs
+     * but uses separate mock clients per response to maintain isolation.
+     *
+     * Steps:
+     * 1. Fund issuer (with auth flags) and user accounts on testnet
+     * 2. Build the regulated transaction (authorize, buy offer, deauthorize)
+     * 3. Submit to mock approval server for each of the 5 response types
+     * 4. Verify each response is correctly parsed
+     * 5. Test postAction done and next_url responses
+     */
+    @Test
+    fun testFullRegulatedTransactionFlowAllResponses() = runTest(timeout = 180.seconds) {
+        val issuerKeyPair = KeyPair.random()
+        val userKeyPair = KeyPair.random()
+        val issuerId = issuerKeyPair.getAccountId()
+        val userId = userKeyPair.getAccountId()
+
+        println("Issuer: $issuerId")
+        println("User: $userId")
+
+        fundAccount(issuerId)
+        fundAccount(userId)
+        setAuthFlags(issuerKeyPair)
+
+        val regulatedAsset = AssetTypeCreditAlphaNum4("GOAT", issuerId)
+
+        val userAccount = horizonServer.accounts().account(userId)
+        val transaction = buildRegulatedTransaction(
+            sourceAccountId = userId,
+            sourceSequence = userAccount.sequenceNumber,
+            trustorId = userId,
+            regulatedAsset = regulatedAsset,
+            issuerId = issuerId
+        )
+        val txXdr = transaction.toEnvelopeXdrBase64()
+        val actionUrl = "https://goat.io/action"
+
+        // --- Success ---
+        val successEngine = MockEngine { request ->
+            respond(
+                content = """{"status": "success", "tx": "$txXdr", "message": "hello"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val successService = createServiceWithMockClient(createMockHttpClient(successEngine))
+        val successResponse = successService.postTransaction(txXdr, "https://goat.io/tx_approve")
+        assertTrue(successResponse is Sep08PostTransactionResponse.Success)
+        val success = successResponse as Sep08PostTransactionResponse.Success
+        assertEquals(txXdr, success.tx)
+        assertEquals("hello", success.message)
+
+        // --- Revised ---
+        val revisedTxXdr = txXdr + txXdr
+        val revisedEngine = MockEngine { request ->
+            respond(
+                content = """{"status": "revised", "tx": "$revisedTxXdr", "message": "hello"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val revisedService = createServiceWithMockClient(createMockHttpClient(revisedEngine))
+        val revisedResponse = revisedService.postTransaction(txXdr, "https://goat.io/tx_approve")
+        assertTrue(revisedResponse is Sep08PostTransactionResponse.Revised)
+        val revised = revisedResponse as Sep08PostTransactionResponse.Revised
+        assertEquals(revisedTxXdr, revised.tx)
+        assertEquals("hello", revised.message)
+
+        // --- Pending ---
+        val pendingEngine = MockEngine { request ->
+            respond(
+                content = """{"status": "pending", "timeout": 3, "message": "hello"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val pendingService = createServiceWithMockClient(createMockHttpClient(pendingEngine))
+        val pendingResponse = pendingService.postTransaction(txXdr, "https://goat.io/tx_approve")
+        assertTrue(pendingResponse is Sep08PostTransactionResponse.Pending)
+        val pending = pendingResponse as Sep08PostTransactionResponse.Pending
+        assertEquals(3, pending.timeout)
+        assertEquals("hello", pending.message)
+
+        // --- Rejected ---
+        val rejectedEngine = MockEngine { request ->
+            respond(
+                content = """{"status": "rejected", "error": "hello"}""",
+                status = HttpStatusCode.BadRequest,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val rejectedService = createServiceWithMockClient(createMockHttpClient(rejectedEngine))
+        val rejectedResponse = rejectedService.postTransaction(txXdr, "https://goat.io/tx_approve")
+        assertTrue(rejectedResponse is Sep08PostTransactionResponse.Rejected)
+        val rejected = rejectedResponse as Sep08PostTransactionResponse.Rejected
+        assertEquals("hello", rejected.error)
+
+        // --- Action Required ---
+        val actionRequiredEngine = MockEngine { request ->
+            respond(
+                content = """{
+                    "status": "action_required",
+                    "message": "hello",
+                    "action_url": "$actionUrl",
+                    "action_method": "POST",
+                    "action_fields": ["email_address", "mobile_number"]
+                }""".trimIndent(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val actionRequiredService = createServiceWithMockClient(createMockHttpClient(actionRequiredEngine))
+        val actionRequiredResponse = actionRequiredService.postTransaction(
+            txXdr, "https://goat.io/tx_approve"
+        )
+        assertTrue(actionRequiredResponse is Sep08PostTransactionResponse.ActionRequired)
+        val actionRequired = actionRequiredResponse as Sep08PostTransactionResponse.ActionRequired
+        assertEquals("hello", actionRequired.message)
+        assertEquals(actionUrl, actionRequired.actionUrl)
+        assertEquals("POST", actionRequired.actionMethod)
+        assertTrue(actionRequired.actionFields!!.contains("email_address"))
+        assertTrue(actionRequired.actionFields!!.contains("mobile_number"))
+
+        // --- Post Action: Done ---
+        val actionDoneEngine = MockEngine { request ->
+            respond(
+                content = """{"result": "no_further_action_required"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val actionDoneService = createServiceWithMockClient(createMockHttpClient(actionDoneEngine))
+        val actionDoneResponse = actionDoneService.postAction(
+            url = actionUrl,
+            actionFields = mapOf(
+                "email_address" to "test@mail.com",
+                "mobile_number" to "+3472829839222"
+            )
+        )
+        assertTrue(actionDoneResponse is Sep08PostActionResponse.Done)
+
+        // --- Post Action: Next URL ---
+        val actionNextEngine = MockEngine { request ->
+            respond(
+                content = """{
+                    "result": "follow_next_url",
+                    "next_url": "$actionUrl",
+                    "message": "Please submit mobile number"
+                }""".trimIndent(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val actionNextService = createServiceWithMockClient(createMockHttpClient(actionNextEngine))
+        val actionNextResponse = actionNextService.postAction(
+            url = actionUrl,
+            actionFields = mapOf("email_address" to "test@mail.com")
+        )
+        assertTrue(actionNextResponse is Sep08PostActionResponse.NextUrl)
+        val nextUrl = actionNextResponse as Sep08PostActionResponse.NextUrl
+        assertEquals(actionUrl, nextUrl.nextUrl)
+        assertEquals("Please submit mobile number", nextUrl.message)
+
+        println("Full regulated transaction flow verified with all 5 response types + 2 action types")
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/sep/sep08/Sep08ExceptionsTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/sep/sep08/Sep08ExceptionsTest.kt
@@ -1,0 +1,215 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.unitTests.sep.sep08
+
+import com.soneso.stellar.sdk.sep.sep08.exceptions.*
+import kotlin.test.*
+
+/**
+ * Unit tests for SEP-08 exception classes.
+ *
+ * Tests cover all exception types:
+ * - Sep08Exception (base)
+ * - Sep08IncompleteInitDataException
+ * - Sep08InvalidTransactionResponseException
+ * - Sep08InvalidActionResponseException
+ */
+class Sep08ExceptionsTest {
+
+    // ========== Sep08Exception (Base) ==========
+
+    @Test
+    fun testSep08ExceptionMessage() {
+        val exception = Sep08Exception("Test error")
+        assertEquals("Test error", exception.message)
+    }
+
+    @Test
+    fun testSep08ExceptionToString() {
+        val exception = Sep08Exception("Test error")
+        assertTrue(exception.toString().contains("SEP-08 error"))
+        assertTrue(exception.toString().contains("Test error"))
+    }
+
+    @Test
+    fun testSep08ExceptionWithCause() {
+        val cause = RuntimeException("Underlying cause")
+        val exception = Sep08Exception("Wrapper", cause)
+        assertEquals("Wrapper", exception.message)
+        assertNotNull(exception.cause)
+        assertEquals("Underlying cause", exception.cause?.message)
+    }
+
+    @Test
+    fun testSep08ExceptionIsException() {
+        val exception = Sep08Exception("Test")
+        assertTrue(exception is Exception)
+        assertTrue(exception is Throwable)
+    }
+
+    // ========== Sep08IncompleteInitDataException ==========
+
+    @Test
+    fun testIncompleteInitDataExceptionMessage() {
+        val exception = Sep08IncompleteInitDataException(
+            "Network passphrase not found in stellar.toml"
+        )
+        assertEquals("Network passphrase not found in stellar.toml", exception.message)
+    }
+
+    @Test
+    fun testIncompleteInitDataExceptionToString() {
+        val exception = Sep08IncompleteInitDataException(
+            "Horizon URL could not be determined"
+        )
+        assertTrue(exception.toString().contains("SEP-08 incomplete init data"))
+        assertTrue(exception.toString().contains("Horizon URL could not be determined"))
+    }
+
+    @Test
+    fun testIncompleteInitDataExceptionIsBase() {
+        val exception = Sep08IncompleteInitDataException("missing data")
+        assertTrue(exception is Sep08Exception)
+        assertTrue(exception is Exception)
+    }
+
+    @Test
+    fun testIncompleteInitDataExceptionCanBeCaughtAsSep08Exception() {
+        val caught = assertFailsWith<Sep08Exception> {
+            throw Sep08IncompleteInitDataException("missing network")
+        }
+        assertTrue(caught is Sep08IncompleteInitDataException)
+    }
+
+    // ========== Sep08InvalidTransactionResponseException ==========
+
+    @Test
+    fun testInvalidTransactionResponseExceptionMessage() {
+        val exception = Sep08InvalidTransactionResponseException(
+            "Missing 'status' field in approval server response"
+        )
+        assertEquals(
+            "Missing 'status' field in approval server response",
+            exception.message
+        )
+    }
+
+    @Test
+    fun testInvalidTransactionResponseExceptionToString() {
+        val exception = Sep08InvalidTransactionResponseException(
+            "Unknown status 'invalid' in response"
+        )
+        assertTrue(exception.toString().contains("SEP-08 invalid transaction response"))
+        assertTrue(exception.toString().contains("Unknown status 'invalid' in response"))
+    }
+
+    @Test
+    fun testInvalidTransactionResponseExceptionIsBase() {
+        val exception = Sep08InvalidTransactionResponseException("bad response")
+        assertTrue(exception is Sep08Exception)
+        assertTrue(exception is Exception)
+    }
+
+    @Test
+    fun testInvalidTransactionResponseExceptionCanBeCaughtAsSep08Exception() {
+        val caught = assertFailsWith<Sep08Exception> {
+            throw Sep08InvalidTransactionResponseException("malformed")
+        }
+        assertTrue(caught is Sep08InvalidTransactionResponseException)
+    }
+
+    // ========== Sep08InvalidActionResponseException ==========
+
+    @Test
+    fun testInvalidActionResponseExceptionMessage() {
+        val exception = Sep08InvalidActionResponseException(
+            "Missing 'result' field in action URL response"
+        )
+        assertEquals(
+            "Missing 'result' field in action URL response",
+            exception.message
+        )
+    }
+
+    @Test
+    fun testInvalidActionResponseExceptionToString() {
+        val exception = Sep08InvalidActionResponseException(
+            "Unknown result 'bad_value' in action URL response"
+        )
+        assertTrue(exception.toString().contains("SEP-08 invalid action response"))
+        assertTrue(exception.toString().contains("Unknown result 'bad_value' in action URL response"))
+    }
+
+    @Test
+    fun testInvalidActionResponseExceptionIsBase() {
+        val exception = Sep08InvalidActionResponseException("bad action response")
+        assertTrue(exception is Sep08Exception)
+        assertTrue(exception is Exception)
+    }
+
+    @Test
+    fun testInvalidActionResponseExceptionCanBeCaughtAsSep08Exception() {
+        val caught = assertFailsWith<Sep08Exception> {
+            throw Sep08InvalidActionResponseException("malformed action")
+        }
+        assertTrue(caught is Sep08InvalidActionResponseException)
+    }
+
+    // ========== Exception Hierarchy ==========
+
+    @Test
+    fun testExceptionHierarchy() {
+        val exceptions: List<Sep08Exception> = listOf(
+            Sep08IncompleteInitDataException("missing"),
+            Sep08InvalidTransactionResponseException("bad tx response"),
+            Sep08InvalidActionResponseException("bad action response")
+        )
+
+        exceptions.forEach { exception ->
+            assertTrue(
+                exception is Sep08Exception,
+                "${exception::class.simpleName} should extend Sep08Exception"
+            )
+            assertTrue(
+                exception is Exception,
+                "${exception::class.simpleName} should extend Exception"
+            )
+            assertNotNull(
+                exception.message,
+                "${exception::class.simpleName} should have a message"
+            )
+        }
+    }
+
+    @Test
+    fun testCatchingAsSep08Exception() {
+        var caught = false
+        try {
+            throw Sep08InvalidTransactionResponseException("Invalid")
+        } catch (e: Sep08Exception) {
+            caught = true
+            assertTrue(e is Sep08InvalidTransactionResponseException)
+        }
+        assertTrue(caught)
+    }
+
+    @Test
+    fun testAllExceptionsHaveDistinctToStringFormats() {
+        val base = Sep08Exception("test")
+        val init = Sep08IncompleteInitDataException("test")
+        val tx = Sep08InvalidTransactionResponseException("test")
+        val action = Sep08InvalidActionResponseException("test")
+
+        assertTrue(base.toString().contains("SEP-08 error"))
+        assertTrue(init.toString().contains("SEP-08 incomplete init data"))
+        assertTrue(tx.toString().contains("SEP-08 invalid transaction response"))
+        assertTrue(action.toString().contains("SEP-08 invalid action response"))
+
+        // Each toString is distinct
+        assertNotEquals(base.toString(), init.toString())
+        assertNotEquals(init.toString(), tx.toString())
+        assertNotEquals(tx.toString(), action.toString())
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/sep/sep08/Sep08ResponseParsingTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/sep/sep08/Sep08ResponseParsingTest.kt
@@ -1,0 +1,471 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.unitTests.sep.sep08
+
+import com.soneso.stellar.sdk.sep.sep08.*
+import com.soneso.stellar.sdk.sep.sep08.exceptions.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.*
+
+/**
+ * Tests for JSON parsing of SEP-8 response types.
+ *
+ * Verifies that [Sep08PostTransactionResponse.fromJson] and [Sep08PostActionResponse.fromJson]
+ * correctly deserialize from JSON, including edge cases with missing fields and unknown values.
+ */
+class Sep08ResponseParsingTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    // ========== Sep08PostTransactionResponse - Success ==========
+
+    @Test
+    fun testParseSuccessResponse() = runTest {
+        val jsonStr = """
+            {"status":"success","tx":"AAAAAgAAAAA...","message":"Transaction approved"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostTransactionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostTransactionResponse.Success)
+        assertEquals("AAAAAgAAAAA...", response.tx)
+        assertEquals("Transaction approved", response.message)
+    }
+
+    @Test
+    fun testParseSuccessNoMessage() = runTest {
+        val jsonStr = """
+            {"status":"success","tx":"AAAAAgAAAAA..."}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostTransactionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostTransactionResponse.Success)
+        assertEquals("AAAAAgAAAAA...", response.tx)
+        assertNull(response.message)
+    }
+
+    // ========== Sep08PostTransactionResponse - Revised ==========
+
+    @Test
+    fun testParseRevisedResponse() = runTest {
+        val jsonStr = """
+            {"status":"revised","tx":"AAAAAgBBBB...","message":"Added compliance operations"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostTransactionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostTransactionResponse.Revised)
+        assertEquals("AAAAAgBBBB...", response.tx)
+        assertEquals("Added compliance operations", response.message)
+    }
+
+    // ========== Sep08PostTransactionResponse - Pending ==========
+
+    @Test
+    fun testParsePendingResponse() = runTest {
+        val jsonStr = """
+            {"status":"pending","timeout":3000,"message":"Waiting for compliance check"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostTransactionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostTransactionResponse.Pending)
+        assertEquals(3000, response.timeout)
+        assertEquals("Waiting for compliance check", response.message)
+    }
+
+    @Test
+    fun testParsePendingMinimal() = runTest {
+        val jsonStr = """
+            {"status":"pending"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostTransactionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostTransactionResponse.Pending)
+        assertEquals(0, response.timeout)
+        assertNull(response.message)
+    }
+
+    // ========== Sep08PostTransactionResponse - ActionRequired ==========
+
+    @Test
+    fun testParseActionRequiredResponse() = runTest {
+        val jsonStr = """
+            {
+                "status":"action_required",
+                "message":"KYC verification needed",
+                "action_url":"https://kyc.io/verify",
+                "action_method":"POST",
+                "action_fields":["email_address","mobile_number"]
+            }
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostTransactionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostTransactionResponse.ActionRequired)
+        assertEquals("KYC verification needed", response.message)
+        assertEquals("https://kyc.io/verify", response.actionUrl)
+        assertEquals("POST", response.actionMethod)
+        assertNotNull(response.actionFields)
+        assertEquals(2, response.actionFields!!.size)
+        assertEquals("email_address", response.actionFields!![0])
+        assertEquals("mobile_number", response.actionFields!![1])
+    }
+
+    @Test
+    fun testParseActionRequiredMinimal() = runTest {
+        val jsonStr = """
+            {
+                "status":"action_required",
+                "message":"Please verify your identity",
+                "action_url":"https://kyc.io/verify"
+            }
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostTransactionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostTransactionResponse.ActionRequired)
+        assertEquals("Please verify your identity", response.message)
+        assertEquals("https://kyc.io/verify", response.actionUrl)
+        assertEquals("GET", response.actionMethod)
+        assertNull(response.actionFields)
+    }
+
+    // ========== Sep08PostTransactionResponse - Rejected ==========
+
+    @Test
+    fun testParseRejectedResponse() = runTest {
+        val jsonStr = """
+            {"status":"rejected","error":"Destination account is blocked"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostTransactionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostTransactionResponse.Rejected)
+        assertEquals("Destination account is blocked", response.error)
+    }
+
+    // ========== Sep08PostTransactionResponse - Error Cases ==========
+
+    @Test
+    fun testParseMissingStatus() = runTest {
+        val jsonStr = """
+            {"tx":"AAAAAgAAAAA...","message":"No status field"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        assertFailsWith<Sep08InvalidTransactionResponseException> {
+            Sep08PostTransactionResponse.fromJson(jsonObject)
+        }
+    }
+
+    @Test
+    fun testParseUnknownStatus() = runTest {
+        val jsonStr = """
+            {"status":"unknown_value","tx":"AAAAAgAAAAA..."}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        val exception = assertFailsWith<Sep08InvalidTransactionResponseException> {
+            Sep08PostTransactionResponse.fromJson(jsonObject)
+        }
+        assertTrue(exception.message!!.contains("Unknown status"))
+        assertTrue(exception.message!!.contains("unknown_value"))
+    }
+
+    @Test
+    fun testParseSuccessMissingTx() = runTest {
+        val jsonStr = """
+            {"status":"success","message":"Approved but no tx"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        val exception = assertFailsWith<Sep08InvalidTransactionResponseException> {
+            Sep08PostTransactionResponse.fromJson(jsonObject)
+        }
+        assertTrue(exception.message!!.contains("tx"))
+    }
+
+    @Test
+    fun testParseRevisedMissingTx() = runTest {
+        val jsonStr = """
+            {"status":"revised","message":"Revised but no tx"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        assertFailsWith<Sep08InvalidTransactionResponseException> {
+            Sep08PostTransactionResponse.fromJson(jsonObject)
+        }
+    }
+
+    @Test
+    fun testParseRevisedMissingMessage() = runTest {
+        val jsonStr = """
+            {"status":"revised","tx":"AAAAAgBBBB..."}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        val exception = assertFailsWith<Sep08InvalidTransactionResponseException> {
+            Sep08PostTransactionResponse.fromJson(jsonObject)
+        }
+        assertTrue(exception.message!!.contains("message"))
+    }
+
+    @Test
+    fun testParseActionRequiredMissingUrl() = runTest {
+        val jsonStr = """
+            {"status":"action_required","message":"KYC needed"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        val exception = assertFailsWith<Sep08InvalidTransactionResponseException> {
+            Sep08PostTransactionResponse.fromJson(jsonObject)
+        }
+        assertTrue(exception.message!!.contains("action_url"))
+    }
+
+    @Test
+    fun testParseActionRequiredMissingMessage() = runTest {
+        val jsonStr = """
+            {"status":"action_required","action_url":"https://kyc.io/verify"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        val exception = assertFailsWith<Sep08InvalidTransactionResponseException> {
+            Sep08PostTransactionResponse.fromJson(jsonObject)
+        }
+        assertTrue(exception.message!!.contains("message"))
+    }
+
+    @Test
+    fun testParseRejectedMissingError() = runTest {
+        val jsonStr = """
+            {"status":"rejected"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        val exception = assertFailsWith<Sep08InvalidTransactionResponseException> {
+            Sep08PostTransactionResponse.fromJson(jsonObject)
+        }
+        assertTrue(exception.message!!.contains("error"))
+    }
+
+    @Test
+    fun testParseEmptyJsonObject() = runTest {
+        val jsonStr = """{}"""
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        assertFailsWith<Sep08InvalidTransactionResponseException> {
+            Sep08PostTransactionResponse.fromJson(jsonObject)
+        }
+    }
+
+    @Test
+    fun testParseNullStatusValue() = runTest {
+        val jsonStr = """{"status":null}"""
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        assertFailsWith<Sep08InvalidTransactionResponseException> {
+            Sep08PostTransactionResponse.fromJson(jsonObject)
+        }
+    }
+
+    // ========== Sep08PostActionResponse - Done ==========
+
+    @Test
+    fun testParseActionDone() = runTest {
+        val jsonStr = """
+            {"result":"no_further_action_required"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostActionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostActionResponse.Done)
+    }
+
+    // ========== Sep08PostActionResponse - NextUrl ==========
+
+    @Test
+    fun testParseActionNextUrl() = runTest {
+        val jsonStr = """
+            {"result":"follow_next_url","next_url":"https://kyc.io/step2","message":"Complete step 2"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostActionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostActionResponse.NextUrl)
+        assertEquals("https://kyc.io/step2", response.nextUrl)
+        assertEquals("Complete step 2", response.message)
+    }
+
+    @Test
+    fun testParseActionNextUrlNoMessage() = runTest {
+        val jsonStr = """
+            {"result":"follow_next_url","next_url":"https://kyc.io/step2"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostActionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostActionResponse.NextUrl)
+        assertEquals("https://kyc.io/step2", response.nextUrl)
+        assertNull(response.message)
+    }
+
+    // ========== Sep08PostActionResponse - Error Cases ==========
+
+    @Test
+    fun testParseActionMissingResult() = runTest {
+        val jsonStr = """
+            {"next_url":"https://kyc.io/step2"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        assertFailsWith<Sep08InvalidActionResponseException> {
+            Sep08PostActionResponse.fromJson(jsonObject)
+        }
+    }
+
+    @Test
+    fun testParseActionUnknownResult() = runTest {
+        val jsonStr = """
+            {"result":"unknown_result_value"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        val exception = assertFailsWith<Sep08InvalidActionResponseException> {
+            Sep08PostActionResponse.fromJson(jsonObject)
+        }
+        assertTrue(exception.message!!.contains("Unknown result"))
+        assertTrue(exception.message!!.contains("unknown_result_value"))
+    }
+
+    @Test
+    fun testParseActionNextUrlMissingUrl() = runTest {
+        val jsonStr = """
+            {"result":"follow_next_url","message":"Go to next step"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        val exception = assertFailsWith<Sep08InvalidActionResponseException> {
+            Sep08PostActionResponse.fromJson(jsonObject)
+        }
+        assertTrue(exception.message!!.contains("next_url"))
+    }
+
+    @Test
+    fun testParseActionEmptyJsonObject() = runTest {
+        val jsonStr = """{}"""
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        assertFailsWith<Sep08InvalidActionResponseException> {
+            Sep08PostActionResponse.fromJson(jsonObject)
+        }
+    }
+
+    @Test
+    fun testParseActionNullResultValue() = runTest {
+        val jsonStr = """{"result":null}"""
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+
+        assertFailsWith<Sep08InvalidActionResponseException> {
+            Sep08PostActionResponse.fromJson(jsonObject)
+        }
+    }
+
+    // ========== Edge Cases ==========
+
+    @Test
+    fun testParseSuccessWithUnknownFields() = runTest {
+        val jsonStr = """
+            {"status":"success","tx":"AAAA...","message":"OK","extra_field":"ignored","number":42}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostTransactionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostTransactionResponse.Success)
+        assertEquals("AAAA...", response.tx)
+        assertEquals("OK", response.message)
+    }
+
+    @Test
+    fun testParsePendingWithZeroTimeout() = runTest {
+        val jsonStr = """
+            {"status":"pending","timeout":0,"message":"Processing"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostTransactionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostTransactionResponse.Pending)
+        assertEquals(0, response.timeout)
+        assertEquals("Processing", response.message)
+    }
+
+    @Test
+    fun testParseActionRequiredWithEmptyActionFields() = runTest {
+        val jsonStr = """
+            {
+                "status":"action_required",
+                "message":"Verify identity",
+                "action_url":"https://kyc.io/verify",
+                "action_method":"POST",
+                "action_fields":[]
+            }
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostTransactionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostTransactionResponse.ActionRequired)
+        assertNotNull(response.actionFields)
+        assertTrue(response.actionFields!!.isEmpty())
+    }
+
+    @Test
+    fun testParseActionDoneWithExtraFields() = runTest {
+        val jsonStr = """
+            {"result":"no_further_action_required","extra":"ignored"}
+        """.trimIndent()
+
+        val jsonObject = json.decodeFromString<JsonObject>(jsonStr)
+        val response = Sep08PostActionResponse.fromJson(jsonObject)
+
+        assertTrue(response is Sep08PostActionResponse.Done)
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/sep/sep08/Sep08ServiceTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/sep/sep08/Sep08ServiceTest.kt
@@ -1,0 +1,1073 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.unitTests.sep.sep08
+
+import com.soneso.stellar.sdk.Network
+import com.soneso.stellar.sdk.sep.sep08.*
+import com.soneso.stellar.sdk.sep.sep08.exceptions.*
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.*
+
+class Sep08ServiceTest {
+
+    // ========== Mock TOML Responses ==========
+
+    private val regulatedToml = """
+        NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+        HORIZON_URL="https://horizon-testnet.stellar.org"
+
+        [[CURRENCIES]]
+        code="GOAT"
+        issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+        regulated=true
+        approval_server="https://goat.io/tx_approve"
+        approval_criteria="The goat approval server will ensure compliance"
+
+        [[CURRENCIES]]
+        code="USD"
+        issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+        regulated=false
+    """.trimIndent()
+
+    private val multiRegulatedToml = """
+        NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+        HORIZON_URL="https://horizon-testnet.stellar.org"
+
+        [[CURRENCIES]]
+        code="GOAT"
+        issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+        regulated=true
+        approval_server="https://goat.io/tx_approve"
+        approval_criteria="The goat approval server will ensure compliance"
+
+        [[CURRENCIES]]
+        code="SHEEP"
+        issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+        regulated=true
+        approval_server="https://sheep.io/tx_approve"
+
+        [[CURRENCIES]]
+        code="USD"
+        issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+        regulated=false
+
+        [[CURRENCIES]]
+        code="EUR"
+        issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+    """.trimIndent()
+
+    private val noRegulatedToml = """
+        NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+        HORIZON_URL="https://horizon-testnet.stellar.org"
+
+        [[CURRENCIES]]
+        code="USD"
+        issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+        regulated=false
+
+        [[CURRENCIES]]
+        code="EUR"
+        issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+    """.trimIndent()
+
+    private val noNetworkToml = """
+        HORIZON_URL="https://horizon-testnet.stellar.org"
+
+        [[CURRENCIES]]
+        code="GOAT"
+        issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+        regulated=true
+        approval_server="https://goat.io/tx_approve"
+    """.trimIndent()
+
+    private val publicNetworkToml = """
+        NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+
+        [[CURRENCIES]]
+        code="GOAT"
+        issuer="GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP"
+        regulated=true
+        approval_server="https://goat.io/tx_approve"
+    """.trimIndent()
+
+    // ========== Mock JSON Responses ==========
+
+    private val successJson = """
+        {"status":"success","tx":"AAAAAgAAAAA...","message":"Approved"}
+    """.trimIndent()
+
+    private val successNoMessageJson = """
+        {"status":"success","tx":"AAAAAgAAAAA..."}
+    """.trimIndent()
+
+    private val revisedJson = """
+        {"status":"revised","tx":"AAAAAgBBBB...","message":"Added authorization ops"}
+    """.trimIndent()
+
+    private val pendingJson = """
+        {"status":"pending","timeout":5000,"message":"Checking..."}
+    """.trimIndent()
+
+    private val pendingMinimalJson = """
+        {"status":"pending"}
+    """.trimIndent()
+
+    private val actionRequiredJson = """
+        {"status":"action_required","message":"KYC needed","action_url":"https://kyc.io/verify","action_method":"POST","action_fields":["email_address","mobile_number"]}
+    """.trimIndent()
+
+    private val actionRequiredGetJson = """
+        {"status":"action_required","message":"Please verify","action_url":"https://kyc.io/verify"}
+    """.trimIndent()
+
+    private val rejectedJson = """
+        {"status":"rejected","error":"Destination blocked"}
+    """.trimIndent()
+
+    private val actionDoneJson = """
+        {"result":"no_further_action_required"}
+    """.trimIndent()
+
+    private val actionNextUrlJson = """
+        {"result":"follow_next_url","next_url":"https://kyc.io/step2","message":"Complete step 2"}
+    """.trimIndent()
+
+    private val actionNextUrlNoMessageJson = """
+        {"result":"follow_next_url","next_url":"https://kyc.io/step2"}
+    """.trimIndent()
+
+    // ========== Helper Methods ==========
+
+    private fun createTomlMockClient(
+        tomlContent: String
+    ): HttpClient {
+        val mockEngine = MockEngine { request ->
+            if (request.url.encodedPath.contains("/.well-known/stellar.toml")) {
+                respond(
+                    content = tomlContent,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "text/plain")
+                )
+            } else {
+                respond(
+                    content = "Not found",
+                    status = HttpStatusCode.NotFound,
+                    headers = headersOf(HttpHeaders.ContentType, "text/plain")
+                )
+            }
+        }
+
+        return HttpClient(mockEngine)
+    }
+
+    private fun createPostMockClient(
+        responseContent: String,
+        statusCode: HttpStatusCode = HttpStatusCode.OK,
+        expectedPath: String? = null
+    ): HttpClient {
+        val mockEngine = MockEngine { request ->
+            if (expectedPath == null || request.url.toString().contains(expectedPath)) {
+                respond(
+                    content = responseContent,
+                    status = statusCode,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            } else {
+                respond(
+                    content = """{"error": "Not found: ${request.url.encodedPath}"}""",
+                    status = HttpStatusCode.NotFound,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            }
+        }
+
+        return HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    isLenient = true
+                })
+            }
+        }
+    }
+
+    private fun createSep08ServiceWithMockClient(
+        mockClient: HttpClient,
+        regulatedAssets: List<RegulatedAsset> = emptyList(),
+        httpRequestHeaders: Map<String, String>? = null
+    ): Sep08Service {
+        val toml = com.soneso.stellar.sdk.sep.sep01.StellarToml.parse(regulatedToml)
+        return Sep08Service(
+            tomlData = toml,
+            regulatedAssets = regulatedAssets,
+            network = Network.TESTNET,
+            horizonServer = com.soneso.stellar.sdk.horizon.HorizonServer(
+                "https://horizon-testnet.stellar.org"
+            ),
+            httpClient = mockClient,
+            httpRequestHeaders = httpRequestHeaders
+        )
+    }
+
+    // ========== fromDomain() Tests ==========
+
+    @Test
+    fun testFromDomainSuccess() = runTest {
+        val mockClient = createTomlMockClient(regulatedToml)
+
+        val service = Sep08Service.fromDomain(
+            domain = "goat.io",
+            httpClient = mockClient
+        )
+
+        assertNotNull(service.tomlData)
+        assertEquals(1, service.regulatedAssets.size)
+
+        val asset = service.regulatedAssets[0]
+        assertEquals("GOAT", asset.code)
+        assertEquals("GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP", asset.issuer)
+        assertEquals("https://goat.io/tx_approve", asset.approvalServer)
+        assertEquals("The goat approval server will ensure compliance", asset.approvalCriteria)
+    }
+
+    @Test
+    fun testFromDomainFiltersNonRegulatedAssets() = runTest {
+        val mockClient = createTomlMockClient(multiRegulatedToml)
+
+        val service = Sep08Service.fromDomain(
+            domain = "example.com",
+            httpClient = mockClient
+        )
+
+        assertEquals(2, service.regulatedAssets.size)
+
+        val codes = service.regulatedAssets.map { it.code }
+        assertTrue(codes.contains("GOAT"))
+        assertTrue(codes.contains("SHEEP"))
+        assertFalse(codes.contains("USD"))
+        assertFalse(codes.contains("EUR"))
+    }
+
+    @Test
+    fun testFromDomainNoRegulatedAssets() = runTest {
+        val mockClient = createTomlMockClient(noRegulatedToml)
+
+        val service = Sep08Service.fromDomain(
+            domain = "example.com",
+            httpClient = mockClient
+        )
+
+        assertTrue(service.regulatedAssets.isEmpty())
+    }
+
+    @Test
+    fun testFromDomainWithExplicitNetwork() = runTest {
+        val mockClient = createTomlMockClient(regulatedToml)
+
+        val service = Sep08Service.fromDomain(
+            domain = "goat.io",
+            network = Network.PUBLIC,
+            httpClient = mockClient
+        )
+
+        assertNotNull(service)
+        assertEquals(1, service.regulatedAssets.size)
+    }
+
+    @Test
+    fun testFromDomainWithExplicitHorizonUrl() = runTest {
+        val mockClient = createTomlMockClient(regulatedToml)
+
+        val service = Sep08Service.fromDomain(
+            domain = "goat.io",
+            horizonUrl = "https://my-custom-horizon.example.com",
+            httpClient = mockClient
+        )
+
+        assertNotNull(service)
+        assertEquals(1, service.regulatedAssets.size)
+    }
+
+    @Test
+    fun testFromDomainMissingNetworkPassphrase() = runTest {
+        val mockClient = createTomlMockClient(noNetworkToml)
+
+        assertFailsWith<Sep08IncompleteInitDataException> {
+            Sep08Service.fromDomain(
+                domain = "goat.io",
+                httpClient = mockClient
+            )
+        }
+    }
+
+    @Test
+    fun testFromDomainWithCustomHeaders() = runTest {
+        var customHeaderVerified = false
+        val mockEngine = MockEngine { request ->
+            if (request.url.encodedPath.contains("/.well-known/stellar.toml")) {
+                customHeaderVerified = request.headers["X-Custom-Header"] == "test-value"
+                respond(
+                    content = regulatedToml,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "text/plain")
+                )
+            } else {
+                respond(
+                    content = "Not found",
+                    status = HttpStatusCode.NotFound,
+                    headers = headersOf(HttpHeaders.ContentType, "text/plain")
+                )
+            }
+        }
+        val mockClient = HttpClient(mockEngine)
+
+        Sep08Service.fromDomain(
+            domain = "goat.io",
+            httpClient = mockClient,
+            httpRequestHeaders = mapOf("X-Custom-Header" to "test-value")
+        )
+
+        assertTrue(customHeaderVerified, "Custom header should be forwarded to TOML fetch")
+    }
+
+    @Test
+    fun testFromDomainPublicNetworkResolvesDefaultHorizon() = runTest {
+        val mockClient = createTomlMockClient(publicNetworkToml)
+
+        val service = Sep08Service.fromDomain(
+            domain = "example.com",
+            httpClient = mockClient
+        )
+
+        assertNotNull(service)
+        assertEquals(1, service.regulatedAssets.size)
+    }
+
+    @Test
+    fun testFromDomainRegulatedAssetWithoutCriteria() = runTest {
+        val mockClient = createTomlMockClient(multiRegulatedToml)
+
+        val service = Sep08Service.fromDomain(
+            domain = "example.com",
+            httpClient = mockClient
+        )
+
+        val sheep = service.regulatedAssets.first { it.code == "SHEEP" }
+        assertNull(sheep.approvalCriteria)
+        assertEquals("https://sheep.io/tx_approve", sheep.approvalServer)
+    }
+
+    // ========== postTransaction() Tests ==========
+
+    @Test
+    fun testPostTransactionSuccess() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = successJson,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        val response = service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(response is Sep08PostTransactionResponse.Success)
+        assertEquals("AAAAAgAAAAA...", response.tx)
+        assertEquals("Approved", response.message)
+    }
+
+    @Test
+    fun testPostTransactionSuccessNoMessage() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = successNoMessageJson,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        val response = service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(response is Sep08PostTransactionResponse.Success)
+        assertEquals("AAAAAgAAAAA...", response.tx)
+        assertNull(response.message)
+    }
+
+    @Test
+    fun testPostTransactionRevised() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = revisedJson,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        val response = service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(response is Sep08PostTransactionResponse.Revised)
+        assertEquals("AAAAAgBBBB...", response.tx)
+        assertEquals("Added authorization ops", response.message)
+    }
+
+    @Test
+    fun testPostTransactionPending() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = pendingJson,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        val response = service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(response is Sep08PostTransactionResponse.Pending)
+        assertEquals(5000, response.timeout)
+        assertEquals("Checking...", response.message)
+    }
+
+    @Test
+    fun testPostTransactionPendingMinimal() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = pendingMinimalJson,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        val response = service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(response is Sep08PostTransactionResponse.Pending)
+        assertEquals(0, response.timeout)
+        assertNull(response.message)
+    }
+
+    @Test
+    fun testPostTransactionActionRequired() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = actionRequiredJson,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        val response = service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(response is Sep08PostTransactionResponse.ActionRequired)
+        assertEquals("KYC needed", response.message)
+        assertEquals("https://kyc.io/verify", response.actionUrl)
+        assertEquals("POST", response.actionMethod)
+        assertNotNull(response.actionFields)
+        assertEquals(2, response.actionFields!!.size)
+        assertTrue(response.actionFields!!.contains("email_address"))
+        assertTrue(response.actionFields!!.contains("mobile_number"))
+    }
+
+    @Test
+    fun testPostTransactionActionRequiredGetDefault() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = actionRequiredGetJson,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        val response = service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(response is Sep08PostTransactionResponse.ActionRequired)
+        assertEquals("Please verify", response.message)
+        assertEquals("https://kyc.io/verify", response.actionUrl)
+        assertEquals("GET", response.actionMethod)
+        assertNull(response.actionFields)
+    }
+
+    @Test
+    fun testPostTransactionRejected() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = rejectedJson,
+            statusCode = HttpStatusCode.BadRequest,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        val response = service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(response is Sep08PostTransactionResponse.Rejected)
+        assertEquals("Destination blocked", response.error)
+    }
+
+    @Test
+    fun testPostTransactionUnknownStatus() = runTest {
+        val unknownStatusJson = """{"status":"unknown_status","tx":"AAAA..."}"""
+        val mockClient = createPostMockClient(
+            responseContent = unknownStatusJson,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        assertFailsWith<Sep08InvalidTransactionResponseException> {
+            service.postTransaction(
+                tx = "AAAAAgAAAAA...",
+                approvalServer = "https://goat.io/tx_approve"
+            )
+        }
+    }
+
+    @Test
+    fun testPostTransactionServerError() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = """{"error":"Internal server error"}""",
+            statusCode = HttpStatusCode.InternalServerError,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        assertFailsWith<Sep08InvalidTransactionResponseException> {
+            service.postTransaction(
+                tx = "AAAAAgAAAAA...",
+                approvalServer = "https://goat.io/tx_approve"
+            )
+        }
+    }
+
+    @Test
+    fun testPostTransactionWithCustomHeaders() = runTest {
+        var customHeaderVerified = false
+        val mockEngine = MockEngine { request ->
+            customHeaderVerified = request.headers["X-Api-Key"] == "my-api-key"
+            respond(
+                content = successJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true; isLenient = true })
+            }
+        }
+
+        val service = createSep08ServiceWithMockClient(
+            mockClient = mockClient,
+            httpRequestHeaders = mapOf("X-Api-Key" to "my-api-key")
+        )
+
+        service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(customHeaderVerified, "Custom header should be sent with request")
+    }
+
+    @Test
+    fun testPostTransactionVerifiesRequestBody() = runTest {
+        var methodVerified = false
+        var contentTypeVerified = false
+        var urlVerified = false
+        val mockEngine = MockEngine { request ->
+            methodVerified = request.method == HttpMethod.Post
+            contentTypeVerified = request.body.contentType?.match(ContentType.Application.Json) == true
+            urlVerified = request.url.toString().contains("tx_approve")
+            respond(
+                content = successJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true; isLenient = true })
+            }
+        }
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(methodVerified, "Request method should be POST")
+        assertTrue(contentTypeVerified, "Content-Type should be application/json")
+        assertTrue(urlVerified, "Request URL should contain the approval server path")
+    }
+
+    @Test
+    fun testPostTransactionVerifiesPostMethod() = runTest {
+        var methodVerified = false
+        val mockEngine = MockEngine { request ->
+            methodVerified = request.method == HttpMethod.Post
+            respond(
+                content = successJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true; isLenient = true })
+            }
+        }
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(methodVerified, "Request method should be POST")
+    }
+
+    @Test
+    fun testPostTransactionVerifiesContentType() = runTest {
+        var contentTypeVerified = false
+        val mockEngine = MockEngine { request ->
+            contentTypeVerified = request.body.contentType?.match(ContentType.Application.Json) == true
+            respond(
+                content = successJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true; isLenient = true })
+            }
+        }
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        service.postTransaction(
+            tx = "AAAAAgAAAAA...",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(contentTypeVerified, "Content-Type should be application/json")
+    }
+
+    @Test
+    fun testPostTransactionBadRequestNonRejected() = runTest {
+        val badRequestJson = """{"status":"success","tx":"AAAA..."}"""
+        val mockClient = createPostMockClient(
+            responseContent = badRequestJson,
+            statusCode = HttpStatusCode.BadRequest,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        assertFailsWith<Sep08InvalidTransactionResponseException> {
+            service.postTransaction(
+                tx = "AAAAAgAAAAA...",
+                approvalServer = "https://goat.io/tx_approve"
+            )
+        }
+    }
+
+    @Test
+    fun testPostTransactionBadRequestMalformedJson() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = "this is not json",
+            statusCode = HttpStatusCode.BadRequest,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        assertFailsWith<Sep08InvalidTransactionResponseException> {
+            service.postTransaction(
+                tx = "AAAAAgAAAAA...",
+                approvalServer = "https://goat.io/tx_approve"
+            )
+        }
+    }
+
+    @Test
+    fun testPostTransactionHttp403() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = """{"error":"Forbidden"}""",
+            statusCode = HttpStatusCode.Forbidden,
+            expectedPath = "tx_approve"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        assertFailsWith<Sep08InvalidTransactionResponseException> {
+            service.postTransaction(
+                tx = "AAAAAgAAAAA...",
+                approvalServer = "https://goat.io/tx_approve"
+            )
+        }
+    }
+
+    // ========== postAction() Tests ==========
+
+    @Test
+    fun testPostActionDone() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = actionDoneJson,
+            expectedPath = "kyc.io"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        val response = service.postAction(
+            url = "https://kyc.io/verify",
+            actionFields = mapOf("email_address" to "user@example.com")
+        )
+
+        assertTrue(response is Sep08PostActionResponse.Done)
+    }
+
+    @Test
+    fun testPostActionNextUrl() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = actionNextUrlJson,
+            expectedPath = "kyc.io"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        val response = service.postAction(
+            url = "https://kyc.io/verify",
+            actionFields = mapOf("email_address" to "user@example.com")
+        )
+
+        assertTrue(response is Sep08PostActionResponse.NextUrl)
+        assertEquals("https://kyc.io/step2", response.nextUrl)
+        assertEquals("Complete step 2", response.message)
+    }
+
+    @Test
+    fun testPostActionNextUrlNoMessage() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = actionNextUrlNoMessageJson,
+            expectedPath = "kyc.io"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        val response = service.postAction(
+            url = "https://kyc.io/verify",
+            actionFields = mapOf("email_address" to "user@example.com")
+        )
+
+        assertTrue(response is Sep08PostActionResponse.NextUrl)
+        assertEquals("https://kyc.io/step2", response.nextUrl)
+        assertNull(response.message)
+    }
+
+    @Test
+    fun testPostActionUnknownResult() = runTest {
+        val unknownResultJson = """{"result":"unknown_result"}"""
+        val mockClient = createPostMockClient(
+            responseContent = unknownResultJson,
+            expectedPath = "kyc.io"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        assertFailsWith<Sep08InvalidActionResponseException> {
+            service.postAction(
+                url = "https://kyc.io/verify",
+                actionFields = mapOf("email_address" to "user@example.com")
+            )
+        }
+    }
+
+    @Test
+    fun testPostActionServerError() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = """{"error":"Internal server error"}""",
+            statusCode = HttpStatusCode.InternalServerError,
+            expectedPath = "kyc.io"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        assertFailsWith<Sep08InvalidActionResponseException> {
+            service.postAction(
+                url = "https://kyc.io/verify",
+                actionFields = mapOf("email_address" to "user@example.com")
+            )
+        }
+    }
+
+    @Test
+    fun testPostActionWithCustomHeaders() = runTest {
+        var customHeaderVerified = false
+        val mockEngine = MockEngine { request ->
+            customHeaderVerified = request.headers["X-Api-Key"] == "my-api-key"
+            respond(
+                content = actionDoneJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true; isLenient = true })
+            }
+        }
+
+        val service = createSep08ServiceWithMockClient(
+            mockClient = mockClient,
+            httpRequestHeaders = mapOf("X-Api-Key" to "my-api-key")
+        )
+
+        service.postAction(
+            url = "https://kyc.io/verify",
+            actionFields = mapOf("email_address" to "user@example.com")
+        )
+
+        assertTrue(customHeaderVerified, "Custom header should be sent with request")
+    }
+
+    @Test
+    fun testPostActionVerifiesRequestBody() = runTest {
+        var methodVerified = false
+        var contentTypeVerified = false
+        var urlVerified = false
+        val mockEngine = MockEngine { request ->
+            methodVerified = request.method == HttpMethod.Post
+            contentTypeVerified = request.body.contentType?.match(ContentType.Application.Json) == true
+            urlVerified = request.url.toString().contains("kyc.io/verify")
+            respond(
+                content = actionDoneJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true; isLenient = true })
+            }
+        }
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        service.postAction(
+            url = "https://kyc.io/verify",
+            actionFields = mapOf("email_address" to "user@example.com")
+        )
+
+        assertTrue(methodVerified, "Request method should be POST")
+        assertTrue(contentTypeVerified, "Content-Type should be application/json")
+        assertTrue(urlVerified, "Request URL should contain the action URL path")
+    }
+
+    @Test
+    fun testPostActionVerifiesPostMethod() = runTest {
+        var methodVerified = false
+        val mockEngine = MockEngine { request ->
+            methodVerified = request.method == HttpMethod.Post
+            respond(
+                content = actionDoneJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true; isLenient = true })
+            }
+        }
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        service.postAction(
+            url = "https://kyc.io/verify",
+            actionFields = mapOf("email_address" to "user@example.com")
+        )
+
+        assertTrue(methodVerified, "Request method should be POST")
+    }
+
+    @Test
+    fun testPostActionHttp403() = runTest {
+        val mockClient = createPostMockClient(
+            responseContent = """{"error":"Forbidden"}""",
+            statusCode = HttpStatusCode.Forbidden,
+            expectedPath = "kyc.io"
+        )
+        val service = createSep08ServiceWithMockClient(mockClient)
+
+        assertFailsWith<Sep08InvalidActionResponseException> {
+            service.postAction(
+                url = "https://kyc.io/verify",
+                actionFields = mapOf("email_address" to "user@example.com")
+            )
+        }
+    }
+
+    // ========== RegulatedAsset Tests ==========
+
+    @Test
+    fun testRegulatedAssetProperties() = runTest {
+        val asset = RegulatedAsset(
+            code = "GOAT",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://goat.io/tx_approve",
+            approvalCriteria = "The goat approval server will ensure compliance"
+        )
+
+        assertEquals("GOAT", asset.code)
+        assertEquals("GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP", asset.issuer)
+        assertEquals("https://goat.io/tx_approve", asset.approvalServer)
+        assertEquals("The goat approval server will ensure compliance", asset.approvalCriteria)
+    }
+
+    @Test
+    fun testRegulatedAssetToString() = runTest {
+        val asset = RegulatedAsset(
+            code = "GOAT",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertEquals(
+            "GOAT:GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            asset.toString()
+        )
+    }
+
+    @Test
+    fun testRegulatedAssetToXdr() = runTest {
+        val asset = RegulatedAsset(
+            code = "GOAT",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        val xdr = asset.toXdr()
+        assertNotNull(xdr)
+    }
+
+    @Test
+    fun testRegulatedAssetToAsset() = runTest {
+        val regulatedAsset = RegulatedAsset(
+            code = "GOAT",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        val asset = regulatedAsset.toAsset()
+        assertNotNull(asset)
+        assertEquals(
+            "GOAT:GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            asset.toString()
+        )
+    }
+
+    @Test
+    fun testRegulatedAssetEquality() = runTest {
+        val asset1 = RegulatedAsset(
+            code = "GOAT",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://goat.io/tx_approve",
+            approvalCriteria = "criteria"
+        )
+        val asset2 = RegulatedAsset(
+            code = "GOAT",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://goat.io/tx_approve",
+            approvalCriteria = "criteria"
+        )
+        val asset3 = RegulatedAsset(
+            code = "SHEEP",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://sheep.io/tx_approve"
+        )
+
+        assertEquals(asset1, asset2)
+        assertEquals(asset1.hashCode(), asset2.hashCode())
+        assertNotEquals(asset1, asset3)
+    }
+
+    @Test
+    fun testRegulatedAssetWithoutCriteria() = runTest {
+        val asset = RegulatedAsset(
+            code = "GOAT",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertNull(asset.approvalCriteria)
+    }
+
+    @Test
+    fun testRegulatedAssetComparable() = runTest {
+        val assetA = RegulatedAsset(
+            code = "AAA",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://example.com/approve"
+        )
+        val assetB = RegulatedAsset(
+            code = "BBB",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://example.com/approve"
+        )
+
+        assertTrue(assetA < assetB)
+    }
+
+    @Test
+    fun testRegulatedAssetAlphaNum12() = runTest {
+        val asset = RegulatedAsset(
+            code = "LONGASSETCD",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://example.com/approve"
+        )
+
+        assertNotNull(asset.toXdr())
+        assertEquals(
+            "LONGASSETCD:GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            asset.toString()
+        )
+    }
+
+    @Test
+    fun testRegulatedAssetNotEqualToNull() = runTest {
+        val asset = RegulatedAsset(
+            code = "GOAT",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertFalse(asset.equals(null))
+    }
+
+    @Test
+    fun testRegulatedAssetNotEqualToDifferentType() = runTest {
+        val asset = RegulatedAsset(
+            code = "GOAT",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertFalse(asset.equals("not an asset"))
+    }
+
+    @Test
+    fun testRegulatedAssetEqualToSelf() = runTest {
+        val asset = RegulatedAsset(
+            code = "GOAT",
+            issuer = "GBWMCCC3NHSKLAOJDBKKYW7SSH2PFTTNVFKWSGLWGDLEBKLOVP5JLBBP",
+            approvalServer = "https://goat.io/tx_approve"
+        )
+
+        assertTrue(asset.equals(asset))
+    }
+}


### PR DESCRIPTION
## Summary

- Add SEP-8 (Regulated Assets) client implementation
- `Sep08Service` discovers regulated assets from stellar.toml, checks issuer AUTH_REQUIRED + AUTH_REVOCABLE flags, and handles the approval server request/response cycle
- Sealed classes for all 5 transaction response types (success, revised, pending, action_required, rejected) and both action response types (done, next_url)
- `RegulatedAsset` wraps the existing `Asset` hierarchy via composition (sealed class constraint)
- Tests: unit tests (service, response parsing, exceptions) + integration tests (live testnet flag checks, mock approval server flows)
- All tests pass on JVM, JS Node, and iOS Simulator