### PR TITLE
Migrate smart account SDK to OZ contracts v0.7.0-rc.2

### DIFF
--- a/docs/smart-accounts/README.md
+++ b/docs/smart-accounts/README.md
@@ -230,13 +230,10 @@ val lowLevelResult = kit.signerManager.addPasskey(
     credentialId = otherCredentialId  // raw credential ID bytes
 )
 
-// Remove a signer
-val delegatedSigner = DelegatedSigner(
-    address = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
-)
+// Remove a signer by its on-chain signer ID
 val removeResult = kit.signerManager.removeSigner(
     contextRuleId = 0u,
-    signer = delegatedSigner
+    signerId = 1u
 )
 ```
 

--- a/docs/smart-accounts/api-reference.md
+++ b/docs/smart-accounts/api-reference.md
@@ -554,7 +554,8 @@ if (result.success) {
 suspend fun submit(
     hostFunction: HostFunctionXdr,
     auth: List<SorobanAuthorizationEntryXdr>,
-    forceMethod: SubmissionMethod? = null
+    forceMethod: SubmissionMethod? = null,
+    resolveContextRuleIds: ResolveContextRuleIds? = null
 ): TransactionResult
 ```
 
@@ -566,10 +567,60 @@ Handles simulation, auth entry extraction, WebAuthn signing, re-simulation, and 
 - `hostFunction`: The Soroban host function to execute
 - `auth`: Initial authorization entries (typically empty; simulation provides them)
 - `forceMethod`: Optional submission method override
+- `resolveContextRuleIds`: Optional callback that returns context rule IDs for each authorization entry. Called once per entry with the entry and its index. When provided, the contract evaluates only the returned rules instead of scanning all matching rules. See [ResolveContextRuleIds](#resolvecontextruleids).
 
 **Returns**: `TransactionResult` with submission outcome
 
 **Throws**: Multiple exception types (see transaction operations exceptions)
+
+---
+
+#### executeAndSubmit
+
+```kotlin
+suspend fun executeAndSubmit(
+    target: String,
+    targetFn: String,
+    targetArgs: List<SCValXdr> = emptyList(),
+    forceMethod: SubmissionMethod? = null,
+    resolveContextRuleIds: ResolveContextRuleIds? = null
+): TransactionResult
+```
+
+Executes a generic contract call through the smart account's `execute` entry point. Builds the invocation, handles simulation, WebAuthn signing, and submission in one step. Designed for single-signer workflows where the connected passkey authorizes the call.
+
+**Parameters**:
+- `target`: Contract address to call (C-address)
+- `targetFn`: Function name to invoke on the target contract
+- `targetArgs`: Arguments for the target function as XDR values
+- `forceMethod`: Optional submission method override
+- `resolveContextRuleIds`: Optional callback that returns context rule IDs for each authorization entry. See [ResolveContextRuleIds](#resolvecontextruleids).
+
+**Returns**: `TransactionResult` with submission outcome
+
+**Throws**:
+- `WalletException.NotConnected`: Wallet is not connected
+- `ValidationException`: Invalid addresses or arguments
+- `TransactionException`: Simulation, signing, or submission failed
+- `WebAuthnException`: Biometric authentication failed
+
+**Example**:
+
+```kotlin
+// Call a custom contract function through the smart account
+val result = kit.transactionOperations.executeAndSubmit(
+    target = "CBCD1234...",
+    targetFn = "approve",
+    targetArgs = listOf(
+        Scv.toAddress("GA7QYNF7..."),
+        Scv.toInt128(1_000_000_000L)
+    )
+)
+
+if (result.success) {
+    println("Executed: ${result.hash}")
+}
+```
 
 ---
 
@@ -908,17 +959,17 @@ Adds an Ed25519 signer to a context rule.
 ```kotlin
 suspend fun removeSigner(
     contextRuleId: UInt,
-    signer: SmartAccountSigner
+    signerId: UInt
 ): TransactionResult
 ```
 
-Removes a signer from a context rule.
+Removes a signer from a context rule by its on-chain signer ID.
 
 **Note**: Cannot remove the last signer unless policies exist.
 
 **Parameters**:
 - `contextRuleId`: Context rule ID
-- `signer`: The signer to remove
+- `signerId`: The on-chain ID of the signer to remove
 
 **Returns**: `TransactionResult`
 
@@ -1070,15 +1121,15 @@ val result = kit.policyManager.addSpendingLimit(
 ```kotlin
 suspend fun removePolicy(
     contextRuleId: UInt,
-    policyAddress: String
+    policyId: UInt
 ): TransactionResult
 ```
 
-Removes a policy from a context rule.
+Removes a policy from a context rule by its on-chain policy ID.
 
 **Parameters**:
 - `contextRuleId`: Context rule ID
-- `policyAddress`: Policy contract address to remove
+- `policyId`: The on-chain ID of the policy to remove
 
 **Returns**: `TransactionResult`
 
@@ -1265,7 +1316,8 @@ suspend fun multiSignerTransfer(
     tokenContract: String,
     recipient: String,
     amount: String,
-    selectedSigners: List<SelectedSigner>
+    selectedSigners: List<SelectedSigner>,
+    resolveContextRuleIds: ResolveContextRuleIds? = null
 ): TransactionResult
 ```
 
@@ -1278,6 +1330,7 @@ The caller explicitly lists every signer. There is no implicit connected passkey
 - `recipient`: Recipient address (G-address or C-address)
 - `amount`: Amount in XLM
 - `selectedSigners`: All signers that must sign, in collection order
+- `resolveContextRuleIds`: Optional callback that returns context rule IDs for each authorization entry. See [ResolveContextRuleIds](#resolvecontextruleids).
 
 **Returns**: `TransactionResult`
 
@@ -1818,6 +1871,31 @@ Represents a WebAuthn signature with authenticator and client data.
 
 ---
 
+### ResolveContextRuleIds
+
+```kotlin
+typealias ResolveContextRuleIds = suspend (
+    entry: SorobanAuthorizationEntryXdr,
+    index: Int
+) -> List<UInt>
+```
+
+Callback that resolves context rule IDs for a given authorization entry during transaction signing. Called once per entry. The `entry` is the authorization entry being signed, and `index` is its position in the authorization list. Return the list of context rule IDs the contract should evaluate for that entry.
+
+**Usage**:
+
+```kotlin
+// Same rule for all entries
+resolveContextRuleIds = { _, _ -> listOf(ruleId) }
+
+// Different rules per entry
+resolveContextRuleIds = { entry, index ->
+    if (index == 0) listOf(1u) else listOf(2u)
+}
+```
+
+---
+
 ### SubmissionMethod
 
 ```kotlin
@@ -1931,4 +2009,4 @@ Stellar SDK Kotlin Multiplatform - Apache License 2.0
 
 ---
 
-**Last Updated**: February 2026
+**Last Updated**: April 2026

--- a/smart-account-demo/macosApp/StellarSmartDemo/Views/KnownSignersScreen.swift
+++ b/smart-account-demo/macosApp/StellarSmartDemo/Views/KnownSignersScreen.swift
@@ -265,13 +265,13 @@ struct KnownSignersScreen: View {
         } else if let external = signer as? ExternalSigner {
             let keyData = external.keyData
             // Determine passkey vs Ed25519 by key length:
-            // WebAuthn compressed P-256 keys are 65 bytes; Ed25519 keys are 32 bytes.
-            if keyData.size == 32 {
+            // WebAuthn P-256 keys are 65 bytes (+ credential ID suffix); Ed25519 keys are 32 bytes.
+            if keyData.size <= 32 {
                 signerType = "ed25519"
                 identifier = KotlinInterop.hexString(from: keyData)
             } else {
                 signerType = "passkey"
-                identifier = KotlinInterop.hexString(from: keyData)
+                identifier = bridgeWrapper.bridge.getCredentialIdFromSigner(signer: external) ?? KotlinInterop.hexString(from: keyData)
             }
         } else {
             signerType = "ed25519"

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/config/DemoConfig.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/config/DemoConfig.kt
@@ -19,19 +19,19 @@ object DemoConfig {
 
     // -- Smart Account Contract --
 
-    /** WASM hash of the multisig smart account contract (OZ stellar-contracts v0.6.0).
+    /** WASM hash of the multisig smart account contract (OZ stellar-contracts v0.7.0).
      *  Passed to OZSmartAccountConfig.accountWasmHash for wallet deployment.
      *  This hash can change when the contract is upgraded or testnet is reset.
      *  See docs/smart-accounts/README.md#testnet-contract-addresses for upload instructions. */
-    const val ACCOUNT_WASM_HASH = "64086253db59176c3bbbcf57fbb68c0a2fbe6fe9e0b05883ff1da44c5978ae4c"
+    const val ACCOUNT_WASM_HASH = "3e51f5b222dec74650f0b33367acb42a41ce497f72639230463070e666abba2c"
 
     // -- Verifier Contracts --
 
     /** WebAuthn (secp256r1) signature verifier contract. Validates passkey signatures on-chain. */
-    const val WEBAUTHN_VERIFIER_ADDRESS = "CBSHV66WG7UV6FQVUTB67P3DZUEJ2KJ5X6JKQH5MFRAAFNFJUAJVXJYV"
+    const val WEBAUTHN_VERIFIER_ADDRESS = "CATPTBRWVMH5ZCIKO5HN2F4FMPXVZEXC56RKGHRXCM7EEZGGXK7PICEH"
 
     /** Ed25519 signature verifier contract. Validates Ed25519 signer signatures on-chain. */
-    const val ED25519_VERIFIER_ADDRESS = "CDGMOL3BP6Y6LYOXXTRNXBNJ2SLNTQ47BGG3LOS2OBBE657E3NYCN54B"
+    const val ED25519_VERIFIER_ADDRESS = "CAIKK32K3BZJYTWVTXHZFPIEEDBR6YCVTGPABH4UQUQ4XFA3OLYXG27G"
 
     // -- Token Contracts --
 
@@ -110,13 +110,13 @@ val KNOWN_POLICIES = listOf(
         type = "threshold",
         name = "Threshold (M-of-N)",
         description = "Requires M signatures out of N total signers",
-        address = "CCT4MMN5MJ6O2OU6LXPYTCVORQ2QVTBMDJ7MYBZQ2ULSYQVUIYP4IFYD"
+        address = "CDDQLFG7CV74QHWPSP6NZIPNBR2PPCMTUVYCJF4P3ONDYHODRFGR7LWC"
     ),
     PolicyInfo(
         type = "spending_limit",
         name = "Spending Limit",
         description = "Limits spending to a maximum amount per time period",
-        address = "CBMMWY54XOV6JJHSWCMKWWPXVRXASR5U26UJMLZDN4SP6CFFTVZARPTY"
+        address = "CBYLPYZGLQ6JVY2IQ5P23QLQPR3KAMMKMZLNWG6RUUKJDNYGPLVHK7U4"
     ),
     PolicyInfo(
         type = "weighted_threshold",

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/flows/ContextRuleFlow.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/flows/ContextRuleFlow.kt
@@ -4,7 +4,7 @@ package com.soneso.smartdemo.flows
  * Business logic for managing context rules on a smart account.
  *
  * Functions provided by this file:
- * - Loading rules: [loadContextRules], [loadContextRule]
+ * - Loading rules: [loadContextRules], [loadParsedContextRule]
  * - Modifying rules: [addContextRule], [removeContextRule], [updateContextRuleName], [updateContextRuleValidUntil]
  * - Signer construction: [registerPasskeySigner], [buildDelegatedSigner], [buildEd25519Signer]
  * - Helpers: [resolveAbsoluteLedger], [loadAvailablePasskeySigners]
@@ -13,9 +13,9 @@ package com.soneso.smartdemo.flows
  * authorize which operations (Default, CallContract, or CreateContract) and which
  * policy contracts are enforced. All modifying operations require passkey authentication.
  *
- * Rule data is stored on-chain as Soroban SCVal maps and parsed by [fetchAllContextRules]
- * from ContextRuleParser.kt. Individual rule parsing is done via parseSingleContextRuleFromScVal
- * (defined in ContextRuleParser.kt) by the calling screen.
+ * Rule data is fetched via [OZContextRuleManager.listContextRules] which returns fully
+ * parsed [ParsedContextRule] objects including the [ParsedContextRule.signerIds] and
+ * [ParsedContextRule.policyIds] fields introduced in v0.7.0.
  */
 
 import com.soneso.smartdemo.config.DemoConfig
@@ -62,43 +62,37 @@ data class FlowPolicyEntry(
 /**
  * Loads all context rules from the connected smart account.
  *
- * SDK workflow:
- * 1. Call [contextRuleManager.getContextRulesCount] to get the total rule count.
- * 2. Iterate IDs from 0 upward, calling [contextRuleManager.getContextRule] for each.
- *    Gaps from removed rules are skipped.
- * 3. Parse each SCVal result using [parseSingleContextRuleFromScVal] from ContextRuleParser.
+ * Delegates to [fetchAllContextRules] which calls [OZContextRuleManager.listContextRules].
+ * The returned rules include [ParsedContextRule.signerIds] and [ParsedContextRule.policyIds]
+ * populated by the SDK.
  *
- * @return List of [ParsedContextRule], sorted by ID with duplicates removed.
+ * @return List of [ParsedContextRule], sorted by ID.
  * @throws IllegalStateException if the kit is not initialized.
  */
 suspend fun loadContextRules(): List<ParsedContextRule> {
-    // fetchAllContextRules reads from DemoState.kit internally and handles the
-    // count-then-fetch pattern with a fallback for contracts without count support.
     val rules = fetchAllContextRules()
     ActivityLogState.info("Fetched ${rules.size} context rule(s)")
     return rules
 }
 
 /**
- * Loads a single context rule by ID for edit mode pre-population.
+ * Loads a single context rule by ID as a fully parsed [ParsedContextRule].
  *
- * SDK workflow:
- * - Calls [OZSmartAccountKit.contextRuleManager.getContextRule] which returns the
- *   rule's on-chain data as a raw SCVal map.
- * - The screen parses the result using [parseSingleContextRuleFromScVal] to populate
- *   its form fields (name, context type, signers, policies, expiry).
+ * Fetches all context rules via [OZContextRuleManager.listContextRules] and returns the
+ * rule matching [ruleId]. This ensures the result includes [ParsedContextRule.signerIds]
+ * and [ParsedContextRule.policyIds] as populated by the SDK parser.
  *
- * @param ruleId The rule ID (0-indexed) to load.
- * @return The raw [SCValXdr] for parsing by the caller.
- * @throws Exception if the rule does not exist or the RPC call fails.
+ * @param ruleId The rule ID to load.
+ * @return The parsed [ParsedContextRule].
+ * @throws IllegalStateException if the kit is not initialized.
+ * @throws NoSuchElementException if no rule with the given ID exists.
  */
-suspend fun loadContextRule(ruleId: UInt): SCValXdr {
+suspend fun loadParsedContextRule(ruleId: UInt): ParsedContextRule {
     val kit = DemoState.kit
         ?: throw IllegalStateException("Kit not initialized")
-
-    // getContextRule returns the raw on-chain SCVal so the screen can parse
-    // it into typed form fields using parseSingleContextRuleFromScVal.
-    return kit.contextRuleManager.getContextRule(ruleId)
+    return kit.contextRuleManager.listContextRules()
+        .firstOrNull { it.id == ruleId }
+        ?: throw NoSuchElementException("Context rule #$ruleId not found")
 }
 
 /**

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/ui/screens/ContextRuleBuilderScreen.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/ui/screens/ContextRuleBuilderScreen.kt
@@ -83,7 +83,7 @@ import com.soneso.smartdemo.flows.addContextRule
 import com.soneso.smartdemo.flows.buildDelegatedSigner
 import com.soneso.smartdemo.flows.buildEd25519Signer
 import com.soneso.smartdemo.flows.loadAvailablePasskeySigners
-import com.soneso.smartdemo.flows.loadContextRule
+import com.soneso.smartdemo.flows.loadParsedContextRule
 import com.soneso.smartdemo.flows.registerPasskeySigner
 import com.soneso.smartdemo.flows.resolveAbsoluteLedger
 import com.soneso.smartdemo.flows.updateContextRuleName
@@ -99,7 +99,6 @@ import com.soneso.smartdemo.util.formatSignerForDisplay
 import com.soneso.smartdemo.util.hexToByteArray
 import com.soneso.smartdemo.util.isUserCancellation
 import com.soneso.smartdemo.util.isValidSpendingAmount
-import com.soneso.smartdemo.util.parseSingleContextRuleFromScVal
 import com.soneso.smartdemo.util.signerTypeColor
 import com.soneso.smartdemo.util.toHexString
 import com.soneso.smartdemo.util.truncateAddress
@@ -188,48 +187,43 @@ class ContextRuleBuilderScreen(
                 isLoadingRule = true
                 errorMessage = null
                 try {
-                    val ruleScVal = loadContextRule(editRuleId)
-                    val parsed = parseSingleContextRuleFromScVal(ruleScVal, editRuleId)
-                    if (parsed != null) {
-                        ruleName = parsed.name
-                        when (val ct = parsed.contextType) {
-                            is ContextRuleType.Default -> {
-                                contextTypeOption = ContextTypeOption.DEFAULT
-                            }
-                            is ContextRuleType.CallContract -> {
-                                contextTypeOption = ContextTypeOption.CALL_CONTRACT
-                                contractAddress = ct.contractAddress
-                            }
-                            is ContextRuleType.CreateContract -> {
-                                contextTypeOption = ContextTypeOption.CREATE_CONTRACT
-                                wasmHashHex = ct.wasmHash.toHexString()
-                            }
+                    val parsed = loadParsedContextRule(editRuleId)
+                    ruleName = parsed.name
+                    when (val ct = parsed.contextType) {
+                        is ContextRuleType.Default -> {
+                            contextTypeOption = ContextTypeOption.DEFAULT
                         }
-                        if (parsed.validUntil != null) {
-                            hasExpiry = true
-                            // Do not pre-populate expiryLedger: the value from on-chain
-                            // is an absolute ledger number and must not be treated as an
-                            // offset at submission time. Show it as informational text only.
-                            existingExpiryLedger = parsed.validUntil
+                        is ContextRuleType.CallContract -> {
+                            contextTypeOption = ContextTypeOption.CALL_CONTRACT
+                            contractAddress = ct.contractAddress
                         }
-                        signers = parsed.signers
-                        // Pre-populate policies from existing rule (addresses only, params not available)
-                        policies = parsed.policies.mapNotNull { addr ->
-                            val known = KNOWN_POLICIES.find { it.address == addr }
-                            if (known != null) {
-                                PolicyEntry(info = known, label = known.name, address = addr)
-                            } else {
-                                PolicyEntry(
-                                    info = null,
-                                    label = "Unknown Policy",
-                                    address = addr
-                                )
-                            }
+                        is ContextRuleType.CreateContract -> {
+                            contextTypeOption = ContextTypeOption.CREATE_CONTRACT
+                            wasmHashHex = ct.wasmHash.toHexString()
                         }
-                        ActivityLogState.info("Loaded rule #$editRuleId for editing")
-                    } else {
-                        errorMessage = "Failed to parse rule #$editRuleId"
                     }
+                    if (parsed.validUntil != null) {
+                        hasExpiry = true
+                        // Do not pre-populate expiryLedger: the value from on-chain
+                        // is an absolute ledger number and must not be treated as an
+                        // offset at submission time. Show it as informational text only.
+                        existingExpiryLedger = parsed.validUntil
+                    }
+                    signers = parsed.signers
+                    // Pre-populate policies from existing rule (addresses only, params not available)
+                    policies = parsed.policies.mapNotNull { addr ->
+                        val known = KNOWN_POLICIES.find { it.address == addr }
+                        if (known != null) {
+                            PolicyEntry(info = known, label = known.name, address = addr)
+                        } else {
+                            PolicyEntry(
+                                info = null,
+                                label = "Unknown Policy",
+                                address = addr
+                            )
+                        }
+                    }
+                    ActivityLogState.info("Loaded rule #$editRuleId for editing")
                 } catch (e: Exception) {
                     errorMessage = "Failed to load rule #$editRuleId: ${e.message}"
                     ActivityLogState.error("Failed to load rule: ${e.message}")

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/util/ContextRuleParser.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/util/ContextRuleParser.kt
@@ -2,20 +2,15 @@ package com.soneso.smartdemo.util
 
 import com.soneso.smartdemo.state.ActivityLogState
 import com.soneso.smartdemo.state.DemoState
-import com.soneso.stellar.sdk.scval.Scv
+import com.soneso.stellar.sdk.Util
 import com.soneso.stellar.sdk.smartaccount.core.DelegatedSigner
 import com.soneso.stellar.sdk.smartaccount.core.ExternalSigner
 import com.soneso.stellar.sdk.smartaccount.core.SmartAccountBuilders
 import com.soneso.stellar.sdk.smartaccount.core.SmartAccountConstants
 import com.soneso.stellar.sdk.smartaccount.core.SmartAccountSigner
-import com.soneso.stellar.sdk.smartaccount.oz.ContextRuleType
 import com.soneso.stellar.sdk.smartaccount.oz.ExternalWalletAdapter
 import com.soneso.stellar.sdk.smartaccount.oz.OZSmartAccountKit
 import com.soneso.stellar.sdk.smartaccount.oz.ParsedContextRule
-import com.soneso.stellar.sdk.Address
-import com.soneso.stellar.sdk.Util
-import com.soneso.stellar.sdk.xdr.SCAddressXdr
-import com.soneso.stellar.sdk.xdr.SCValXdr
 
 /**
  * Represents a signer extracted from context rules with its signing capability.
@@ -31,32 +26,20 @@ data class SignerInfo(
 /**
  * Fetches all context rules from the connected smart account.
  *
- * Iterates rule IDs from 0 upward using [OZContextRuleManager.getContextRule], stopping
- * once all active rules (per [OZContextRuleManager.getContextRulesCount]) are found or
- * [OZSmartAccountConfig.maxContextRuleScanId] is reached. Gaps from removed rules are skipped.
+ * Delegates to [OZContextRuleManager.listContextRules] which handles the count-then-fetch
+ * iteration and full SDK-level parsing including [ParsedContextRule.signerIds] and
+ * [ParsedContextRule.policyIds].
  *
  * @param kit The initialized [OZSmartAccountKit] instance.
  * @throws IllegalStateException if kit is not initialized.
  */
 suspend fun fetchAllContextRules(kit: OZSmartAccountKit): List<ParsedContextRule> {
-    val allRuleScVals = try {
-        kit.contextRuleManager.getAllContextRules()
+    return try {
+        kit.contextRuleManager.listContextRules()
     } catch (e: Exception) {
         ActivityLogState.error("Failed to fetch context rules: ${e.message}")
         emptyList()
     }
-
-    val result = mutableListOf<ParsedContextRule>()
-    val seenIds = mutableSetOf<UInt>()
-
-    for ((index, ruleScVal) in allRuleScVals.withIndex()) {
-        val parsed = parseSingleContextRuleFromScVal(ruleScVal, index.toUInt())
-        if (parsed != null && seenIds.add(parsed.id)) {
-            result.add(parsed)
-        }
-    }
-
-    return result.sortedBy { it.id }
 }
 
 /**
@@ -117,220 +100,5 @@ fun extractSignersFromRules(
             }
         }
         SignerInfo(signer = signer, canSign = canSign)
-    }
-}
-
-/**
- * Parses a single context rule from its ScVal map representation.
- *
- * Soroban structs are encoded as ScMap with Symbol keys in alphabetical order:
- * { context_type, id, name, policies, signers, valid_until }
- *
- * @param scVal The ScVal to parse.
- * @param fallbackId Used as the rule ID if the map does not contain an "id" field.
- * @return A [ParsedContextRule] or null if the ScVal is not a valid map.
- */
-fun parseSingleContextRuleFromScVal(
-    scVal: SCValXdr,
-    fallbackId: UInt?
-): ParsedContextRule? {
-    val map = (scVal as? SCValXdr.Map)?.value?.value ?: return null
-
-    var id: UInt = fallbackId ?: 0u
-    var contextType: ContextRuleType = ContextRuleType.Default
-    var name = ""
-    var signers = listOf<SmartAccountSigner>()
-    var policies = listOf<String>()
-    var validUntil: UInt? = null
-
-    for (entry in map) {
-        val fieldName = try { Scv.fromSymbol(entry.key) } catch (_: Exception) { continue }
-        val fieldValue = entry.`val`
-
-        when (fieldName) {
-            "id" -> {
-                id = try { Scv.fromUint32(fieldValue) } catch (_: Exception) { fallbackId ?: 0u }
-            }
-            "context_type" -> {
-                contextType = parseContextType(fieldValue)
-            }
-            "name" -> {
-                name = when (fieldValue) {
-                    is SCValXdr.Str -> fieldValue.value.value
-                    is SCValXdr.Sym -> fieldValue.value.value
-                    else -> ""
-                }
-            }
-            "signers" -> {
-                signers = parseSigners(fieldValue)
-            }
-            "policies" -> {
-                policies = parsePolicies(fieldValue)
-            }
-            "valid_until" -> {
-                validUntil = when (fieldValue) {
-                    is SCValXdr.U32 -> try { Scv.fromUint32(fieldValue) } catch (_: Exception) { null }
-                    is SCValXdr.Void -> null
-                    else -> null
-                }
-            }
-        }
-    }
-
-    return ParsedContextRule(
-        id = id,
-        contextType = contextType,
-        name = name,
-        signers = signers,
-        policies = policies,
-        validUntil = validUntil
-    )
-}
-
-/**
- * Parses a context type from its ScVal Vec representation.
- *
- * On-chain encoding:
- * - Default: Vec[Symbol("Default")]
- * - CallContract: Vec[Symbol("CallContract"), Address(contractAddress)]
- * - CreateContract: Vec[Symbol("CreateContract"), Bytes(wasmHash)]
- */
-fun parseContextType(scVal: SCValXdr): ContextRuleType {
-    val vec = (scVal as? SCValXdr.Vec)?.value?.value ?: return ContextRuleType.Default
-    if (vec.isEmpty()) return ContextRuleType.Default
-
-    val tag = try { Scv.fromSymbol(vec[0]) } catch (_: Exception) { return ContextRuleType.Default }
-
-    return when (tag) {
-        "Default" -> ContextRuleType.Default
-
-        "CallContract" -> {
-            if (vec.size >= 2) {
-                val address = (vec[1] as? SCValXdr.Address)?.value
-                if (address != null) {
-                    val addressStr = extractAddressString(address)
-                    if (addressStr != null) {
-                        ContextRuleType.CallContract(addressStr)
-                    } else {
-                        ContextRuleType.Default
-                    }
-                } else {
-                    ContextRuleType.Default
-                }
-            } else {
-                ContextRuleType.Default
-            }
-        }
-
-        "CreateContract" -> {
-            if (vec.size >= 2) {
-                val bytes = try { Scv.fromBytes(vec[1]) } catch (_: Exception) { null }
-                if (bytes != null) {
-                    ContextRuleType.CreateContract(bytes)
-                } else {
-                    ContextRuleType.Default
-                }
-            } else {
-                ContextRuleType.Default
-            }
-        }
-
-        else -> ContextRuleType.Default
-    }
-}
-
-/**
- * Parses signers from a ScVal Vec.
- *
- * Each signer element is a Vec:
- * - Delegated: Vec[Symbol("Delegated"), Address(address)]
- * - External: Vec[Symbol("External"), Address(verifier), Bytes(keyData)]
- */
-fun parseSigners(scVal: SCValXdr): List<SmartAccountSigner> {
-    val vec = (scVal as? SCValXdr.Vec)?.value?.value ?: return emptyList()
-    return vec.mapNotNull { signerVal -> parseSingleSigner(signerVal) }
-}
-
-/**
- * Parses a single signer from its ScVal Vec representation.
- *
- * @return A [SmartAccountSigner] or null if the ScVal cannot be parsed.
- */
-fun parseSingleSigner(scVal: SCValXdr): SmartAccountSigner? {
-    val vec = (scVal as? SCValXdr.Vec)?.value?.value ?: return null
-    if (vec.isEmpty()) return null
-
-    val tag = try { Scv.fromSymbol(vec[0]) } catch (_: Exception) { return null }
-
-    return when (tag) {
-        "Delegated" -> {
-            if (vec.size >= 2) {
-                val address = (vec[1] as? SCValXdr.Address)?.value
-                if (address != null) {
-                    val addressStr = extractAddressString(address)
-                    if (addressStr != null) {
-                        try {
-                            DelegatedSigner(addressStr)
-                        } catch (_: Exception) {
-                            null
-                        }
-                    } else null
-                } else null
-            } else null
-        }
-
-        "External" -> {
-            if (vec.size >= 3) {
-                val verifier = (vec[1] as? SCValXdr.Address)?.value
-                val keyData = try { Scv.fromBytes(vec[2]) } catch (_: Exception) { null }
-                if (verifier != null && keyData != null) {
-                    val verifierStr = extractAddressString(verifier)
-                    if (verifierStr != null) {
-                        try {
-                            ExternalSigner(verifierStr, keyData)
-                        } catch (_: Exception) {
-                            null
-                        }
-                    } else null
-                } else null
-            } else null
-        }
-
-        else -> null
-    }
-}
-
-/**
- * Parses policy addresses from a ScVal.
- *
- * Policies can be encoded as:
- * - Vec[Address, ...]: list of policy contract addresses
- * - Map[Address -> ScVal, ...]: policy address to install params (keys extracted)
- */
-fun parsePolicies(scVal: SCValXdr): List<String> {
-    return when (scVal) {
-        is SCValXdr.Vec -> {
-            val vec = scVal.value?.value ?: return emptyList()
-            vec.mapNotNull { element ->
-                val address = (element as? SCValXdr.Address)?.value
-                if (address != null) extractAddressString(address) else null
-            }
-        }
-        is SCValXdr.Map -> {
-            val entries = scVal.value?.value ?: return emptyList()
-            entries.mapNotNull { mapEntry ->
-                val address = (mapEntry.key as? SCValXdr.Address)?.value
-                if (address != null) extractAddressString(address) else null
-            }
-        }
-        else -> emptyList()
-    }
-}
-
-private fun extractAddressString(address: SCAddressXdr): String? {
-    return try {
-        Address.fromSCAddress(address).toString()
-    } catch (_: Exception) {
-        null
     }
 }

--- a/smart-account-demo/shared/src/macosMain/kotlin/com/soneso/smartdemo/MacOSBridge.kt
+++ b/smart-account-demo/shared/src/macosMain/kotlin/com/soneso/smartdemo/MacOSBridge.kt
@@ -26,8 +26,8 @@ import com.soneso.smartdemo.flows.initializeKit
 import com.soneso.smartdemo.flows.loadAccountSigners
 import com.soneso.smartdemo.flows.loadAvailablePasskeySigners
 import com.soneso.smartdemo.flows.loadAvailableSigners
-import com.soneso.smartdemo.flows.loadContextRule
 import com.soneso.smartdemo.flows.loadContextRules
+import com.soneso.smartdemo.flows.loadParsedContextRule
 import com.soneso.smartdemo.flows.manualConnect
 import com.soneso.smartdemo.flows.multiSignerTransfer
 import com.soneso.smartdemo.flows.quickConnect
@@ -47,7 +47,6 @@ import com.soneso.smartdemo.util.buildWeightedThresholdScVal
 import com.soneso.smartdemo.util.formatContextType
 import com.soneso.smartdemo.util.hexToByteArray
 import com.soneso.smartdemo.util.isUserCancellation
-import com.soneso.smartdemo.util.parseSingleContextRuleFromScVal
 import com.soneso.smartdemo.util.toHexString
 import com.soneso.smartdemo.util.truncateAddress
 import com.soneso.stellar.sdk.KeyPair
@@ -507,20 +506,16 @@ class MacOSBridge {
     /**
      * Loads a single context rule for pre-populating an edit form in Swift.
      *
-     * Fetches the raw [SCValXdr] from the chain and parses it using [parseSingleContextRuleFromScVal],
-     * then converts all Kotlin-specific types to their [ParsedRuleBridge] equivalents.
+     * Fetches the fully parsed [ParsedContextRule] via [loadParsedContextRule] (which uses
+     * [OZContextRuleManager.listContextRules]) and converts it to a [ParsedRuleBridge].
      *
      * @param ruleId Rule ID as an Int (converted to UInt internally).
-     * @return [ParsedRuleBridge] with all rule fields in Swift-friendly format.
+     * @return [ParsedRuleBridge] with rule fields in Swift-friendly format.
      * @throws Exception if the rule does not exist or the RPC call fails.
      */
     @Throws(Exception::class)
     suspend fun loadContextRuleForEdit(ruleId: Int): ParsedRuleBridge {
-        val ruleIdUInt = ruleId.toUInt()
-        val scVal = loadContextRule(ruleIdUInt)
-        val parsed = parseSingleContextRuleFromScVal(scVal, ruleIdUInt)
-            ?: throw IllegalStateException("Failed to parse context rule #$ruleId")
-
+        val parsed = loadParsedContextRule(ruleId.toUInt())
         return convertRuleToBridge(parsed)
     }
 

--- a/stellar-sdk/src/androidMain/kotlin/com/soneso/stellar/sdk/smartaccount/AndroidWebAuthnProvider.kt
+++ b/stellar-sdk/src/androidMain/kotlin/com/soneso/stellar/sdk/smartaccount/AndroidWebAuthnProvider.kt
@@ -177,7 +177,7 @@ class AndroidWebAuthnProvider(
         challenge: ByteArray,
         allowCredentialIds: List<ByteArray>?
     ): WebAuthnAuthenticationResult {
-        val requestJson = buildAuthenticationRequestJson(challenge)
+        val requestJson = buildAuthenticationRequestJson(challenge, allowCredentialIds)
 
         val getRequest = GetCredentialRequest(
             credentialOptions = listOf(
@@ -288,15 +288,31 @@ class AndroidWebAuthnProvider(
      * Builds the PublicKeyCredentialRequestOptions JSON for an authentication ceremony.
      *
      * Constructs a JSON string conforming to the WebAuthn specification's
-     * `PublicKeyCredentialRequestOptions` dictionary. Uses an empty `allowCredentials`
-     * list to enable discoverable credential selection (the user picks which passkey
-     * to use).
+     * `PublicKeyCredentialRequestOptions` dictionary. When [allowCredentialIds] is
+     * provided, the `allowCredentials` array constrains the authenticator to only
+     * the specified credentials. When null or empty, discoverable credential selection
+     * is used (the user picks which passkey to use).
      *
      * @param challenge The challenge bytes (base64url encoded in the JSON)
+     * @param allowCredentialIds Optional list of credential ID bytes to constrain selection
      * @return JSON string for the authentication request
      */
-    private fun buildAuthenticationRequestJson(challenge: ByteArray): String {
+    private fun buildAuthenticationRequestJson(
+        challenge: ByteArray,
+        allowCredentialIds: List<ByteArray>? = null
+    ): String {
         val challengeB64 = base64UrlEncode(challenge)
+
+        val allowCredentials = if (!allowCredentialIds.isNullOrEmpty()) {
+            JsonArray(allowCredentialIds.map { credId ->
+                JsonObject(mapOf(
+                    "type" to JsonPrimitive("public-key"),
+                    "id" to JsonPrimitive(base64UrlEncode(credId))
+                ))
+            })
+        } else {
+            JsonArray(emptyList())
+        }
 
         val jsonObject = JsonObject(
             mapOf(
@@ -304,8 +320,7 @@ class AndroidWebAuthnProvider(
                 "rpId" to JsonPrimitive(rpId),
                 "timeout" to JsonPrimitive(timeout),
                 "userVerification" to JsonPrimitive("required"),
-                // Empty allowCredentials = discoverable credential (passkey) selection
-                "allowCredentials" to JsonArray(emptyList())
+                "allowCredentials" to allowCredentials
             )
         )
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/core/SmartAccountAuth.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/core/SmartAccountAuth.kt
@@ -13,14 +13,12 @@ import com.soneso.stellar.sdk.xdr.HashIDPreimageSorobanAuthorizationXdr
 import com.soneso.stellar.sdk.xdr.HashXdr
 import com.soneso.stellar.sdk.xdr.Int64Xdr
 import com.soneso.stellar.sdk.scval.Scv
-import com.soneso.stellar.sdk.xdr.SCMapEntryXdr
 import com.soneso.stellar.sdk.xdr.SCValXdr
 import com.soneso.stellar.sdk.xdr.SorobanAddressCredentialsXdr
 import com.soneso.stellar.sdk.xdr.SorobanAuthorizationEntryXdr
 import com.soneso.stellar.sdk.xdr.SorobanCredentialsXdr
 import com.soneso.stellar.sdk.xdr.Uint32Xdr
 import com.soneso.stellar.sdk.xdr.SorobanAuthorizedInvocationXdr
-import com.soneso.stellar.sdk.Util
 import com.soneso.stellar.sdk.xdr.XdrReader
 import com.soneso.stellar.sdk.xdr.XdrWriter
 
@@ -60,6 +58,47 @@ object SmartAccountAuth {
     // ========================================================================
     // Payload Hash Building
     // ========================================================================
+
+    /**
+     * Computes the auth digest that binds context rule IDs to the signature payload.
+     *
+     * The digest is computed as:
+     * ```
+     * auth_digest = SHA-256(signaturePayload || contextRuleIds.toXDR())
+     * ```
+     *
+     * Where `contextRuleIds.toXDR()` is the XDR encoding of `ScVal::Vec([ScVal::U32(id), ...])`.
+     * This matches the TypeScript SDK computation exactly:
+     * ```typescript
+     * const ruleIdsXdr = xdr.ScVal.scvVec(contextRuleIds.map(id => xdr.ScVal.scvU32(id))).toXDR();
+     * return hash(Buffer.concat([signaturePayload, ruleIdsXdr]));
+     * ```
+     *
+     * @param signaturePayload The 32-byte signature payload hash from [buildAuthPayloadHash]
+     * @param contextRuleIds The context rule IDs to bind into the digest
+     * @return The 32-byte SHA-256 auth digest
+     * @throws TransactionException.SigningFailed if XDR encoding fails
+     */
+    suspend fun buildAuthDigest(
+        signaturePayload: ByteArray,
+        contextRuleIds: List<UInt>
+    ): ByteArray {
+        val ruleIdsScVal = Scv.toVec(contextRuleIds.map { id -> Scv.toUint32(id) })
+
+        val ruleIdsXdr: ByteArray = try {
+            val writer = XdrWriter()
+            ruleIdsScVal.encode(writer)
+            writer.toByteArray()
+        } catch (e: Exception) {
+            throw TransactionException.signingFailed(
+                "Failed to XDR encode context rule IDs ScVal",
+                e
+            )
+        }
+
+        val concatenated = signaturePayload + ruleIdsXdr
+        return getSha256Crypto().hash(concatenated)
+    }
 
     /**
      * Builds the authorization payload hash for signing.
@@ -230,7 +269,8 @@ object SmartAccountAuth {
         entry: SorobanAuthorizationEntryXdr,
         signer: SmartAccountSigner,
         signature: SmartAccountSignature,
-        expirationLedger: UInt
+        expirationLedger: UInt,
+        contextRuleIds: List<UInt> = emptyList()
     ): SorobanAuthorizationEntryXdr {
         // STEP 1: Clone entry via XDR round-trip to avoid mutating input
         val entryBytes: ByteArray = try {
@@ -294,17 +334,34 @@ object SmartAccountAuth {
             )
         }
 
-        // Step C: Wrap those raw bytes in a new ScVal::Bytes
-        val signatureValue = Scv.toBytes(sigXdrBytes)
+        // STEP 4-6: Update AuthPayload and return updated entry
 
-        // Create map entry
-        val mapEntry = SCMapEntryXdr(key = signerKey, `val` = signatureValue)
+        // Read existing payload from credentials (Void -> empty payload)
+        val existingPayload = SmartAccountAuthPayloadCodec.read(credentials.signature)
 
-        // STEP 4-6: Add to signatures map and return updated entry
-        return appendSignatureMapEntry(
-            entry = entryCopy,
-            credentials = credentials,
-            mapEntry = mapEntry
+        // Preserve or override context rule IDs
+        val updatedPayload = SmartAccountAuthPayload(
+            signers = existingPayload.signers,
+            contextRuleIds = if (contextRuleIds.isNotEmpty()) contextRuleIds else existingPayload.contextRuleIds
+        )
+
+        // Upsert signer with double-XDR-encoded signature bytes
+        SmartAccountAuthPayloadCodec.upsertSigner(updatedPayload, signer, sigXdrBytes)
+
+        // Write updated payload back as SCVal
+        val payloadScVal = SmartAccountAuthPayloadCodec.write(updatedPayload)
+
+        // Build updated credentials with new signature
+        val updatedCredentials = SorobanAddressCredentialsXdr(
+            address = credentials.address,
+            nonce = credentials.nonce,
+            signatureExpirationLedger = credentials.signatureExpirationLedger,
+            signature = payloadScVal
+        )
+
+        return SorobanAuthorizationEntryXdr(
+            credentials = SorobanCredentialsXdr.Address(updatedCredentials),
+            rootInvocation = entryCopy.rootInvocation
         )
     }
 
@@ -316,28 +373,69 @@ object SmartAccountAuth {
      * Adds a raw key/value entry to the auth entry's signature map.
      *
      * Used for delegated signer placeholders where the value is `Bytes(empty)`
-     * rather than a double-XDR-encoded signature. The entry is cloned, the map
-     * entry is appended, and the map is re-sorted.
+     * rather than a double-XDR-encoded signature. Uses the v0.7.0 AuthPayload format.
      *
      * @param entry The auth entry to modify
      * @param signerKey The signer identity ScVal (map key)
-     * @param signatureValue The raw ScVal to use as the map value
+     * @param signatureValue The raw ScVal to use as the map value. If `SCValXdr.Bytes`, the bytes
+     *        are stored directly. Otherwise the value is XDR-encoded and the resulting bytes stored.
+     * @param contextRuleIds The context rule IDs to bind into the payload (optional).
      * @return A new auth entry with the map entry added
      */
     fun addRawSignatureMapEntry(
         entry: SorobanAuthorizationEntryXdr,
         signerKey: SCValXdr,
-        signatureValue: SCValXdr
+        signatureValue: SCValXdr,
+        contextRuleIds: List<UInt> = emptyList()
     ): SorobanAuthorizationEntryXdr {
         val credentials = (entry.credentials as? SorobanCredentialsXdr.Address)?.value
             ?: throw TransactionException.signingFailed(
                 "Credentials must be of type address to add signature map entry"
             )
 
-        return appendSignatureMapEntry(
-            entry = entry,
-            credentials = credentials,
-            mapEntry = SCMapEntryXdr(key = signerKey, `val` = signatureValue)
+        // Read existing payload
+        val existingPayload = SmartAccountAuthPayloadCodec.read(credentials.signature)
+
+        // Preserve or override context rule IDs
+        val updatedPayload = SmartAccountAuthPayload(
+            signers = existingPayload.signers,
+            contextRuleIds = if (contextRuleIds.isNotEmpty()) contextRuleIds else existingPayload.contextRuleIds
+        )
+
+        // Extract bytes from signatureValue: use raw bytes if Bytes, otherwise XDR-encode
+        val sigBytes = when (signatureValue) {
+            is SCValXdr.Bytes -> signatureValue.value.value
+            else -> {
+                try {
+                    val writer = XdrWriter()
+                    signatureValue.encode(writer)
+                    writer.toByteArray()
+                } catch (e: Exception) {
+                    throw TransactionException.signingFailed(
+                        "Failed to XDR-encode raw signature value",
+                        e
+                    )
+                }
+            }
+        }
+
+        // Parse signer from key ScVal and upsert
+        val signer = SmartAccountAuthPayloadCodec.signerFromScVal(signerKey)
+        updatedPayload.signers[signer] = sigBytes
+
+        // Write updated payload back as SCVal
+        val payloadScVal = SmartAccountAuthPayloadCodec.write(updatedPayload)
+
+        val updatedCredentials = SorobanAddressCredentialsXdr(
+            address = credentials.address,
+            nonce = credentials.nonce,
+            signatureExpirationLedger = credentials.signatureExpirationLedger,
+            signature = payloadScVal
+        )
+
+        return SorobanAuthorizationEntryXdr(
+            credentials = SorobanCredentialsXdr.Address(updatedCredentials),
+            rootInvocation = entry.rootInvocation
         )
     }
 
@@ -388,85 +486,5 @@ object SmartAccountAuth {
         }
 
         return getSha256Crypto().hash(encodedPreimage)
-    }
-
-    /**
-     * Appends a signature map entry to an authorization entry's credential signature map.
-     *
-     * Collects existing map entries from the credentials signature field (if any),
-     * appends the new entry, sorts all entries by XDR-encoded key bytes (lowercase hex,
-     * lexicographic), rebuilds the signature Vec/Map structure, and returns a new
-     * [SorobanAuthorizationEntryXdr] with updated credentials. The input [entry] is not mutated.
-     *
-     * @param entry The authorization entry whose root invocation is preserved
-     * @param credentials The address credentials containing the existing signature map
-     * @param mapEntry The new map entry to append
-     * @return A new authorization entry with the map entry added and the map re-sorted
-     */
-    private fun appendSignatureMapEntry(
-        entry: SorobanAuthorizationEntryXdr,
-        credentials: SorobanAddressCredentialsXdr,
-        mapEntry: SCMapEntryXdr
-    ): SorobanAuthorizationEntryXdr {
-        val mapEntries = mutableListOf<SCMapEntryXdr>()
-
-        if (credentials.signature is SCValXdr.Vec) {
-            val existingVecXdr = (credentials.signature as SCValXdr.Vec).value
-            if (existingVecXdr != null && existingVecXdr.value.isNotEmpty()) {
-                val firstElement = existingVecXdr.value[0]
-                if (firstElement is SCValXdr.Map) {
-                    firstElement.value?.let { mapXdr ->
-                        mapEntries.addAll(mapXdr.value)
-                    }
-                }
-            }
-        }
-
-        mapEntries.add(mapEntry)
-
-        val sortedEntries = sortMapEntries(mapEntries)
-        val signatureMap = Scv.toMap(linkedMapOf<SCValXdr, SCValXdr>().apply {
-            sortedEntries.forEach { e -> put(e.key, e.`val`) }
-        })
-        val updatedCredentials = SorobanAddressCredentialsXdr(
-            address = credentials.address,
-            nonce = credentials.nonce,
-            signatureExpirationLedger = credentials.signatureExpirationLedger,
-            signature = Scv.toVec(listOf(signatureMap))
-        )
-
-        return SorobanAuthorizationEntryXdr(
-            credentials = SorobanCredentialsXdr.Address(updatedCredentials),
-            rootInvocation = entry.rootInvocation
-        )
-    }
-
-    /**
-     * Sorts map entries by XDR-encoded key bytes (lowercase hex, lexicographic).
-     *
-     * This is CRITICAL for contract compatibility. The smart account contract expects
-     * signature map entries to be sorted in a specific order based on the XDR-encoded
-     * key bytes converted to lowercase hex strings.
-     *
-     * @param entries The list of map entries to sort
-     * @return Sorted list of map entries
-     */
-    private fun sortMapEntries(entries: List<SCMapEntryXdr>): List<SCMapEntryXdr> {
-        return entries.sortedBy { entry ->
-            try {
-                // Encode the key to XDR bytes
-                val writer = XdrWriter()
-                entry.key.encode(writer)
-                val keyBytes = writer.toByteArray()
-
-                // Convert to lowercase hex string
-                Util.bytesToHex(keyBytes)
-            } catch (e: Exception) {
-                throw TransactionException.signingFailed(
-                    "Failed to XDR-encode signature map key for sorting: ${e.message}",
-                    e
-                )
-            }
-        }
     }
 }

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/core/SmartAccountAuthPayload.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/core/SmartAccountAuthPayload.kt
@@ -1,0 +1,260 @@
+//
+//  SmartAccountAuthPayload.kt
+//  Stellar SDK Kotlin Multiplatform
+//
+//  Copyright © 2026 Soneso. All rights reserved.
+//
+
+package com.soneso.stellar.sdk.smartaccount.core
+
+import com.soneso.stellar.sdk.Address
+import com.soneso.stellar.sdk.Util
+import com.soneso.stellar.sdk.scval.Scv
+import com.soneso.stellar.sdk.xdr.SCMapEntryXdr
+import com.soneso.stellar.sdk.xdr.SCValXdr
+import com.soneso.stellar.sdk.xdr.XdrWriter
+
+/**
+ * Represents the v0.7.0 AuthPayload format used by the OZ smart account contract.
+ *
+ * In v0.7.0, the signature payload changed from a Vec-based tuple struct to a Map-based
+ * named struct with two fields: `context_rule_ids` and `signers`.
+ *
+ * Contract representation:
+ * ```
+ * ScVal::Map([
+ *   { key: Symbol("context_rule_ids"), val: Vec([U32(id), ...]) },
+ *   { key: Symbol("signers"),          val: Map([{ key: signer.toScVal(), val: Bytes(sig) }, ...]) }
+ * ])
+ * ```
+ *
+ * @property signers Mutable map from signer to their double-XDR-encoded signature bytes.
+ * @property contextRuleIds The context rule IDs bound into the signing digest.
+ */
+data class SmartAccountAuthPayload(
+    val signers: MutableMap<SmartAccountSigner, ByteArray>,
+    val contextRuleIds: List<UInt>
+)
+
+/**
+ * Codec for reading and writing [SmartAccountAuthPayload] to/from [SCValXdr].
+ *
+ * Handles the v0.7.0 OZ smart account contract AuthPayload format, which is a
+ * named struct (Map-based) with fields `context_rule_ids` and `signers`.
+ */
+object SmartAccountAuthPayloadCodec {
+
+    /**
+     * Reads an [SmartAccountAuthPayload] from its [SCValXdr] representation.
+     *
+     * Accepts `SCValXdr.Void` (returns empty payload) or `SCValXdr.Map` (full payload).
+     *
+     * @param signatureScVal The ScVal stored in the authorization entry credentials signature field.
+     * @return The decoded [SmartAccountAuthPayload].
+     * @throws TransactionException.SigningFailed if the ScVal is not Void or Map.
+     */
+    fun read(signatureScVal: SCValXdr): SmartAccountAuthPayload {
+        if (signatureScVal is SCValXdr.Void) {
+            return SmartAccountAuthPayload(
+                signers = mutableMapOf(),
+                contextRuleIds = emptyList()
+            )
+        }
+
+        if (signatureScVal !is SCValXdr.Map) {
+            throw TransactionException.signingFailed(
+                "Smart account auth signature is not encoded as AuthPayload"
+            )
+        }
+
+        val mapEntries = signatureScVal.value?.value ?: emptyList()
+
+        var contextRuleIds: List<UInt> = emptyList()
+        val signers: MutableMap<SmartAccountSigner, ByteArray> = mutableMapOf()
+
+        for (entry in mapEntries) {
+            val key = entry.key
+            if (key !is SCValXdr.Sym) continue
+
+            when (key.value.value) {
+                "context_rule_ids" -> {
+                    val vec = entry.`val`
+                    if (vec is SCValXdr.Vec) {
+                        contextRuleIds = vec.value?.value?.mapNotNull { element ->
+                            if (element is SCValXdr.U32) element.value.value else null
+                        } ?: emptyList()
+                    }
+                }
+                "signers" -> {
+                    val signersMap = entry.`val`
+                    if (signersMap is SCValXdr.Map) {
+                        for (signerEntry in signersMap.value?.value ?: emptyList()) {
+                            val signer = signerFromScVal(signerEntry.key)
+                            val sigBytes = when (val sigVal = signerEntry.`val`) {
+                                is SCValXdr.Bytes -> sigVal.value.value
+                                else -> throw TransactionException.signingFailed(
+                                    "Signer signature value is not encoded as Bytes in AuthPayload"
+                                )
+                            }
+                            signers[signer] = sigBytes
+                        }
+                    }
+                }
+            }
+        }
+
+        return SmartAccountAuthPayload(
+            signers = signers,
+            contextRuleIds = contextRuleIds
+        )
+    }
+
+    /**
+     * Writes an [SmartAccountAuthPayload] to its [SCValXdr] representation.
+     *
+     * Builds the Map with exactly two entries (order: `context_rule_ids`, then `signers`).
+     * Signer entries within the signers map are sorted by XDR-encoded key bytes
+     * (lowercase hex, lexicographic).
+     *
+     * @param payload The payload to encode.
+     * @return The [SCValXdr] representation of the payload.
+     */
+    fun write(payload: SmartAccountAuthPayload): SCValXdr {
+        // Build signer map entries, wrapping raw bytes in Scv.toBytes()
+        val signerEntries = payload.signers.map { (signer, sigBytes) ->
+            SCMapEntryXdr(key = signer.toScVal(), `val` = Scv.toBytes(sigBytes))
+        }
+
+        // Sort signer entries by XDR-encoded key bytes (lowercase hex, lexicographic)
+        val sortedSignerEntries = signerEntries.sortedBy { entry ->
+            try {
+                val writer = XdrWriter()
+                entry.key.encode(writer)
+                Util.bytesToHex(writer.toByteArray())
+            } catch (e: Exception) {
+                throw TransactionException.signingFailed(
+                    "Failed to XDR-encode signer key for sorting: ${e.message}",
+                    e
+                )
+            }
+        }
+
+        val signersMapScVal = Scv.toMap(linkedMapOf<SCValXdr, SCValXdr>().apply {
+            sortedSignerEntries.forEach { e -> put(e.key, e.`val`) }
+        })
+
+        // context_rule_ids sorts before signers lexicographically, so order is correct
+        val contextRuleIdsScVal = Scv.toVec(payload.contextRuleIds.map { id ->
+            Scv.toUint32(id)
+        })
+
+        val outerMap = linkedMapOf<SCValXdr, SCValXdr>(
+            Scv.toSymbol("context_rule_ids") to contextRuleIdsScVal,
+            Scv.toSymbol("signers") to signersMapScVal
+        )
+
+        return Scv.toMap(outerMap)
+    }
+
+    /**
+     * Upserts a signer entry in the payload.
+     *
+     * If a signer matching [signer] already exists (using [SmartAccountBuilders.signersEqual]),
+     * the old entry is removed before adding the new one.
+     *
+     * @param payload The payload to update (mutated in place).
+     * @param signer The signer to add or replace.
+     * @param signatureBytes The double-XDR-encoded signature bytes to associate with the signer.
+     */
+    fun upsertSigner(
+        payload: SmartAccountAuthPayload,
+        signer: SmartAccountSigner,
+        signatureBytes: ByteArray
+    ) {
+        // Remove existing entry for this signer if present
+        val existingKey = payload.signers.keys.find { existing ->
+            SmartAccountBuilders.signersEqual(existing, signer)
+        }
+        if (existingKey != null) {
+            payload.signers.remove(existingKey)
+        }
+        payload.signers[signer] = signatureBytes
+    }
+
+    /**
+     * Parses a [SmartAccountSigner] from its [SCValXdr] representation.
+     *
+     * Supported formats:
+     * - `Vec([Symbol("Delegated"), Address(...)])` -> [DelegatedSigner]
+     * - `Vec([Symbol("External"), Address(...), Bytes(...)])` -> [ExternalSigner]
+     *
+     * @param scVal The ScVal to parse.
+     * @return The parsed [SmartAccountSigner].
+     * @throws TransactionException.SigningFailed if the ScVal format is unrecognized.
+     */
+    fun signerFromScVal(scVal: SCValXdr): SmartAccountSigner {
+        if (scVal !is SCValXdr.Vec) {
+            throw TransactionException.signingFailed(
+                "Signer ScVal is not a Vec"
+            )
+        }
+
+        val elements = scVal.value?.value
+            ?: throw TransactionException.signingFailed("Signer ScVal Vec is null or empty")
+
+        if (elements.isEmpty()) {
+            throw TransactionException.signingFailed("Signer ScVal Vec is empty")
+        }
+
+        val typeTag = elements[0]
+        if (typeTag !is SCValXdr.Sym) {
+            throw TransactionException.signingFailed(
+                "First element of signer Vec is not a Symbol"
+            )
+        }
+
+        return when (typeTag.value.value) {
+            "Delegated" -> {
+                if (elements.size < 2) {
+                    throw TransactionException.signingFailed(
+                        "Delegated signer Vec must have at least 2 elements"
+                    )
+                }
+                val addressScVal = elements[1]
+                if (addressScVal !is SCValXdr.Address) {
+                    throw TransactionException.signingFailed(
+                        "Delegated signer second element is not an Address"
+                    )
+                }
+                val addressStr = Address.fromSCAddress(addressScVal.value).getEncodedAddress()
+                DelegatedSigner(addressStr)
+            }
+            "External" -> {
+                if (elements.size < 3) {
+                    throw TransactionException.signingFailed(
+                        "External signer Vec must have at least 3 elements"
+                    )
+                }
+                val addressScVal = elements[1]
+                if (addressScVal !is SCValXdr.Address) {
+                    throw TransactionException.signingFailed(
+                        "External signer second element is not an Address"
+                    )
+                }
+                val verifierAddressStr = Address.fromSCAddress(addressScVal.value).getEncodedAddress()
+
+                val keyDataScVal = elements[2]
+                if (keyDataScVal !is SCValXdr.Bytes) {
+                    throw TransactionException.signingFailed(
+                        "External signer third element is not Bytes"
+                    )
+                }
+                val keyData = keyDataScVal.value.value
+                ExternalSigner(verifierAddressStr, keyData)
+            }
+            else -> throw TransactionException.signingFailed(
+                "Unknown signer type tag: '${typeTag.value.value}'"
+            )
+        }
+    }
+}

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/core/SmartAccountErrors.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/core/SmartAccountErrors.kt
@@ -765,3 +765,42 @@ object SmartAccountConstants {
      */
     const val UNCOMPRESSED_PUBKEY_PREFIX: Byte = 0x04
 }
+
+// ============================================================================
+// Contract Error Codes
+// ============================================================================
+
+/**
+ * Contract-level error codes from the OZ smart account contract.
+ *
+ * These codes are returned in contract error responses and can be mapped to
+ * exceptions by the SDK when interpreting failed transaction results.
+ *
+ * Error code range: 3xxx (credential errors, aligned with the contract's Error enum).
+ */
+object ContractErrorCodes {
+    /**
+     * Integer arithmetic overflow occurred in the contract.
+     */
+    const val MATH_OVERFLOW = 3012
+
+    /**
+     * The key_data field on a signer exceeds the maximum allowed size.
+     */
+    const val KEY_DATA_TOO_LARGE = 3013
+
+    /**
+     * The number of context rule IDs in the auth payload does not match the expected count.
+     */
+    const val CONTEXT_RULE_IDS_LENGTH_MISMATCH = 3014
+
+    /**
+     * A name field (e.g. context rule name) exceeds the maximum allowed length.
+     */
+    const val NAME_TOO_LONG = 3015
+
+    /**
+     * The signer is not authorized to sign the given context rule.
+     */
+    const val UNAUTHORIZED_SIGNER = 3016
+}

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZConstants.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZConstants.kt
@@ -61,4 +61,5 @@ object OZConstants {
      * Maximum context rules per smart account (OZ contract limit).
      */
     const val MAX_CONTEXT_RULES = 15
+
 }

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZContextRuleManager.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZContextRuleManager.kt
@@ -15,6 +15,10 @@ import com.soneso.stellar.sdk.xdr.HostFunctionXdr
 import com.soneso.stellar.sdk.xdr.InvokeContractArgsXdr
 import com.soneso.stellar.sdk.xdr.SCSymbolXdr
 import com.soneso.stellar.sdk.xdr.SCValXdr
+import com.soneso.stellar.sdk.xdr.ContractExecutableXdr
+import com.soneso.stellar.sdk.xdr.SorobanAuthorizationEntryXdr
+import com.soneso.stellar.sdk.xdr.SorobanAuthorizedFunctionXdr
+import com.soneso.stellar.sdk.xdr.SorobanAuthorizedInvocationXdr
 
 /**
  * Type of context rule that determines which operations it applies to.
@@ -122,7 +126,9 @@ sealed class ContextRuleType {
  * @property contextType The type of operations this rule applies to
  * @property name Human-readable name for the rule
  * @property signers List of signers who can authorize operations matching this context
+ * @property signerIds Positionally-aligned signer IDs corresponding to [signers]
  * @property policies List of policy contract addresses that constrain operations
+ * @property policyIds Positionally-aligned policy IDs corresponding to [policies]
  * @property validUntil Optional ledger number when this rule expires (null = no expiration)
  */
 data class ParsedContextRule(
@@ -130,7 +136,9 @@ data class ParsedContextRule(
     val contextType: ContextRuleType,
     val name: String,
     val signers: List<SmartAccountSigner>,
-    val policies: List<String>,  // Policy contract addresses
+    val signerIds: List<UInt>,
+    val policies: List<String>,
+    val policyIds: List<UInt>,
     val validUntil: UInt?
 )
 
@@ -150,7 +158,6 @@ data class ParsedContextRule(
  * 2. Which policies must be satisfied for the transaction to execute
  *
  * Contract limits:
- * - Maximum 15 context rules per smart account
  * - Maximum 15 signers per context rule
  * - Maximum 5 policies per context rule
  *
@@ -190,15 +197,13 @@ class OZContextRuleManager internal constructor(
      *
      * Flow:
      * 1. Validates inputs (name, signers count, policies count)
-     * 2. Checks that adding this rule won't exceed MAX_CONTEXT_RULES
-     * 3. Builds contract invocation for add_context_rule
-     * 4. Simulates to get auth entries
-     * 5. Signs auth entries (requires user interaction)
-     * 6. Submits transaction
-     * 7. Polls for confirmation
+     * 2. Builds contract invocation for add_context_rule
+     * 3. Simulates to get auth entries
+     * 4. Signs auth entries (requires user interaction)
+     * 5. Submits transaction
+     * 6. Polls for confirmation
      *
      * Contract limits enforced:
-     * - Maximum 15 context rules per smart account (checked via getContextRulesCount)
      * - Maximum 15 signers per context rule
      * - Maximum 5 policies per context rule
      *
@@ -245,10 +250,17 @@ class OZContextRuleManager internal constructor(
             throw ValidationException.invalidInput("name", "Context rule name cannot be empty")
         }
 
-        if (signers.isEmpty() || signers.size > OZConstants.MAX_SIGNERS) {
+        if (signers.isEmpty() && policies.isEmpty()) {
             throw ValidationException.invalidInput(
                 "signers",
-                "Context rule must have between 1 and ${OZConstants.MAX_SIGNERS} signers, got: ${signers.size}"
+                "Context rule must have at least one signer or one policy"
+            )
+        }
+
+        if (signers.size > OZConstants.MAX_SIGNERS) {
+            throw ValidationException.invalidInput(
+                "signers",
+                "Context rule cannot have more than ${OZConstants.MAX_SIGNERS} signers, got: ${signers.size}"
             )
         }
 
@@ -262,15 +274,6 @@ class OZContextRuleManager internal constructor(
         // Validate policy addresses
         for ((address, _) in policies) {
             requireContractAddress(address, "contractAddress")
-        }
-
-        // Check MAX_CONTEXT_RULES limit
-        val currentCount = getContextRulesCount()
-        if (currentCount >= OZConstants.MAX_CONTEXT_RULES.toUInt()) {
-            throw ValidationException.invalidInput(
-                "contextRules",
-                "Cannot add context rule: maximum of ${OZConstants.MAX_CONTEXT_RULES} rules already reached"
-            )
         }
 
         // Build function arguments
@@ -379,8 +382,7 @@ class OZContextRuleManager internal constructor(
      * Retrieves the total number of context rules in the smart account.
      *
      * Queries the smart account contract to determine how many context rules are
-     * currently configured. This is useful for checking whether adding a new rule
-     * would exceed the MAX_CONTEXT_RULES limit.
+     * currently configured.
      *
      * This is a query operation (read-only, no authorization required). It uses simulation
      * to extract the return value without submitting a transaction.
@@ -393,10 +395,6 @@ class OZContextRuleManager internal constructor(
      * ```kotlin
      * val count = contextMgr.getContextRulesCount()
      * println("Smart account has $count context rules")
-     *
-     * if (count < OZConstants.MAX_CONTEXT_RULES.toUInt()) {
-     *     // Can add more rules
-     * }
      * ```
      */
     suspend fun getContextRulesCount(): UInt {
@@ -440,11 +438,7 @@ class OZContextRuleManager internal constructor(
      * @return List of raw ScVal objects, one per active context rule.
      */
     suspend fun getAllContextRules(maxScanId: UInt = kit.config.maxContextRuleScanId): List<SCValXdr> {
-        val activeCount = try {
-            getContextRulesCount()
-        } catch (_: Exception) {
-            0u
-        }
+        val activeCount = getContextRulesCount()
 
         if (activeCount == 0u) return emptyList()
 
@@ -455,12 +449,431 @@ class OZContextRuleManager internal constructor(
             try {
                 val ruleScVal = getContextRule(id)
                 result.add(ruleScVal)
-            } catch (_: Exception) {
+            } catch (_: TransactionException.SimulationFailed) {
                 // Gap from removed rule — skip
             }
         }
 
         return result
+    }
+
+    // MARK: - List Context Rules
+
+    /**
+     * Lists all active context rules as parsed objects.
+     *
+     * Fetches all raw ScVal rules via [getAllContextRules] and parses each one.
+     * This is the primary method for rule discovery in v0.7.0.
+     *
+     * @param maxScanId Upper bound on rule IDs to scan
+     * @return List of parsed context rules
+     * @throws ValidationException if a rule ScVal cannot be parsed
+     * @throws TransactionException if simulation fails
+     */
+    suspend fun listContextRules(maxScanId: UInt = kit.config.maxContextRuleScanId): List<ParsedContextRule> {
+        return getAllContextRules(maxScanId).map { scVal -> parseContextRule(scVal) }
+    }
+
+    /**
+     * Parses a context rule from its on-chain ScVal representation.
+     *
+     * The Soroban named struct serializes as ScVal::Map with Symbol-keyed entries
+     * sorted lexicographically. Fields are looked up by key name, not by position.
+     * Expected keys (alphabetical): context_type, id, name, policies, policy_ids,
+     * signer_ids, signers, valid_until.
+     *
+     * @param scVal The raw ScVal containing the context rule data
+     * @return The parsed context rule
+     * @throws ValidationException if the ScVal structure is invalid or required fields are missing
+     */
+    private fun parseContextRule(scVal: SCValXdr): ParsedContextRule {
+        val mapEntries = (scVal as? SCValXdr.Map)?.value?.value
+            ?: throw ValidationException.invalidInput("contextRule", "Expected Map ScVal for context rule")
+
+        // Build a lookup by symbol key
+        val fields = mutableMapOf<String, SCValXdr>()
+        for (entry in mapEntries) {
+            val key = (entry.key as? SCValXdr.Sym)?.value?.value ?: continue
+            fields[key] = entry.`val`
+        }
+
+        // Parse id (U32)
+        val id = fields["id"]?.let {
+            try { Scv.fromUint32(it) } catch (e: Exception) {
+                throw ValidationException.invalidInput("id", "Expected U32 for id: ${e.message}")
+            }
+        } ?: throw ValidationException.invalidInput("contextRule", "Missing required field: id")
+
+        // Parse name (String)
+        val name = fields["name"]?.let {
+            try { Scv.fromString(it) } catch (e: Exception) {
+                throw ValidationException.invalidInput("name", "Expected String for name: ${e.message}")
+            }
+        } ?: throw ValidationException.invalidInput("contextRule", "Missing required field: name")
+
+        // Parse context_type (Vec)
+        val contextType = fields["context_type"]?.let { parseContextRuleType(it) }
+            ?: throw ValidationException.invalidInput("contextRule", "Missing required field: context_type")
+
+        // Parse signers (Vec of signer ScVals)
+        val signers = fields["signers"]?.let { signerVecScVal ->
+            val signerVec = try { Scv.fromVec(signerVecScVal) } catch (e: Exception) {
+                throw ValidationException.invalidInput("signers", "Expected Vec for signers: ${e.message}")
+            }
+            signerVec.map { parseSigner(it) }
+        } ?: emptyList()
+
+        // Parse signer_ids (Vec of U32)
+        val signerIds = fields["signer_ids"]?.let { signerIdsScVal ->
+            val vec = try { Scv.fromVec(signerIdsScVal) } catch (e: Exception) {
+                throw ValidationException.invalidInput("signer_ids", "Expected Vec for signer_ids: ${e.message}")
+            }
+            vec.map { entry ->
+                try { Scv.fromUint32(entry) } catch (e: Exception) {
+                    throw ValidationException.invalidInput("signer_ids", "Expected U32 entries in signer_ids: ${e.message}")
+                }
+            }
+        } ?: emptyList()
+
+        // Parse policies (Vec of Address)
+        val policies = fields["policies"]?.let { policiesScVal ->
+            val vec = try { Scv.fromVec(policiesScVal) } catch (e: Exception) {
+                throw ValidationException.invalidInput("policies", "Expected Vec for policies: ${e.message}")
+            }
+            vec.map { entry ->
+                try { Address.fromSCVal(entry).toString() } catch (e: Exception) {
+                    throw ValidationException.invalidInput("policies", "Expected Address entries in policies: ${e.message}")
+                }
+            }
+        } ?: emptyList()
+
+        // Parse policy_ids (Vec of U32)
+        val policyIds = fields["policy_ids"]?.let { policyIdsScVal ->
+            val vec = try { Scv.fromVec(policyIdsScVal) } catch (e: Exception) {
+                throw ValidationException.invalidInput("policy_ids", "Expected Vec for policy_ids: ${e.message}")
+            }
+            vec.map { entry ->
+                try { Scv.fromUint32(entry) } catch (e: Exception) {
+                    throw ValidationException.invalidInput("policy_ids", "Expected U32 entries in policy_ids: ${e.message}")
+                }
+            }
+        } ?: emptyList()
+
+        // Parse valid_until (Option<U32>: void = null, U32 = value)
+        val validUntil = fields["valid_until"]?.let { validUntilScVal ->
+            when (validUntilScVal) {
+                is SCValXdr.Void -> null
+                else -> try { Scv.fromUint32(validUntilScVal) } catch (e: Exception) {
+                    throw ValidationException.invalidInput("valid_until", "Expected U32 or Void for valid_until: ${e.message}")
+                }
+            }
+        }
+
+        return ParsedContextRule(
+            id = id,
+            contextType = contextType,
+            name = name,
+            signers = signers,
+            signerIds = signerIds,
+            policies = policies,
+            policyIds = policyIds,
+            validUntil = validUntil
+        )
+    }
+
+    /**
+     * Parses the context_type field from its Vec ScVal representation.
+     *
+     * Format:
+     * - Default: Vec([Symbol("Default")])
+     * - CallContract: Vec([Symbol("CallContract"), Address(contractAddress)])
+     * - CreateContract: Vec([Symbol("CreateContract"), Bytes(wasmHash)])
+     */
+    private fun parseContextRuleType(scVal: SCValXdr): ContextRuleType {
+        val vec = try { Scv.fromVec(scVal) } catch (e: Exception) {
+            throw ValidationException.invalidInput("context_type", "Expected Vec for context_type: ${e.message}")
+        }
+        if (vec.isEmpty()) {
+            throw ValidationException.invalidInput("context_type", "context_type Vec is empty")
+        }
+        val discriminant = try { Scv.fromSymbol(vec[0]) } catch (e: Exception) {
+            throw ValidationException.invalidInput("context_type", "Expected Symbol discriminant in context_type Vec: ${e.message}")
+        }
+        return when (discriminant) {
+            "Default" -> ContextRuleType.Default
+            "CallContract" -> {
+                if (vec.size < 2) {
+                    throw ValidationException.invalidInput("context_type", "CallContract context_type missing address element")
+                }
+                val address = try { Address.fromSCVal(vec[1]).toString() } catch (e: Exception) {
+                    throw ValidationException.invalidInput("context_type", "Expected Address for CallContract context_type: ${e.message}")
+                }
+                ContextRuleType.CallContract(address)
+            }
+            "CreateContract" -> {
+                if (vec.size < 2) {
+                    throw ValidationException.invalidInput("context_type", "CreateContract context_type missing wasm hash element")
+                }
+                val wasmHash = try { Scv.fromBytes(vec[1]) } catch (e: Exception) {
+                    throw ValidationException.invalidInput("context_type", "Expected Bytes for CreateContract context_type: ${e.message}")
+                }
+                ContextRuleType.CreateContract(wasmHash)
+            }
+            else -> throw ValidationException.invalidInput("context_type", "Unknown context_type discriminant: $discriminant")
+        }
+    }
+
+    /**
+     * Parses a signer from its Vec ScVal representation.
+     *
+     * Format:
+     * - Delegated: Vec([Symbol("Delegated"), Address])
+     * - External: Vec([Symbol("External"), Address, Bytes])
+     */
+    private fun parseSigner(scVal: SCValXdr): SmartAccountSigner {
+        val vec = try { Scv.fromVec(scVal) } catch (e: Exception) {
+            throw ValidationException.invalidInput("signer", "Expected Vec for signer: ${e.message}")
+        }
+        if (vec.isEmpty()) {
+            throw ValidationException.invalidInput("signer", "Signer Vec is empty")
+        }
+        val discriminant = try { Scv.fromSymbol(vec[0]) } catch (e: Exception) {
+            throw ValidationException.invalidInput("signer", "Expected Symbol discriminant in signer Vec: ${e.message}")
+        }
+        return when (discriminant) {
+            "Delegated" -> {
+                if (vec.size < 2) {
+                    throw ValidationException.invalidInput("signer", "Delegated signer missing address element")
+                }
+                val address = try { Address.fromSCVal(vec[1]).toString() } catch (e: Exception) {
+                    throw ValidationException.invalidInput("signer", "Expected Address for Delegated signer: ${e.message}")
+                }
+                DelegatedSigner(address)
+            }
+            "External" -> {
+                if (vec.size < 3) {
+                    throw ValidationException.invalidInput("signer", "External signer missing address or keyData element")
+                }
+                val verifierAddress = try { Address.fromSCVal(vec[1]).toString() } catch (e: Exception) {
+                    throw ValidationException.invalidInput("signer", "Expected Address for External signer verifier: ${e.message}")
+                }
+                val keyData = try { Scv.fromBytes(vec[2]) } catch (e: Exception) {
+                    throw ValidationException.invalidInput("signer", "Expected Bytes for External signer keyData: ${e.message}")
+                }
+                ExternalSigner(verifierAddress, keyData)
+            }
+            else -> throw ValidationException.invalidInput("signer", "Unknown signer discriminant: $discriminant")
+        }
+    }
+
+    // MARK: - Resolve Context Rule IDs
+
+    /**
+     * Resolves context rule IDs for a given auth entry.
+     *
+     * Analyzes the auth entry's invocations to determine which context types are needed,
+     * then matches those against the account's active rules. The resolution algorithm:
+     * 1. Filter rules by context type match
+     * 2. If 1 candidate: use it
+     * 3. If multiple: filter by exact signer match (same signers, same count)
+     * 4. If 1 match: use it
+     * 5. If multiple: filter by signer subset (rule signers subset of selected, no policies)
+     * 6. If 1 match: use it
+     * 7. Otherwise: throw error
+     *
+     * @param entry The auth entry to resolve rules for
+     * @param selectedSigners The signers that will sign this entry
+     * @return Ordered list of context rule IDs, one per invocation context
+     * @throws ValidationException if no unique context rule can be resolved for any context
+     * @throws TransactionException if simulation fails while fetching rules
+     */
+    suspend fun resolveContextRuleIdsForEntry(
+        entry: SorobanAuthorizationEntryXdr,
+        selectedSigners: List<SmartAccountSigner>
+    ): List<UInt> {
+        val rules = listContextRules()
+        return resolveContextRuleIdsForEntry(entry, selectedSigners, rules)
+    }
+
+    /**
+     * Resolves context rule IDs using a pre-fetched rules list.
+     *
+     * Use this overload to avoid redundant RPC calls when resolving multiple auth entries
+     * in the same transaction. Fetch rules once via [listContextRules] and pass them here.
+     *
+     * @param entry The auth entry to resolve rules for
+     * @param selectedSigners The signers that will sign this entry
+     * @param rules Pre-fetched list of active context rules
+     * @return Ordered list of context rule IDs, one per invocation context
+     * @throws ValidationException if no unique context rule can be resolved for any context
+     */
+    fun resolveContextRuleIdsForEntry(
+        entry: SorobanAuthorizationEntryXdr,
+        selectedSigners: List<SmartAccountSigner>,
+        rules: List<ParsedContextRule>
+    ): List<UInt> {
+        val contexts = buildInvocationContextTypes(entry)
+
+        return contexts.map { contextType ->
+            val candidates = rules.filter { rule ->
+                contextRuleTypeMatches(rule.contextType, contextType)
+            }
+
+            if (candidates.size == 1) {
+                return@map candidates[0].id
+            }
+
+            // Tier 1: Exact signer match — same number of signers and all match bidirectionally
+            val exactSignerMatches = candidates.filter { rule ->
+                if (rule.signers.size != selectedSigners.size) return@filter false
+
+                selectedSigners.all { selected ->
+                    rule.signers.any { ruleSigner ->
+                        SmartAccountBuilders.signersEqual(ruleSigner, selected)
+                    }
+                } && rule.signers.all { ruleSigner ->
+                    selectedSigners.any { selected ->
+                        SmartAccountBuilders.signersEqual(ruleSigner, selected)
+                    }
+                }
+            }
+
+            if (exactSignerMatches.size == 1) {
+                return@map exactSignerMatches[0].id
+            }
+
+            // Tier 2: Rule signers subset of selected (all rule signers in selectedSigners, no policies)
+            val signerSubsetMatches = candidates.filter { rule ->
+                if (rule.policies.isNotEmpty()) return@filter false
+
+                rule.signers.all { ruleSigner ->
+                    selectedSigners.any { selected ->
+                        SmartAccountBuilders.signersEqual(ruleSigner, selected)
+                    }
+                }
+            }
+
+            if (signerSubsetMatches.size == 1) {
+                return@map signerSubsetMatches[0].id
+            }
+
+            // Tier 3: Selected signers subset of rule (all selected signers exist in the rule).
+            // Handles threshold scenarios where the user picks fewer signers than the rule has.
+            val selectedSubsetMatches = candidates.filter { rule ->
+                selectedSigners.all { selected ->
+                    rule.signers.any { ruleSigner ->
+                        SmartAccountBuilders.signersEqual(ruleSigner, selected)
+                    }
+                }
+            }
+
+            if (selectedSubsetMatches.size == 1) {
+                return@map selectedSubsetMatches[0].id
+            }
+
+            if (candidates.isEmpty()) {
+                throw ValidationException.invalidInput(
+                    "contextRuleIds",
+                    "No context rule matches $contextType. Add a rule for this context type or a Default rule."
+                )
+            }
+
+            if (selectedSubsetMatches.size > 1) {
+                val ids = selectedSubsetMatches.joinToString(", ") { it.id.toString() }
+                throw ValidationException.invalidInput(
+                    "contextRuleIds",
+                    "Selected signers match multiple context rules: $ids."
+                )
+            }
+
+            throw ValidationException.invalidInput(
+                "contextRuleIds",
+                "No context rule contains all selected signers."
+            )
+        }
+    }
+
+    // MARK: - Build Invocation Context Types
+
+    /**
+     * Extracts context types from an auth entry's invocation tree.
+     *
+     * Walks the invocation tree recursively and extracts the context type for each invocation:
+     * - ContractFn invocations produce [ContextRuleType.CallContract] with the contract address
+     * - Create contract invocations produce [ContextRuleType.CreateContract] with the WASM hash
+     *
+     * @param entry The auth entry whose invocation tree to traverse
+     * @return Ordered list of context types, one per invocation node (depth-first)
+     */
+    fun buildInvocationContextTypes(entry: SorobanAuthorizationEntryXdr): List<ContextRuleType> {
+        val result = mutableListOf<ContextRuleType>()
+        collectInvocationContextTypes(entry.rootInvocation.function, result)
+        collectSubInvocationContextTypes(entry.rootInvocation.subInvocations, result)
+        return result
+    }
+
+    private fun collectInvocationContextTypes(
+        function: SorobanAuthorizedFunctionXdr,
+        result: MutableList<ContextRuleType>
+    ) {
+        when (function) {
+            is SorobanAuthorizedFunctionXdr.ContractFn -> {
+                val contractAddress = try {
+                    Address.fromSCAddress(function.value.contractAddress).toString()
+                } catch (e: Exception) {
+                    throw ValidationException.invalidInput(
+                        "contractAddress",
+                        "Failed to parse contract address from ContractFn invocation: ${e.message}"
+                    )
+                }
+                result.add(ContextRuleType.CallContract(contractAddress))
+            }
+            is SorobanAuthorizedFunctionXdr.CreateContractHostFn -> {
+                val wasmHash = extractWasmHash(function.value.executable)
+                result.add(ContextRuleType.CreateContract(wasmHash))
+            }
+            is SorobanAuthorizedFunctionXdr.CreateContractV2HostFn -> {
+                val wasmHash = extractWasmHash(function.value.executable)
+                result.add(ContextRuleType.CreateContract(wasmHash))
+            }
+        }
+    }
+
+    private fun collectSubInvocationContextTypes(
+        subInvocations: List<SorobanAuthorizedInvocationXdr>,
+        result: MutableList<ContextRuleType>
+    ) {
+        for (subInvocation in subInvocations) {
+            collectInvocationContextTypes(subInvocation.function, result)
+            collectSubInvocationContextTypes(subInvocation.subInvocations, result)
+        }
+    }
+
+    private fun extractWasmHash(executable: ContractExecutableXdr): ByteArray {
+        return when (executable) {
+            is ContractExecutableXdr.WasmHash -> executable.value.value
+            is ContractExecutableXdr.Void -> throw ValidationException.invalidInput(
+                "executable",
+                "CreateContract invocation references a Stellar Asset Contract, not a WASM contract"
+            )
+        }
+    }
+
+    // MARK: - Context Rule Type Matching
+
+    /**
+     * Checks if a rule's context type matches a required context type.
+     *
+     * [ContextRuleType.Default] matches any required context type, acting as a fallback.
+     * Other types require an exact equality match.
+     *
+     * @param ruleType The context type defined in the rule
+     * @param requiredType The context type required by the invocation
+     * @return true if the rule's context type matches the required type
+     */
+    fun contextRuleTypeMatches(ruleType: ContextRuleType, requiredType: ContextRuleType): Boolean {
+        if (ruleType is ContextRuleType.Default) return true
+        return ruleType == requiredType
     }
 
     // MARK: - Update Context Rule Name

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZContextRuleManager.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZContextRuleManager.kt
@@ -778,8 +778,17 @@ class OZContextRuleManager internal constructor(
                 )
             }
 
-            if (selectedSubsetMatches.size > 1) {
-                val ids = selectedSubsetMatches.joinToString(", ") { it.id.toString() }
+            // Collect all rules that contain ALL selected signers (from tiers 1-3)
+            val allMatchingRules = candidates.filter { rule ->
+                selectedSigners.all { selected ->
+                    rule.signers.any { ruleSigner ->
+                        SmartAccountBuilders.signersEqual(ruleSigner, selected)
+                    }
+                }
+            }
+
+            if (allMatchingRules.size > 1) {
+                val ids = allMatchingRules.joinToString(", ") { it.id.toString() }
                 throw ValidationException.invalidInput(
                     "contextRuleIds",
                     "Selected signers match multiple context rules: $ids."

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZMultiSignerManager.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZMultiSignerManager.kt
@@ -134,6 +134,10 @@ class OZMultiSignerManager internal constructor(
      * @param amount The amount to transfer in XLM units
      * @param selectedSigners All signers that must sign, in collection order.
      *   An empty list means no signatures are collected (only valid for read-only simulation).
+     * @param contextRuleId Explicit context rule ID to use instead of automatic resolution.
+     *   When null (default), the SDK resolves the rule ID automatically from the selected signers.
+     *   Provide an explicit ID when automatic resolution fails due to ambiguity (selected signers
+     *   match multiple rules).
      * @return TransactionResult indicating success or failure
      * @throws SmartAccountException if validation fails, signing fails, or submission fails
      *
@@ -158,7 +162,8 @@ class OZMultiSignerManager internal constructor(
         tokenContract: String,
         recipient: String,
         amount: String,
-        selectedSigners: List<SelectedSigner>
+        selectedSigners: List<SelectedSigner>,
+        contextRuleId: UInt? = null
     ): TransactionResult {
         // STEP 1: Validate inputs (same as single-signer transfer)
         val (_, contractId) = kit.requireConnected()
@@ -260,6 +265,9 @@ class OZMultiSignerManager internal constructor(
         val expirationLedger = latestLedger.sequence.toUInt() +
                 OZConstants.AUTH_ENTRY_EXPIRATION_BUFFER.toUInt()
 
+        // Pre-fetch context rules ONCE for all auth entries (avoids N+1 RPC calls per entry)
+        val contextRules = kit.contextRuleManager.listContextRules()
+
         // STEP 6: Sign auth entries.
         // Uses the same SmartAccountAuth.signAuthEntry() as the single-signer flow.
         // signAuthEntry is called once per passkey and the entry accumulates signatures across calls.
@@ -282,6 +290,46 @@ class OZMultiSignerManager internal constructor(
             // Clone the entry and set the expiration ledger before signing
             var signedEntry = cloneEntryWithExpiration(entry, expirationLedger)
 
+            // Build the list of SmartAccountSigner objects from selectedSigners for rule resolution.
+            val smartAccountSigners = selectedSigners.map { selectedSigner ->
+                when (selectedSigner) {
+                    is SelectedSigner.Passkey -> {
+                        val keyData = selectedSigner.keyData
+                            ?: throw ValidationException.invalidInput(
+                                "selectedSigners",
+                                "keyData is required for passkey signers for rule resolution"
+                            )
+                        ExternalSigner(
+                            verifierAddress = kit.config.webauthnVerifierAddress,
+                            keyData = keyData
+                        ) as SmartAccountSigner
+                    }
+                    is SelectedSigner.Wallet -> {
+                        DelegatedSigner(address = selectedSigner.address) as SmartAccountSigner
+                    }
+                }
+            }
+
+            // Use caller-provided context rule ID or resolve automatically.
+            val resolvedContextRuleIds = if (contextRuleId != null) {
+                listOf(contextRuleId)
+            } else {
+                kit.contextRuleManager.resolveContextRuleIdsForEntry(
+                    signedEntry, smartAccountSigners, contextRules
+                )
+            }
+
+            // Compute the payload hash once for this entry (used by both passkey and delegated paths).
+            val payloadHash = SmartAccountAuth.buildAuthPayloadHash(
+                entry = signedEntry,
+                expirationLedger = expirationLedger,
+                networkPassphrase = kit.config.networkPassphrase
+            )
+
+            // Compute the auth digest binding the rule IDs. This is what all signers actually sign,
+            // preventing rule-selection downgrade attacks.
+            val authDigest = SmartAccountAuth.buildAuthDigest(payloadHash, resolvedContextRuleIds)
+
             // STEP 6a: Sign with each passkey signer using SmartAccountAuth.signAuthEntry().
             // Each call triggers one WebAuthn prompt and appends to the signature map.
             for ((signerIndex, selectedSigner) in selectedSigners.withIndex()) {
@@ -293,20 +341,13 @@ class OZMultiSignerManager internal constructor(
                                 "WebAuthn provider is required for passkey signers but is not configured"
                             )
 
-                        // Compute payload hash from the entry (which now has expiration set)
-                        val payloadHash = SmartAccountAuth.buildAuthPayloadHash(
-                            entry = signedEntry,
-                            expirationLedger = expirationLedger,
-                            networkPassphrase = kit.config.networkPassphrase
-                        )
-
                         // Trigger WebAuthn authentication (one OS prompt per passkey signer).
                         // Pass credentialIdBytes as allowCredentials so the browser uses
                         // the correct passkey when multiple exist for this RP.
                         val allowCredentialIds = selectedSigner.credentialIdBytes?.let { listOf(it) }
 
                         val authResult = try {
-                            webauthnProvider.authenticate(payloadHash, allowCredentialIds)
+                            webauthnProvider.authenticate(authDigest, allowCredentialIds)
                         } catch (e: Exception) {
                             throw WebAuthnException.authenticationFailed(
                                 "WebAuthn authentication failed for passkey signer " +
@@ -345,7 +386,8 @@ class OZMultiSignerManager internal constructor(
                             entry = signedEntry,
                             signer = passkeySigner,
                             signature = webAuthnSig,
-                            expirationLedger = expirationLedger
+                            expirationLedger = expirationLedger,
+                            contextRuleIds = resolvedContextRuleIds
                         )
                     }
 
@@ -369,19 +411,14 @@ class OZMultiSignerManager internal constructor(
                     )
 
                 // Build the invocation targeting the smart account's __check_auth.
-                // The payload hash from the smart account's entry is passed as argument.
-                val payloadHash = SmartAccountAuth.buildAuthPayloadHash(
-                    entry = signedEntry,
-                    expirationLedger = expirationLedger,
-                    networkPassphrase = kit.config.networkPassphrase
-                )
-
+                // The auth digest (payloadHash bound to contextRuleIds) is passed as argument,
+                // matching what the verifier contract expects in v0.7.0+.
                 val checkAuthInvocation = SorobanAuthorizedInvocationXdr(
                     function = SorobanAuthorizedFunctionXdr.ContractFn(
                         InvokeContractArgsXdr(
                             contractAddress = Address(contractId).toSCAddress(),
                             functionName = SCSymbolXdr("__check_auth"),
-                            args = listOf(Scv.toBytes(payloadHash))
+                            args = listOf(Scv.toBytes(authDigest))
                         )
                     ),
                     subInvocations = emptyList()
@@ -434,7 +471,8 @@ class OZMultiSignerManager internal constructor(
                 signedEntry = SmartAccountAuth.addRawSignatureMapEntry(
                     entry = signedEntry,
                     signerKey = delegatedSigner.toScVal(),
-                    signatureValue = Scv.toBytes(byteArrayOf())
+                    signatureValue = Scv.toBytes(byteArrayOf()),
+                    contextRuleIds = resolvedContextRuleIds
                 )
             }
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZMultiSignerManager.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZMultiSignerManager.kt
@@ -134,10 +134,10 @@ class OZMultiSignerManager internal constructor(
      * @param amount The amount to transfer in XLM units
      * @param selectedSigners All signers that must sign, in collection order.
      *   An empty list means no signatures are collected (only valid for read-only simulation).
-     * @param contextRuleId Explicit context rule ID to use instead of automatic resolution.
-     *   When null (default), the SDK resolves the rule ID automatically from the selected signers.
-     *   Provide an explicit ID when automatic resolution fails due to ambiguity (selected signers
-     *   match multiple rules).
+     * @param resolveContextRuleIds Optional callback to resolve context rule IDs per auth entry.
+     *   When null (default), the SDK resolves the rule IDs automatically from the selected signers
+     *   and available context rules. Provide a callback when automatic resolution fails due to
+     *   ambiguity (selected signers match multiple rules) or to bypass auto-resolution.
      * @return TransactionResult indicating success or failure
      * @throws SmartAccountException if validation fails, signing fails, or submission fails
      *
@@ -163,7 +163,7 @@ class OZMultiSignerManager internal constructor(
         recipient: String,
         amount: String,
         selectedSigners: List<SelectedSigner>,
-        contextRuleId: UInt? = null
+        resolveContextRuleIds: ResolveContextRuleIds? = null
     ): TransactionResult {
         // STEP 1: Validate inputs (same as single-signer transfer)
         val (_, contractId) = kit.requireConnected()
@@ -273,7 +273,7 @@ class OZMultiSignerManager internal constructor(
         // signAuthEntry is called once per passkey and the entry accumulates signatures across calls.
         val signedAuthEntries = mutableListOf<SorobanAuthorizationEntryXdr>()
 
-        for (entry in authEntries) {
+        for ((entryIndex, entry) in authEntries.withIndex()) {
             // Check if this entry's credentials match our contract
             val credentials = (entry.credentials as? SorobanCredentialsXdr.Address)?.value
             if (credentials == null) {
@@ -310,9 +310,9 @@ class OZMultiSignerManager internal constructor(
                 }
             }
 
-            // Use caller-provided context rule ID or resolve automatically.
-            val resolvedContextRuleIds = if (contextRuleId != null) {
-                listOf(contextRuleId)
+            // Use caller-provided callback or resolve automatically.
+            val resolvedContextRuleIds = if (resolveContextRuleIds != null) {
+                resolveContextRuleIds(signedEntry, entryIndex)
             } else {
                 kit.contextRuleManager.resolveContextRuleIdsForEntry(
                     signedEntry, smartAccountSigners, contextRules

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZMultiSignerManager.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZMultiSignerManager.kt
@@ -500,25 +500,15 @@ class OZMultiSignerManager internal constructor(
             throw TransactionException.simulationFailed("Re-simulation error: ${resignedSimulation.error}")
         }
 
-        val transactionData = resignedSimulation.parseTransactionData()
-            ?: throw TransactionException.submissionFailed(
-                "Failed to get transaction data from re-simulation"
-            )
-
-        val minResourceFee = resignedSimulation.minResourceFee
-            ?: throw TransactionException.submissionFailed(
-                "Failed to get min resource fee from re-simulation"
-            )
-
-        // STEP 8: Submit via the same Mode 1 / Mode 2 routing as single-signer transfer.
+        // STEP 8: Assemble and submit via the same Mode 1 / Mode 2 routing as single-signer.
         // Mode 1 (default): relayer receives hostFunction + authEntries and builds the envelope.
         // Mode 2 (fallback): used only when source_account auth entries are present.
+        // prepareTransaction applies resource fees, footprint, and soroban data from simulation.
         return kit.transactionOperations.submitMultiSignerTransaction(
             hostFunction = hostFunction,
             signedAuthEntries = signedAuthEntries,
-            transactionData = transactionData,
-            minResourceFee = minResourceFee,
-            deployerAccount = refetchedDeployerAccount
+            signedTransaction = signedTransaction,
+            simulation = resignedSimulation
         )
     }
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZPolicyManager.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZPolicyManager.kt
@@ -240,10 +240,10 @@ sealed class PolicyInstallParams {
  *     println("Policy added successfully")
  * }
  *
- * // Remove a policy
+ * // Remove a policy by its ID (ID available from ParsedContextRule.policyIds)
  * val removeResult = policyManager.removePolicy(
  *     contextRuleId = 0u,
- *     policyAddress = "CBCD1234..."
+ *     policyId = 1u
  * )
  * ```
  *
@@ -439,14 +439,15 @@ class OZPolicyManager internal constructor(
     // MARK: - Remove Policy
 
     /**
-     * Removes a policy from a context rule.
+     * Removes a policy from a context rule by its ID.
      *
-     * Uninstalls an existing policy from the specified context rule. The policy
-     * contract remains deployed on the network but is no longer evaluated for
-     * this context rule.
+     * Uninstalls the policy with the given ID from the specified context rule. The policy
+     * contract remains deployed on the network but is no longer evaluated for this context rule.
+     * The policy ID is assigned by the contract when the policy is added and is available via
+     * [ParsedContextRule.policyIds] after fetching the context rule.
      *
      * Flow:
-     * 1. Validates inputs (connected wallet, policy address format)
+     * 1. Validates that a wallet is connected
      * 2. Builds contract invocation for remove_policy
      * 3. Submits transaction via transactionOps (handles simulation, signing, polling)
      *
@@ -455,17 +456,20 @@ class OZPolicyManager internal constructor(
      * to sign the transaction.
      *
      * @param contextRuleId The context rule ID to remove the policy from (0 for Default rule)
-     * @param policyAddress The policy contract address to remove (C-address)
+     * @param policyId The on-chain policy ID assigned by the contract (available from [ParsedContextRule.policyIds])
      * @return [TransactionResult] indicating success or failure
      * @throws ValidationException if validation fails
      * @throws TransactionException if transaction submission fails
      *
      * Example:
      * ```kotlin
-     * // Remove a policy from the default context rule
+     * // Fetch the context rule to get policy IDs
+     * val contextRule = kit.contextRuleManager.getContextRule(contextRuleId = 0u)
+     * val policyIdToRemove = contextRule.policyIds.first()
+     *
      * val result = policyManager.removePolicy(
      *     contextRuleId = 0u,
-     *     policyAddress = "CBCD1234..."
+     *     policyId = policyIdToRemove
      * )
      *
      * if (result.success) {
@@ -477,19 +481,16 @@ class OZPolicyManager internal constructor(
      */
     suspend fun removePolicy(
         contextRuleId: UInt,
-        policyAddress: String
+        policyId: UInt
     ): TransactionResult {
         // Validate wallet is connected
         val (_, contractId) = kit.requireConnected()
-
-        // Validate policy address (must be C-address)
-        requireContractAddress(policyAddress, "policyAddress")
 
         // Build host function
         val hostFunction = buildRemovePolicyFunction(
             contractId = contractId,
             contextRuleId = contextRuleId,
-            policyAddress = policyAddress
+            policyId = policyId
         )
 
         // Submit transaction
@@ -517,6 +518,10 @@ class OZPolicyManager internal constructor(
      * Contract limits:
      * - Maximum [OZConstants.MAX_POLICIES] policies per context rule
      * - Policy address must be a valid C-address
+     *
+     * Note: The contract returns a u32 policy ID for the newly added policy. The ID is available
+     * via [ParsedContextRule.policyIds] after fetching the context rule and can be used with
+     * [OZPolicyManager.removePolicy] to remove the policy.
      *
      * @param contextRuleId The context rule ID to add the policy to (0 for Default rule)
      * @param policyAddress The policy contract address (C-address)
@@ -609,24 +614,24 @@ class OZPolicyManager internal constructor(
     /**
      * Builds the host function for removing a policy.
      *
-     * Contract method: remove_policy(context_rule_id: u32, policy: Address)
+     * Contract method: remove_policy(context_rule_id: u32, policy_id: u32)
      *
      * @param contractId The smart account contract ID
      * @param contextRuleId The context rule ID
-     * @param policyAddress The policy contract address
+     * @param policyId The on-chain policy ID to remove
      * @return HostFunctionXDR for the remove_policy invocation
      */
     private fun buildRemovePolicyFunction(
         contractId: String,
         contextRuleId: UInt,
-        policyAddress: String
+        policyId: UInt
     ): HostFunctionXdr {
         val invokeArgs = InvokeContractArgsXdr(
             contractAddress = Address(contractId).toSCAddress(),
             functionName = SCSymbolXdr("remove_policy"),
             args = listOf(
                 Scv.toUint32(contextRuleId),
-                Scv.toAddress(Address(policyAddress).toSCAddress())
+                Scv.toUint32(policyId)
             )
         )
         return HostFunctionXdr.InvokeContract(invokeArgs)

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZSignerManager.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZSignerManager.kt
@@ -219,7 +219,8 @@ class OZSignerManager internal constructor(
      * context rule. The user will be prompted for biometric authentication if the current
      * passkey is the authorizing signer.
      *
-     * Contract call: `smart_account.add_signer(context_rule_id, signer)`
+     * Contract call: `smart_account.add_signer(context_rule_id, signer)` — returns a u32 signer ID.
+     * The assigned ID is available via [ParsedContextRule.signerIds] after fetching the context rule.
      *
      * @param contextRuleId The context rule ID to add the signer to (e.g., 0 for Default)
      * @param publicKey The uncompressed secp256r1 public key (65 bytes, starting with 0x04)
@@ -293,7 +294,8 @@ class OZSignerManager internal constructor(
      * The transaction requires authorization from an existing signer on the specified
      * context rule.
      *
-     * Contract call: `smart_account.add_signer(context_rule_id, signer)`
+     * Contract call: `smart_account.add_signer(context_rule_id, signer)` — returns a u32 signer ID.
+     * The assigned ID is available via [ParsedContextRule.signerIds] after fetching the context rule.
      *
      * @param contextRuleId The context rule ID to add the signer to (e.g., 0 for Default)
      * @param address The Stellar address (G-address for accounts, C-address for contracts)
@@ -342,7 +344,8 @@ class OZSignerManager internal constructor(
      * The transaction requires authorization from an existing signer on the specified
      * context rule.
      *
-     * Contract call: `smart_account.add_signer(context_rule_id, signer)`
+     * Contract call: `smart_account.add_signer(context_rule_id, signer)` — returns a u32 signer ID.
+     * The assigned ID is available via [ParsedContextRule.signerIds] after fetching the context rule.
      *
      * @param contextRuleId The context rule ID to add the signer to (e.g., 0 for Default)
      * @param verifierAddress The Ed25519 verifier contract address (C-address)
@@ -384,11 +387,11 @@ class OZSignerManager internal constructor(
     // MARK: - Remove Signer
 
     /**
-     * Removes a signer from a context rule.
+     * Removes a signer from a context rule by its ID.
      *
-     * Removes the specified signer from the given context rule on the smart account contract.
-     * The signer is identified by its on-chain representation (address for delegated signers,
-     * verifier+key for external signers).
+     * Removes the signer with the given ID from the specified context rule on the smart
+     * account contract. The signer ID is assigned by the contract when the signer is added
+     * and is available via [ParsedContextRule.signerIds] after fetching the context rule.
      *
      * The transaction requires authorization from an existing signer on the specified
      * context rule.
@@ -397,31 +400,22 @@ class OZSignerManager internal constructor(
      * has policies that provide authorization. The contract will throw error 3004
      * if you attempt to remove the last signer with no policies configured.
      *
-     * Contract call: `smart_account.remove_signer(context_rule_id, signer)`
+     * Contract call: `smart_account.remove_signer(context_rule_id, signer_id)`
      *
      * @param contextRuleId The context rule ID to remove the signer from
-     * @param signer The signer to remove (must match an existing signer exactly)
+     * @param signerId The on-chain signer ID assigned by the contract (available from [ParsedContextRule.signerIds])
      * @return TransactionResult indicating success or failure
      * @throws SmartAccountException if validation fails or transaction fails
      *
      * Example:
      * ```kotlin
-     * // Remove a delegated signer
-     * val delegatedSigner = DelegatedSigner(address = "GA7QYNF7...")
+     * // Fetch the context rule to get signer IDs
+     * val contextRule = kit.contextRuleManager.getContextRule(contextRuleId = 0u)
+     * val signerIdToRemove = contextRule.signerIds.first()
+     *
      * val result = signerManager.removeSigner(
      *     contextRuleId = 0u,
-     *     signer = delegatedSigner
-     * )
-     *
-     * // Remove a passkey signer
-     * val passkeySignerToRemove = ExternalSigner.webAuthn(
-     *     verifierAddress = "CBCD1234...",
-     *     publicKey = publicKey,
-     *     credentialId = credentialId
-     * )
-     * val removeResult = signerManager.removeSigner(
-     *     contextRuleId = 0u,
-     *     signer = passkeySignerToRemove
+     *     signerId = signerIdToRemove
      * )
      *
      * if (!result.success) {
@@ -431,17 +425,15 @@ class OZSignerManager internal constructor(
      */
     suspend fun removeSigner(
         contextRuleId: UInt,
-        signer: SmartAccountSigner
+        signerId: UInt
     ): TransactionResult {
         // Validate inputs
         val (_, contractId) = kit.requireConnected()
 
         // Build contract invocation for remove_signer
-        val signerScVal = signer.toScVal()
-
         val functionArgs = listOf(
             Scv.toUint32(contextRuleId),
-            signerScVal
+            Scv.toUint32(signerId)
         )
 
         val invokeArgs = InvokeContractArgsXdr(
@@ -463,6 +455,10 @@ class OZSignerManager internal constructor(
      *
      * Builds the contract invocation for add_signer and submits it via transaction operations.
      * The submit method handles simulation, authorization entry signing, and transaction submission.
+     *
+     * Note: The contract returns a u32 signer ID for the newly added signer. The ID is emitted
+     * in a contract event and is accessible via [ParsedContextRule.signerIds] after fetching
+     * the context rule. It can be used with [OZSignerManager.removeSigner] to remove the signer.
      *
      * @param contextRuleId The context rule ID
      * @param signer The signer to add

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZTransactionOperations.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZTransactionOperations.kt
@@ -74,6 +74,33 @@ data class TransactionResult(
 )
 
 /**
+ * Callback for resolving context rule IDs per auth entry.
+ *
+ * Called during the signing flow for each authorization entry that matches the connected
+ * smart account. The callback receives the entry and its index in the auth entries list,
+ * and returns the context rule IDs to use for that entry's invocation tree.
+ *
+ * When not provided, the SDK resolves rule IDs automatically from the connected signer
+ * and available context rules. Provide a callback when automatic resolution fails due
+ * to ambiguity (selected signers match multiple rules) or to bypass auto-resolution.
+ *
+ * Example:
+ * ```kotlin
+ * // Simple case: same rule for all entries
+ * val resolver: ResolveContextRuleIds = { _, _ -> listOf(ruleId) }
+ *
+ * // Advanced: inspect entry to decide
+ * val resolver: ResolveContextRuleIds = { entry, index ->
+ *     if (index == 0) listOf(rule1Id) else listOf(rule2Id)
+ * }
+ * ```
+ */
+typealias ResolveContextRuleIds = suspend (
+    entry: SorobanAuthorizationEntryXdr,
+    index: Int
+) -> List<UInt>
+
+/**
  * Transaction operations for OpenZeppelin Smart Accounts.
  *
  * Provides high-level transaction building, signing, and submission capabilities
@@ -221,6 +248,64 @@ class OZTransactionOperations internal constructor(
         return submit(hostFunction = hostFunction, auth = emptyList(), forceMethod = forceMethod)
     }
 
+    // MARK: - Execute Arbitrary Contract Function
+
+    /**
+     * Executes an arbitrary contract function call through the smart account's execute entry point.
+     *
+     * Builds an invocation of the smart account contract's `execute(target, target_fn, target_args)`
+     * function, which calls the target contract on behalf of the smart account. The smart account's
+     * authorization rules (context rules, signers, policies) apply to this call.
+     *
+     * This is the single-signer equivalent of arbitrary contract execution. For multi-signer
+     * operations, use [OZMultiSignerManager].
+     *
+     * @param target The target contract address (C-address) to call
+     * @param targetFn The function name to invoke on the target contract
+     * @param targetArgs The arguments to pass to the target function as SCVal list
+     * @param forceMethod Optional override to force relayer or RPC submission
+     * @param resolveContextRuleIds Optional callback to resolve context rule IDs per auth entry.
+     *   When null, rule IDs are resolved automatically from the connected signer and available
+     *   context rules. Provide a callback when automatic resolution fails due to ambiguity or to
+     *   bypass auto-resolution.
+     * @return TransactionResult indicating success or failure
+     * @throws SmartAccountException if submission fails
+     */
+    suspend fun executeAndSubmit(
+        target: String,
+        targetFn: String,
+        targetArgs: List<SCValXdr> = emptyList(),
+        forceMethod: SubmissionMethod? = null,
+        resolveContextRuleIds: ResolveContextRuleIds? = null
+    ): TransactionResult {
+        val (_, contractId) = kit.requireConnected()
+
+        // Validate target address (must be C-address)
+        requireContractAddress(target, "target")
+
+        // Build the execute invocation on the smart account contract
+        val functionArgs = listOf(
+            Scv.toAddress(Address(target).toSCAddress()),
+            Scv.toSymbol(targetFn),
+            Scv.toVec(targetArgs)
+        )
+
+        val invokeArgs = InvokeContractArgsXdr(
+            contractAddress = Address(contractId).toSCAddress(),
+            functionName = SCSymbolXdr("execute"),
+            args = functionArgs
+        )
+
+        val hostFunction = HostFunctionXdr.InvokeContract(invokeArgs)
+
+        return submit(
+            hostFunction = hostFunction,
+            auth = emptyList(),
+            forceMethod = forceMethod,
+            resolveContextRuleIds = resolveContextRuleIds
+        )
+    }
+
     // MARK: - Transaction Submission
 
     /**
@@ -281,6 +366,10 @@ class OZTransactionOperations internal constructor(
      * @param hostFunction The host function to execute
      * @param auth Authorization entries for the transaction (typically empty; simulation provides them)
      * @param forceMethod Optional override to force relayer or RPC submission (default: auto-detect)
+     * @param resolveContextRuleIds Optional callback to resolve context rule IDs per auth entry.
+     *   When null (default), rule IDs are resolved automatically from the connected signer and
+     *   available context rules. Provide a callback when automatic resolution is ambiguous or to
+     *   bypass auto-resolution entirely.
      * @return TransactionResult indicating success or failure
      * @throws SmartAccountException if submission, simulation, signing, or polling fails
      *
@@ -289,7 +378,8 @@ class OZTransactionOperations internal constructor(
     suspend fun submit(
         hostFunction: HostFunctionXdr,
         auth: List<SorobanAuthorizationEntryXdr>,
-        forceMethod: SubmissionMethod? = null
+        forceMethod: SubmissionMethod? = null,
+        resolveContextRuleIds: ResolveContextRuleIds? = null
     ): TransactionResult {
         // STEP 1: Require connected wallet
         val (credentialId, contractId) = kit.requireConnected()
@@ -331,7 +421,7 @@ class OZTransactionOperations internal constructor(
 
             val signed = mutableListOf<SorobanAuthorizationEntryXdr>()
 
-            for (entry in simulatedAuthEntries) {
+            for ((entryIndex, entry) in simulatedAuthEntries.withIndex()) {
                 // Check if this entry has address credentials
                 val addressCreds = (entry.credentials as? SorobanCredentialsXdr.Address)?.value
                 if (addressCreds == null) {
@@ -390,12 +480,16 @@ class OZTransactionOperations internal constructor(
                 )
 
                 // (f) Resolve context rule IDs for this auth entry (using pre-fetched rules)
-                val contextRuleIds = kit.contextRuleManager.resolveContextRuleIdsForEntry(
-                    entry, listOf(signer), contextRules
-                )
+                val resolvedContextRuleIds = if (resolveContextRuleIds != null) {
+                    resolveContextRuleIds(entry, entryIndex)
+                } else {
+                    kit.contextRuleManager.resolveContextRuleIdsForEntry(
+                        entry, listOf(signer), contextRules
+                    )
+                }
 
                 // (g) Compute auth digest binding rule IDs to the payload hash
-                val authDigest = SmartAccountAuth.buildAuthDigest(payloadHash, contextRuleIds)
+                val authDigest = SmartAccountAuth.buildAuthDigest(payloadHash, resolvedContextRuleIds)
 
                 // (h) Authenticate with passkey using auth digest as challenge (triggers biometric prompt)
                 val authResult = webauthnProvider.authenticate(
@@ -419,7 +513,7 @@ class OZTransactionOperations internal constructor(
                     signer = signer,
                     signature = webAuthnSig,
                     expirationLedger = expiration,
-                    contextRuleIds = contextRuleIds
+                    contextRuleIds = resolvedContextRuleIds
                 )
 
                 signed.add(signedEntry)

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZTransactionOperations.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZTransactionOperations.kt
@@ -221,76 +221,6 @@ class OZTransactionOperations internal constructor(
         return submit(hostFunction = hostFunction, auth = emptyList(), forceMethod = forceMethod)
     }
 
-    // MARK: - Auth Entry Signing
-
-    /**
-     * Signs authorization entries matching the connected contract.
-     *
-     * Iterates through all auth entries and signs those with address credentials
-     * matching the connected smart account contract. The signature is added to the
-     * entry's signature map using the specified signer.
-     *
-     * @param authEntries The authorization entries to sign
-     * @param signer The smart account signer to use for signing
-     * @param signature The signature object (WebAuthn, Ed25519, or Policy)
-     * @param expirationLedger Optional ledger number at which signatures expire (defaults to current + buffer)
-     * @return Array of signed authorization entries
-     * @throws SmartAccountException if signing fails
-     *
-     * Example:
-     * ```kotlin
-     * val webAuthnSig = WebAuthnSignature(
-     *     authenticatorData = authData,
-     *     clientData = clientData,
-     *     signature = signature
-     * )
-     *
-     * val signedEntries = txOps.signAuthEntries(
-     *     authEntries = unsignedEntries,
-     *     signer = externalSigner,
-     *     signature = webAuthnSig,
-     *     expirationLedger = currentLedger + 100u
-     * )
-     * ```
-     */
-    suspend fun signAuthEntries(
-        authEntries: List<SorobanAuthorizationEntryXdr>,
-        signer: SmartAccountSigner,
-        signature: SmartAccountSignature,
-        expirationLedger: UInt? = null
-    ): List<SorobanAuthorizationEntryXdr> {
-        val (_, contractId) = kit.requireConnected()
-
-        // Determine expiration ledger
-        val expiration = expirationLedger ?: run {
-            // Fetch latest ledger and add buffer
-            val latestLedger = kit.sorobanServer.getLatestLedger()
-            latestLedger.sequence.toUInt() + OZConstants.AUTH_ENTRY_EXPIRATION_BUFFER.toUInt()
-        }
-
-        // Sign all matching auth entries
-        return authEntries.map { entry ->
-            // Check if this entry's credentials match our contract
-            val credentials = (entry.credentials as? SorobanCredentialsXdr.Address)?.value
-                ?: return@map entry // Not an address credential, skip
-
-            // Check if the address matches our contract
-            val entryAddress = try { Address.fromSCAddress(credentials.address).toString() } catch (_: Exception) { null }
-            if (entryAddress == contractId) {
-                // This entry is for our smart account - sign it
-                SmartAccountAuth.signAuthEntry(
-                    entry = entry,
-                    signer = signer,
-                    signature = signature,
-                    expirationLedger = expiration
-                )
-            } else {
-                // Not our entry, pass through unchanged
-                entry
-            }
-        }
-    }
-
     // MARK: - Transaction Submission
 
     /**
@@ -308,14 +238,17 @@ class OZTransactionOperations internal constructor(
      * 4. Simulate transaction to discover required auth entries
      * 5. Extract auth entries from simulation result
      * 6. For each auth entry matching our contract:
-     *    a. Set signature expiration ledger
-     *    b. Build auth payload hash
-     *    c. Sign with WebAuthn passkey (triggers biometric prompt)
-     *    d. Normalize signature to low-S compact format
-     *    e. Build WebAuthn signature ScVal
-     *    f. Construct signer key from stored credential
-     *    g. Build signature map entry with double XDR-encoded signature
-     *    h. Set credential signature on entry
+     *    a. Build auth payload hash
+     *    b. Require WebAuthn provider
+     *    c. Decode credential ID bytes
+     *    d. Resolve key data from storage or on-chain context rules
+     *    e. Build ExternalSigner for context rule resolution
+     *    f. Resolve context rule IDs via contextRuleManager
+     *    g. Compute auth digest: SHA-256(payloadHash || contextRuleIds.toXDR())
+     *    h. Authenticate with WebAuthn using auth digest as challenge
+     *    i. Normalize signature to low-S compact format
+     *    j. Build WebAuthn signature ScVal
+     *    k. Attach signature and context rule IDs to the auth entry
      * 7. Update transaction with signed auth entries
      * 8. Re-simulate to get correct resource fees
      * 9. Assemble transaction from re-simulation
@@ -393,6 +326,9 @@ class OZTransactionOperations internal constructor(
             val latestLedger = kit.sorobanServer.getLatestLedger()
             val expiration = latestLedger.sequence.toUInt() + OZConstants.AUTH_ENTRY_EXPIRATION_BUFFER.toUInt()
 
+            // Pre-fetch context rules ONCE for all auth entries (avoids N+1 RPC calls per entry)
+            val contextRules = kit.contextRuleManager.listContextRules()
+
             val signed = mutableListOf<SorobanAuthorizationEntryXdr>()
 
             for (entry in simulatedAuthEntries) {
@@ -437,22 +373,7 @@ class OZTransactionOperations internal constructor(
                     )
                 }
 
-                // (d) Authenticate with passkey (triggers biometric prompt)
-                val authResult = webauthnProvider.authenticate(
-                    payloadHash,
-                    allowCredentialIds = listOf(credIdBytes)
-                )
-
-                // (e) Normalize DER signature to compact format with low-S
-                val compactSig = SmartAccountUtils.normalizeSignature(authResult.signature)
-
-                // (f) Build WebAuthn signature
-                val webAuthnSig = WebAuthnSignature(
-                    authenticatorData = authResult.authenticatorData,
-                    clientData = authResult.clientDataJSON,
-                    signature = compactSig
-                )
-
+                // (d) Resolve key data from storage or on-chain context rules
                 val keyData: ByteArray
                 val storage = kit.getStorage()
                 val stored = storage.get(credentialId)
@@ -462,17 +383,43 @@ class OZTransactionOperations internal constructor(
                     keyData = findKeyDataFromContextRules(credIdBytes)
                 }
 
+                // (e) Build the connected signer — required for context rule resolution
                 val signer = ExternalSigner(
                     verifierAddress = kit.config.webauthnVerifierAddress,
                     keyData = keyData
                 )
 
-                // (h) Attach the signature to the auth entry
+                // (f) Resolve context rule IDs for this auth entry (using pre-fetched rules)
+                val contextRuleIds = kit.contextRuleManager.resolveContextRuleIdsForEntry(
+                    entry, listOf(signer), contextRules
+                )
+
+                // (g) Compute auth digest binding rule IDs to the payload hash
+                val authDigest = SmartAccountAuth.buildAuthDigest(payloadHash, contextRuleIds)
+
+                // (h) Authenticate with passkey using auth digest as challenge (triggers biometric prompt)
+                val authResult = webauthnProvider.authenticate(
+                    authDigest,
+                    allowCredentialIds = listOf(credIdBytes)
+                )
+
+                // (i) Normalize DER signature to compact format with low-S
+                val compactSig = SmartAccountUtils.normalizeSignature(authResult.signature)
+
+                // (j) Build WebAuthn signature
+                val webAuthnSig = WebAuthnSignature(
+                    authenticatorData = authResult.authenticatorData,
+                    clientData = authResult.clientDataJSON,
+                    signature = compactSig
+                )
+
+                // (k) Attach the signature and context rule IDs to the auth entry
                 val signedEntry = SmartAccountAuth.signAuthEntry(
                     entry = entry,
                     signer = signer,
                     signature = webAuthnSig,
-                    expirationLedger = expiration
+                    expirationLedger = expiration,
+                    contextRuleIds = contextRuleIds
                 )
 
                 signed.add(signedEntry)

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZTransactionOperations.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZTransactionOperations.kt
@@ -18,8 +18,9 @@ import com.soneso.stellar.sdk.FriendBot
 import com.soneso.stellar.sdk.Network
 import com.soneso.stellar.sdk.Transaction
 import com.soneso.stellar.sdk.TransactionBuilder
-import com.soneso.stellar.sdk.TransactionBuilderAccount
 import com.soneso.stellar.sdk.rpc.responses.GetTransactionStatus
+import com.soneso.stellar.sdk.rpc.responses.SendTransactionStatus
+import com.soneso.stellar.sdk.rpc.responses.SimulateTransactionResponse
 import com.soneso.stellar.sdk.xdr.HostFunctionXdr
 import com.soneso.stellar.sdk.xdr.Int64Xdr
 import com.soneso.stellar.sdk.xdr.InvokeContractArgsXdr
@@ -28,7 +29,6 @@ import com.soneso.stellar.sdk.xdr.SCValXdr
 import com.soneso.stellar.sdk.xdr.SorobanAddressCredentialsXdr
 import com.soneso.stellar.sdk.xdr.SorobanAuthorizationEntryXdr
 import com.soneso.stellar.sdk.xdr.SorobanCredentialsXdr
-import com.soneso.stellar.sdk.xdr.SorobanTransactionDataXdr
 import com.soneso.stellar.sdk.xdr.Uint32Xdr
 import com.soneso.stellar.sdk.xdr.XdrReader
 import com.soneso.stellar.sdk.xdr.XdrWriter
@@ -463,10 +463,14 @@ class OZTransactionOperations internal constructor(
                     )
                 }
 
-                // (d) Resolve key data from storage or on-chain context rules
+                // (d) Resolve key data from storage or on-chain context rules.
+                // Storage lookup is an optimization; fall through to on-chain lookup on any failure.
                 val keyData: ByteArray
-                val storage = kit.getStorage()
-                val stored = storage.get(credentialId)
+                val stored = try {
+                    kit.getStorage().get(credentialId)
+                } catch (_: Exception) {
+                    null
+                }
                 if (stored != null) {
                     keyData = stored.publicKey + credIdBytes
                 } else {
@@ -532,9 +536,12 @@ class OZTransactionOperations internal constructor(
             )
         )
 
-        // STEP 9: Rebuild transaction with signed auth entries
+        // STEP 9: Rebuild transaction with signed auth entries.
+        // Re-fetch deployer account to get the correct on-chain sequence number.
+        // The initial fetch (step 2) was consumed by TransactionBuilder.build() in step 3.
+        val refreshedDeployerAccount = kit.sorobanServer.getAccount(deployer.getAccountId())
         val signedOperation = InvokeHostFunctionOperation(hostFunction, signedAuthEntries)
-        val signedTransaction = TransactionBuilder(deployerAccount, Network(kit.config.networkPassphrase))
+        val signedTransaction = TransactionBuilder(refreshedDeployerAccount, Network(kit.config.networkPassphrase))
             .setBaseFee(100)
             .addOperation(signedOperation)
             .addMemo(MemoNone)
@@ -548,25 +555,9 @@ class OZTransactionOperations internal constructor(
             throw TransactionException.simulationFailed("Re-simulation error: ${reSimulation.error}")
         }
 
-        // STEP 11: Assemble transaction from re-simulation
-        val transactionData = reSimulation.parseTransactionData()
-            ?: throw TransactionException.submissionFailed(
-                "Failed to get transaction data from re-simulation"
-            )
-
-        val minResourceFee = reSimulation.minResourceFee
-            ?: throw TransactionException.submissionFailed(
-                "Failed to get min resource fee from re-simulation"
-            )
-
-        // Rebuild transaction with Soroban data and resource fee
-        val finalTransaction = TransactionBuilder(deployerAccount, Network(kit.config.networkPassphrase))
-            .setBaseFee(100 + minResourceFee)
-            .addOperation(signedOperation)
-            .addMemo(MemoNone)
-            .setTimeout(300)
-            .setSorobanData(transactionData)
-            .build()
+        // STEP 11: Assemble transaction from re-simulation.
+        // prepareTransaction applies resource fees, footprint, and soroban data from simulation.
+        val finalTransaction = kit.sorobanServer.prepareTransaction(signedTransaction, reSimulation)
 
         // STEP 12: Determine submission method and submit
         val submissionMethod = getSubmissionMethod(forceMethod)
@@ -596,33 +587,22 @@ class OZTransactionOperations internal constructor(
      *
      * @param hostFunction The host function for the token transfer
      * @param signedAuthEntries Auth entries with all collected signatures
-     * @param transactionData Soroban transaction data from re-simulation
-     * @param minResourceFee Minimum resource fee from re-simulation
-     * @param deployerAccount The deployer account (already fetched by the caller to avoid
-     *   a redundant network round-trip and potential sequence number drift)
+     * @param signedTransaction The transaction with signed auth entries (pre-assembly)
+     * @param simulation The re-simulation response for transaction assembly
      * @return TransactionResult with submission outcome
      * @throws SmartAccountException if submission fails
      */
     internal suspend fun submitMultiSignerTransaction(
         hostFunction: HostFunctionXdr,
         signedAuthEntries: List<SorobanAuthorizationEntryXdr>,
-        transactionData: SorobanTransactionDataXdr,
-        minResourceFee: Long,
-        deployerAccount: TransactionBuilderAccount
+        signedTransaction: Transaction,
+        simulation: SimulateTransactionResponse
     ): TransactionResult {
         val deployer = kit.getDeployer()
 
-        val signedOperation = InvokeHostFunctionOperation(hostFunction, signedAuthEntries)
-        val finalTransaction = TransactionBuilder(
-            deployerAccount,
-            Network(kit.config.networkPassphrase)
-        )
-            .setBaseFee(100 + minResourceFee)
-            .addOperation(signedOperation)
-            .addMemo(MemoNone)
-            .setTimeout(300)
-            .setSorobanData(transactionData)
-            .build()
+        // Assemble the transaction using the SDK's prepareTransaction.
+        // This correctly applies resource fees, footprint, and soroban data from simulation.
+        val finalTransaction = kit.sorobanServer.prepareTransaction(signedTransaction, simulation)
 
         // submitMultiSignerTransaction intentionally uses relayerClient presence directly
         // rather than getSubmissionMethod(), because multi-signer transfers do not support
@@ -798,8 +778,8 @@ class OZTransactionOperations internal constructor(
         // Extract auth entries from simulation
         val simulatedAuthEntries = simulation.results?.firstOrNull()?.parseAuth() ?: emptyList()
 
-        // STEP 8: Convert source_account auth entries to Address credentials
-        // This allows the Relayer to use its own channel accounts for fee sponsoring
+        // STEP 8: Convert source_account auth entries to Address credentials.
+        // This allows the Relayer to use its own channel accounts for fee sponsoring.
         val latestLedger = kit.sorobanServer.getLatestLedger()
         val expirationLedger = latestLedger.sequence.toUInt() + OZConstants.AUTH_ENTRY_EXPIRATION_BUFFER.toUInt()
 
@@ -809,10 +789,10 @@ class OZTransactionOperations internal constructor(
             expirationLedger = expirationLedger
         )
 
-        // STEP 9: Refresh temp account for re-simulation
+        // STEP 9: Rebuild transaction with signed auth entries and re-simulate.
+        // Use a fresh account fetch to avoid sequence number issues.
         val tempAccountRefresh = kit.sorobanServer.getAccount(tempKeypair.getAccountId())
 
-        // Build transaction with signed auth entries
         val signedOperation = InvokeHostFunctionOperation(hostFunction, signedAuthEntries)
         val signedTransaction = TransactionBuilder(tempAccountRefresh, Network(kit.config.networkPassphrase))
             .setBaseFee(100)
@@ -821,40 +801,22 @@ class OZTransactionOperations internal constructor(
             .setTimeout(300)
             .build()
 
-        // STEP 10: Re-simulate with signed auth entries to get correct resource estimates
         val reSimulation = kit.sorobanServer.simulateTransaction(signedTransaction)
 
         if (reSimulation.error != null) {
             throw TransactionException.simulationFailed("Re-simulation error: ${reSimulation.error}")
         }
 
-        // Assemble transaction from re-simulation
-        val transactionData = reSimulation.parseTransactionData()
-            ?: throw TransactionException.submissionFailed(
-                "Failed to get transaction data from re-simulation"
-            )
-
-        val minResourceFee = reSimulation.minResourceFee
-            ?: throw TransactionException.submissionFailed(
-                "Failed to get min resource fee from re-simulation"
-            )
-
-        // Rebuild transaction with signed auth entries and Soroban data
-        val finalOperation = InvokeHostFunctionOperation(hostFunction, signedAuthEntries)
-        val finalTransaction = TransactionBuilder(tempAccountRefresh, Network(kit.config.networkPassphrase))
-            .setBaseFee(100 + minResourceFee)
-            .addOperation(finalOperation)
-            .addMemo(MemoNone)
-            .setTimeout(300)
-            .setSorobanData(transactionData)
-            .build()
+        // STEP 10: Assemble the transaction using the SDK's prepareTransaction.
+        // This correctly applies resource fees, footprint, and soroban data from simulation.
+        val preparedTransaction = kit.sorobanServer.prepareTransaction(signedTransaction, reSimulation)
 
         // STEP 11: Determine submission method and submit
         val submissionMethod = getSubmissionMethod(forceMethod)
         val useRelayer = submissionMethod == SubmissionMethod.RELAYER
 
         val result = submitOrRelay(
-            transaction = finalTransaction,
+            transaction = preparedTransaction,
             hostFunction = hostFunction,
             signedAuthEntries = signedAuthEntries,
             signer = tempKeypair,
@@ -868,7 +830,7 @@ class OZTransactionOperations internal constructor(
             )
         }
 
-        // STEP 13: Return funded amount as XLM string
+        // STEP 12: Return funded amount as XLM string
         val xlmWhole = transferStroops / BigInteger.fromLong(Util.STROOPS_PER_XLM)
         val xlmFraction = transferStroops % BigInteger.fromLong(Util.STROOPS_PER_XLM)
         return if (xlmFraction == BigInteger.ZERO) {
@@ -1170,9 +1132,29 @@ class OZTransactionOperations internal constructor(
             // Submit via RPC
             val sendResult = kit.sorobanServer.sendTransaction(transaction)
 
+            when (sendResult.status) {
+                SendTransactionStatus.ERROR -> {
+                    return TransactionResult(
+                        success = false,
+                        hash = sendResult.hash ?: "",
+                        error = sendResult.errorResultXdr ?: "Transaction rejected by network"
+                    )
+                }
+                SendTransactionStatus.TRY_AGAIN_LATER -> {
+                    return TransactionResult(
+                        success = false,
+                        hash = sendResult.hash ?: "",
+                        error = "Network is congested. Try again later."
+                    )
+                }
+                else -> {
+                    // PENDING or DUPLICATE — poll for confirmation
+                }
+            }
+
             val hash = sendResult.hash
                 ?: throw TransactionException.submissionFailed(
-                    "Failed to get transaction hash from send result: ${sendResult.errorResultXdr ?: "unknown error"}"
+                    "No transaction hash returned from send result"
                 )
 
             if (emitEvents) {
@@ -1189,55 +1171,38 @@ class OZTransactionOperations internal constructor(
     }
 
     /**
-     * Polls for transaction confirmation.
+     * Polls for transaction confirmation using the SDK's [SorobanServer.pollTransaction].
      *
-     * Repeatedly checks the transaction status on Soroban RPC until it is confirmed,
-     * fails, or times out. Uses exponential backoff between attempts.
+     * Uses 30 attempts with 3-second intervals (~90 seconds total) to account for
+     * testnet ledger close times and potential congestion.
      *
      * @param hash The transaction hash to poll
      * @return TransactionResult indicating success or failure
-     * @throws SmartAccountException if polling times out
      */
     private suspend fun pollForConfirmation(hash: String): TransactionResult {
-        val maxAttempts = 10
-        val sleepDurationMs = 2000L
+        val txResponse = kit.sorobanServer.pollTransaction(
+            hash = hash,
+            maxAttempts = 30,
+            sleepStrategy = { 3000L }
+        )
 
-        repeat(maxAttempts) { attempt ->
-            val txStatus = kit.sorobanServer.getTransaction(hash)
-
-            when (txStatus.status) {
-                GetTransactionStatus.SUCCESS -> return TransactionResult(
-                    success = true,
-                    hash = hash,
-                    ledger = txStatus.latestLedger?.toUInt()
-                )
-
-                GetTransactionStatus.FAILED -> {
-                    val errorMessage = txStatus.resultXdr ?: "Transaction failed on-chain"
-                    return TransactionResult(
-                        success = false,
-                        hash = hash,
-                        ledger = txStatus.latestLedger?.toUInt(),
-                        error = errorMessage
-                    )
-                }
-
-                GetTransactionStatus.NOT_FOUND -> {
-                    // Transaction not yet confirmed, retry
-                    if (attempt < maxAttempts - 1) {
-                        delay(sleepDurationMs)
-                    } else {
-                        return TransactionResult(
-                            success = false,
-                            hash = hash,
-                            error = "Transaction timed out after $maxAttempts attempts"
-                        )
-                    }
-                }
-            }
+        return when (txResponse.status) {
+            GetTransactionStatus.SUCCESS -> TransactionResult(
+                success = true,
+                hash = hash,
+                ledger = txResponse.latestLedger?.toUInt()
+            )
+            GetTransactionStatus.FAILED -> TransactionResult(
+                success = false,
+                hash = hash,
+                ledger = txResponse.latestLedger?.toUInt(),
+                error = txResponse.resultXdr ?: "Transaction failed on-chain"
+            )
+            GetTransactionStatus.NOT_FOUND -> TransactionResult(
+                success = false,
+                hash = hash,
+                error = "Transaction not confirmed after 30 polling attempts"
+            )
         }
-
-        // Should not reach here, but for safety
-        throw TransactionException.timeout("Transaction polling timed out after $maxAttempts attempts")
     }
 }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/smartaccount/SmartAccountTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/smartaccount/SmartAccountTest.kt
@@ -29,6 +29,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -896,16 +897,18 @@ class SmartAccountTest {
         )
 
         val credentials = (signedEntry.credentials as SorobanCredentialsXdr.Address).value
-        assertTrue(credentials.signature is com.soneso.stellar.sdk.xdr.SCValXdr.Vec)
+        assertTrue(credentials.signature is com.soneso.stellar.sdk.xdr.SCValXdr.Map)
 
-        val vec = (credentials.signature as com.soneso.stellar.sdk.xdr.SCValXdr.Vec).value
-        assertFalse(vec?.value.isNullOrEmpty())
+        val outerMap = (credentials.signature as com.soneso.stellar.sdk.xdr.SCValXdr.Map).value
+        assertFalse(outerMap?.value.isNullOrEmpty())
+        assertEquals(2, outerMap?.value?.size)
 
-        val firstElement = vec?.value?.get(0)
-        assertTrue(firstElement is com.soneso.stellar.sdk.xdr.SCValXdr.Map)
-
-        val map = (firstElement as com.soneso.stellar.sdk.xdr.SCValXdr.Map).value
-        assertEquals(1, map?.value?.size)
+        val signersEntry = outerMap?.value?.first {
+            (it.key as? com.soneso.stellar.sdk.xdr.SCValXdr.Sym)?.value?.value == "signers"
+        }
+        assertNotNull(signersEntry)
+        val signersMap = (signersEntry!!.`val` as com.soneso.stellar.sdk.xdr.SCValXdr.Map).value
+        assertEquals(1, signersMap?.value?.size)
     }
 
     @Test
@@ -935,9 +938,12 @@ class SmartAccountTest {
         )
 
         val credentials = (signedEntry.credentials as SorobanCredentialsXdr.Address).value
-        val vec = (credentials.signature as com.soneso.stellar.sdk.xdr.SCValXdr.Vec).value
-        val map = (vec?.value?.get(0) as com.soneso.stellar.sdk.xdr.SCValXdr.Map).value
-        val sigValue = map?.value?.get(0)?.`val`
+        val outerMap = (credentials.signature as com.soneso.stellar.sdk.xdr.SCValXdr.Map).value
+        val signersEntry = outerMap?.value?.first {
+            (it.key as? com.soneso.stellar.sdk.xdr.SCValXdr.Sym)?.value?.value == "signers"
+        }
+        val signersMap = (signersEntry!!.`val` as com.soneso.stellar.sdk.xdr.SCValXdr.Map).value
+        val sigValue = signersMap?.value?.get(0)?.`val`
 
         // Signature value should be Bytes containing XDR
         assertTrue(sigValue is com.soneso.stellar.sdk.xdr.SCValXdr.Bytes)

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/ContractMethodSignatureTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/ContractMethodSignatureTest.kt
@@ -547,30 +547,30 @@ class ContractMethodSignatureTest {
     // ========================================================================
 
     @Test
+    fun testExecuteFunction_isInvokedByExecuteAndSubmit() {
+        // "execute" (SmartAccountContractAbi.Functions.EXECUTE) is used by
+        // OZTransactionOperations.executeAndSubmit(), which builds an invocation of the
+        // smart account's execute(target, target_fn, target_args) entry point.
+        assertEquals("execute", SmartAccountContractAbi.Functions.EXECUTE)
+    }
+
+    @Test
     fun testUnusedAbiFunctions_areDocumented() {
-        // The following ABI functions are NOT currently invoked in the KMP SDK:
+        // The following ABI function is NOT currently invoked in the KMP SDK:
         //
-        // 1. "execute" (SmartAccountContractAbi.Functions.EXECUTE)
-        //    - ExecutionEntryPoint trait method for invoking target contracts
-        //    - The KMP SDK uses direct InvokeHostFunction operations instead
-        //    - Rationale: The SDK builds and submits transactions directly rather than
-        //      routing through the smart account's execute() function
-        //
-        // 2. "upgrade" (SmartAccountContractAbi.Functions.UPGRADE)
+        // 1. "upgrade" (SmartAccountContractAbi.Functions.UPGRADE)
         //    - Upgradeable trait method for WASM upgrade
         //    - Not yet implemented in the KMP SDK
         //    - Rationale: Contract upgrade functionality is not yet part of the SDK's scope
         //
-        // This test serves as documentation of the unused functions.
-        // If these functions are implemented in the future, this test should be updated.
+        // This test serves as documentation of the unused function.
+        // If this function is implemented in the future, this test should be updated.
 
         val unusedFunctions = listOf(
-            SmartAccountContractAbi.Functions.EXECUTE,
             SmartAccountContractAbi.Functions.UPGRADE
         )
-        assertEquals(2, unusedFunctions.size, "There should be exactly 2 unused ABI functions")
-        assertEquals("execute", unusedFunctions[0])
-        assertEquals("upgrade", unusedFunctions[1])
+        assertEquals(1, unusedFunctions.size, "There should be exactly 1 unused ABI function")
+        assertEquals("upgrade", unusedFunctions[0])
     }
 
     // ========================================================================

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/SignAuthEntryCryptoTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/SignAuthEntryCryptoTest.kt
@@ -118,11 +118,9 @@ class SignAuthEntryCryptoTest {
 
         // Unpack the signature from the signed entry
         val credentials = (signedEntry.credentials as SorobanCredentialsXdr.Address).value
-        val vec = (credentials.signature as SCValXdr.Vec).value
-        assertNotNull(vec)
-        assertTrue(vec.value.isNotEmpty())
-
-        val mapEntry = (vec.value[0] as SCValXdr.Map).value
+        val outerMap = (credentials.signature as SCValXdr.Map).value!!
+        val signersEntry = outerMap.value.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val mapEntry = (signersEntry.`val` as SCValXdr.Map).value
         assertNotNull(mapEntry)
         assertEquals(1, mapEntry.value.size)
 
@@ -184,8 +182,9 @@ class SignAuthEntryCryptoTest {
 
         // Unpack signature bytes
         val credentials = (signedEntry.credentials as SorobanCredentialsXdr.Address).value
-        val vec = (credentials.signature as SCValXdr.Vec).value!!
-        val mapEntry = (vec.value[0] as SCValXdr.Map).value!!
+        val outerMap = (credentials.signature as SCValXdr.Map).value!!
+        val signersEntry = outerMap.value.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val mapEntry = (signersEntry.`val` as SCValXdr.Map).value!!
         val xdrBytes = ((mapEntry.value[0].`val`) as SCValXdr.Bytes).value.value
         val innerMap = (SCValXdr.decode(com.soneso.stellar.sdk.xdr.XdrReader(xdrBytes)) as SCValXdr.Map).value!!
         val sigEntry = innerMap.value.first { (it.key as? SCValXdr.Sym)?.value?.value == "signature" }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/SmartAccountAuthTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/SmartAccountAuthTest.kt
@@ -295,7 +295,8 @@ class SmartAccountAuthTest {
     @Test
     fun testAddRawSignatureMapEntry_addsEntryToVoidSignatureEntry() {
         val entry = createAddressAuthEntry()
-        val signerKey = Scv.toBytes(ByteArray(32) { 0xAB.toByte() })
+        val delegatedSigner = DelegatedSigner("GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW")
+        val signerKey = delegatedSigner.toScVal()
         val signatureValue = Scv.toBytes(ByteArray(0))
 
         val result = SmartAccountAuth.addRawSignatureMapEntry(
@@ -305,23 +306,22 @@ class SmartAccountAuthTest {
         )
 
         val credentials = (result.credentials as SorobanCredentialsXdr.Address).value
-        val vecXdr = credentials.signature as? SCValXdr.Vec
-        assertNotNull(vecXdr, "Signature must be a Vec")
-        assertNotNull(vecXdr.value, "Vec value must not be null")
-        assertEquals(1, vecXdr.value!!.value.size, "Vec must contain exactly one element")
+        val outerMap = credentials.signature as? SCValXdr.Map
+        assertNotNull(outerMap, "Signature must be a Map (AuthPayload)")
+        val outerEntries = outerMap.value!!.value
+        assertEquals(2, outerEntries.size, "AuthPayload must have exactly 2 entries")
 
-        val mapXdr = vecXdr.value!!.value[0] as? SCValXdr.Map
-        assertNotNull(mapXdr, "Vec element must be a Map")
-        assertNotNull(mapXdr.value, "Map value must not be null")
-        assertEquals(1, mapXdr.value!!.value.size, "Map must contain exactly one entry")
+        val signersEntry = outerEntries.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        assertEquals(1, signersMap.size, "Signers map must contain exactly one entry")
     }
 
     @Test
     fun testAddRawSignatureMapEntry_mapEntryHasCorrectKeyAndValue() {
         val entry = createAddressAuthEntry()
-        val keyBytes = ByteArray(32) { it.toByte() }
         val valueBytes = ByteArray(16) { (it + 1).toByte() }
-        val signerKey = Scv.toBytes(keyBytes)
+        val delegatedSigner = DelegatedSigner("GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW")
+        val signerKey = delegatedSigner.toScVal()
         val signatureValue = Scv.toBytes(valueBytes)
 
         val result = SmartAccountAuth.addRawSignatureMapEntry(
@@ -331,14 +331,13 @@ class SmartAccountAuthTest {
         )
 
         val credentials = (result.credentials as SorobanCredentialsXdr.Address).value
-        val mapEntries = ((credentials.signature as SCValXdr.Vec).value!!.value[0] as SCValXdr.Map).value!!.value
-        assertEquals(1, mapEntries.size)
+        val outerMap = credentials.signature as? SCValXdr.Map
+        assertNotNull(outerMap, "Signature must be a Map (AuthPayload)")
+        val signersEntry = outerMap.value!!.value.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        assertEquals(1, signersMap.size)
 
-        val entryKey = mapEntries[0].key as? SCValXdr.Bytes
-        assertNotNull(entryKey, "Map entry key must be SCValXdr.Bytes")
-        assertTrue(entryKey.value.value.contentEquals(keyBytes), "Key bytes must match")
-
-        val entryValue = mapEntries[0].`val` as? SCValXdr.Bytes
+        val entryValue = signersMap[0].`val` as? SCValXdr.Bytes
         assertNotNull(entryValue, "Map entry value must be SCValXdr.Bytes")
         assertTrue(entryValue.value.value.contentEquals(valueBytes), "Value bytes must match")
     }
@@ -346,8 +345,10 @@ class SmartAccountAuthTest {
     @Test
     fun testAddRawSignatureMapEntry_secondCallProducesTwoEntries() {
         val entry = createAddressAuthEntry()
-        val key1 = Scv.toBytes(ByteArray(32) { 0x01.toByte() })
-        val key2 = Scv.toBytes(ByteArray(32) { 0x02.toByte() })
+        val signer1 = DelegatedSigner("GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW")
+        val signer2 = DelegatedSigner("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ")
+        val key1 = signer1.toScVal()
+        val key2 = signer2.toScVal()
         val voidValue = Scv.toBytes(ByteArray(0))
 
         val entryWith1 = SmartAccountAuth.addRawSignatureMapEntry(
@@ -362,8 +363,11 @@ class SmartAccountAuthTest {
         )
 
         val credentials = (entryWith2.credentials as SorobanCredentialsXdr.Address).value
-        val mapEntries = ((credentials.signature as SCValXdr.Vec).value!!.value[0] as SCValXdr.Map).value!!.value
-        assertEquals(2, mapEntries.size, "Map must contain two entries after two addRawSignatureMapEntry calls")
+        val outerMap = credentials.signature as? SCValXdr.Map
+        assertNotNull(outerMap, "Signature must be a Map (AuthPayload)")
+        val signersEntry = outerMap.value!!.value.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        assertEquals(2, signersMap.size, "Signers map must contain two entries after two addRawSignatureMapEntry calls")
     }
 
     @Test
@@ -371,24 +375,27 @@ class SmartAccountAuthTest {
         val entry = createAddressAuthEntry()
         val voidValue = Scv.toBytes(ByteArray(0))
 
-        // Key with higher byte value added first: should end up second after sort
-        val higherKey = Scv.toBytes(ByteArray(32) { 0xFF.toByte() })
-        val lowerKey  = Scv.toBytes(ByteArray(32) { 0x00.toByte() })
+        // Add two different delegated signers — order inserted should not determine final order
+        val signer1 = DelegatedSigner("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ")
+        val signer2 = DelegatedSigner("GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW")
 
-        val entryWithHigher = SmartAccountAuth.addRawSignatureMapEntry(
+        val entryWithFirst = SmartAccountAuth.addRawSignatureMapEntry(
             entry = entry,
-            signerKey = higherKey,
+            signerKey = signer1.toScVal(),
             signatureValue = voidValue
         )
         val entryWithBoth = SmartAccountAuth.addRawSignatureMapEntry(
-            entry = entryWithHigher,
-            signerKey = lowerKey,
+            entry = entryWithFirst,
+            signerKey = signer2.toScVal(),
             signatureValue = voidValue
         )
 
         val credentials = (entryWithBoth.credentials as SorobanCredentialsXdr.Address).value
-        val mapEntries = ((credentials.signature as SCValXdr.Vec).value!!.value[0] as SCValXdr.Map).value!!.value
-        assertEquals(2, mapEntries.size)
+        val outerMap = credentials.signature as? SCValXdr.Map
+        assertNotNull(outerMap, "Signature must be a Map (AuthPayload)")
+        val signersEntry = outerMap.value!!.value.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        assertEquals(2, signersMap.size)
 
         // Compute XDR hex keys for both entries and verify ascending order
         fun xdrHex(scVal: SCValXdr): String {
@@ -396,9 +403,9 @@ class SmartAccountAuthTest {
             scVal.encode(w)
             return w.toByteArray().joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
         }
-        val firstKeyHex = xdrHex(mapEntries[0].key)
-        val secondKeyHex = xdrHex(mapEntries[1].key)
-        assertTrue(firstKeyHex < secondKeyHex, "Map entries must be sorted by XDR-encoded key hex in strictly ascending order (distinct entries)")
+        val firstKeyHex = xdrHex(signersMap[0].key)
+        val secondKeyHex = xdrHex(signersMap[1].key)
+        assertTrue(firstKeyHex < secondKeyHex, "Signers map entries must be sorted by XDR-encoded key hex in strictly ascending order (distinct entries)")
     }
 
     @Test
@@ -438,7 +445,8 @@ class SmartAccountAuthTest {
     @Test
     fun testAddRawSignatureMapEntry_doesNotMutateOriginalEntry() {
         val entry = createAddressAuthEntry()
-        val signerKey = Scv.toBytes(ByteArray(32) { 0xAA.toByte() })
+        val delegatedSigner = DelegatedSigner("GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW")
+        val signerKey = delegatedSigner.toScVal()
         val signatureValue = Scv.toBytes(ByteArray(0))
 
         SmartAccountAuth.addRawSignatureMapEntry(
@@ -459,7 +467,8 @@ class SmartAccountAuthTest {
     fun testAddRawSignatureMapEntry_rawBytesAreStoredAsScvBytes() {
         val entry = createAddressAuthEntry()
         val rawBytes = ByteArray(64) { (it * 3).toByte() }
-        val signerKey = Scv.toBytes(ByteArray(32) { 0xCC.toByte() })
+        val delegatedSigner = DelegatedSigner("GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW")
+        val signerKey = delegatedSigner.toScVal()
         val signatureValue = Scv.toBytes(rawBytes)
 
         val result = SmartAccountAuth.addRawSignatureMapEntry(
@@ -469,8 +478,11 @@ class SmartAccountAuthTest {
         )
 
         val credentials = (result.credentials as SorobanCredentialsXdr.Address).value
-        val mapEntries = ((credentials.signature as SCValXdr.Vec).value!!.value[0] as SCValXdr.Map).value!!.value
-        val storedValue = mapEntries[0].`val` as? SCValXdr.Bytes
+        val outerMap = credentials.signature as? SCValXdr.Map
+        assertNotNull(outerMap, "Signature must be a Map (AuthPayload)")
+        val signersEntry = outerMap.value!!.value.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        val storedValue = signersMap[0].`val` as? SCValXdr.Bytes
         assertNotNull(storedValue, "Stored value must be SCValXdr.Bytes")
         assertTrue(storedValue.value.value.contentEquals(rawBytes), "Raw bytes must be preserved exactly")
     }
@@ -512,10 +524,13 @@ class SmartAccountAuthTest {
 
         val credentials = (entryAfterSecond.credentials as SorobanCredentialsXdr.Address).value
         assertEquals(expirationLedger, credentials.signatureExpirationLedger.value, "Expiration ledger must be set on credentials")
-        val vec = credentials.signature as? SCValXdr.Vec
-        assertNotNull(vec)
-        val mapEntries = (vec.value!!.value[0] as SCValXdr.Map).value!!.value
-        assertEquals(2, mapEntries.size, "Both signatures must be present in the map")
+        val outerMap = credentials.signature as? SCValXdr.Map
+        assertNotNull(outerMap, "Signature must be a Map (AuthPayload)")
+        val outerEntries = outerMap.value!!.value
+        assertEquals(2, outerEntries.size, "AuthPayload must have exactly 2 entries")
+        val signersEntry = outerEntries.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        assertEquals(2, signersMap.size, "Both signatures must be present in the signers map")
     }
 
     @Test
@@ -551,16 +566,19 @@ class SmartAccountAuthTest {
         )
 
         val credentials = (entryAfterSecond.credentials as SorobanCredentialsXdr.Address).value
-        val mapEntries = (((credentials.signature as SCValXdr.Vec).value!!.value[0]) as SCValXdr.Map).value!!.value
-        assertEquals(2, mapEntries.size)
+        val outerMap = credentials.signature as? SCValXdr.Map
+        assertNotNull(outerMap, "Signature must be a Map (AuthPayload)")
+        val signersEntry = outerMap.value!!.value.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        assertEquals(2, signersMap.size)
 
         fun xdrHex(scVal: SCValXdr): String {
             val w = XdrWriter()
             scVal.encode(w)
             return w.toByteArray().joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
         }
-        val firstKeyHex = xdrHex(mapEntries[0].key)
-        val secondKeyHex = xdrHex(mapEntries[1].key)
+        val firstKeyHex = xdrHex(signersMap[0].key)
+        val secondKeyHex = xdrHex(signersMap[1].key)
         assertTrue(firstKeyHex < secondKeyHex, "Two-signer map must be sorted by XDR-encoded key hex in strictly ascending order (distinct entries)")
     }
 
@@ -586,8 +604,9 @@ class SmartAccountAuthTest {
             expirationLedger = expirationLedger
         )
 
-        // Add a raw placeholder entry (e.g., for a delegated signer awaiting require_auth)
-        val rawKey = Scv.toBytes(ByteArray(32) { 0xDD.toByte() })
+        // Add a raw placeholder entry for a delegated signer (different from the keypair-based signer)
+        val rawDelegatedSigner = DelegatedSigner("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ")
+        val rawKey = rawDelegatedSigner.toScVal()
         val rawValue = Scv.toBytes(ByteArray(0))
         val entryWithBoth = SmartAccountAuth.addRawSignatureMapEntry(
             entry = signedEntry,
@@ -596,8 +615,11 @@ class SmartAccountAuthTest {
         )
 
         val credentials = (entryWithBoth.credentials as SorobanCredentialsXdr.Address).value
-        val mapEntries = (((credentials.signature as SCValXdr.Vec).value!!.value[0]) as SCValXdr.Map).value!!.value
-        assertEquals(2, mapEntries.size, "Entry from signAuthEntry and raw entry must both be present")
+        val outerMap = credentials.signature as? SCValXdr.Map
+        assertNotNull(outerMap, "Signature must be a Map (AuthPayload)")
+        val signersEntry = outerMap.value!!.value.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        assertEquals(2, signersMap.size, "Entry from signAuthEntry and raw entry must both be present")
     }
 
     // MARK: - PolicySignature + DelegatedSigner Tests
@@ -622,19 +644,22 @@ class SmartAccountAuthTest {
         val credentials = (signedEntry.credentials as SorobanCredentialsXdr.Address).value
         assertEquals(expirationLedger, credentials.signatureExpirationLedger.value, "Expiration ledger must be set")
 
-        // Verify outer Vec -> Map structure
-        val vec = credentials.signature as? SCValXdr.Vec
-        assertNotNull(vec, "Signature must be a Vec")
-        assertNotNull(vec.value, "Vec value must not be null")
-        assertEquals(1, vec.value!!.value.size, "Vec must contain exactly one element")
+        // Verify outer Map (AuthPayload) structure
+        val outerMap = credentials.signature as? SCValXdr.Map
+        assertNotNull(outerMap, "Signature must be a Map (AuthPayload)")
+        val outerEntries = outerMap.value!!.value
+        assertEquals(2, outerEntries.size, "AuthPayload must have exactly 2 entries")
 
-        val mapXdr = vec.value!!.value[0] as? SCValXdr.Map
-        assertNotNull(mapXdr, "Vec element must be a Map")
-        assertNotNull(mapXdr.value, "Map value must not be null")
-        assertEquals(1, mapXdr.value!!.value.size, "Map must contain exactly one entry")
+        val contextRuleIdsEntry = outerEntries.first { (it.key as? SCValXdr.Sym)?.value?.value == "context_rule_ids" }
+        val contextRuleIdsVec = contextRuleIdsEntry.`val` as? SCValXdr.Vec
+        assertNotNull(contextRuleIdsVec, "context_rule_ids must be a Vec")
+
+        val signersEntry = outerEntries.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        assertEquals(1, signersMap.size, "Signers map must contain exactly one entry")
 
         // Verify the value is double-XDR-encoded empty map (PolicySignature.toScVal() = empty map)
-        val outerBytes = mapXdr.value!!.value[0].`val` as? SCValXdr.Bytes
+        val outerBytes = signersMap[0].`val` as? SCValXdr.Bytes
         assertNotNull(outerBytes, "Signature value must be SCValXdr.Bytes (outer double-encoding)")
 
         val innerScVal = SCValXdr.decode(XdrReader(outerBytes.value.value))
@@ -691,13 +716,14 @@ class SmartAccountAuthTest {
         val credentials = (signedEntry.credentials as SorobanCredentialsXdr.Address).value
         assertEquals(expirationLedger, credentials.signatureExpirationLedger.value)
 
-        val vec = credentials.signature as? SCValXdr.Vec
-        assertNotNull(vec, "Signature must be a Vec")
-        val mapEntries = (vec.value!!.value[0] as SCValXdr.Map).value!!.value
-        assertEquals(1, mapEntries.size, "Map must have exactly one entry")
+        val outerMap = credentials.signature as? SCValXdr.Map
+        assertNotNull(outerMap, "Signature must be a Map (AuthPayload)")
+        val signersEntry = outerMap.value!!.value.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        assertEquals(1, signersMap.size, "Signers map must have exactly one entry")
 
         // The value must be a double-XDR-encoded SCVal::Bytes
-        val outerBytes = mapEntries[0].`val` as? SCValXdr.Bytes
+        val outerBytes = signersMap[0].`val` as? SCValXdr.Bytes
         assertNotNull(outerBytes, "Signature value must be SCValXdr.Bytes (outer)")
         val innerScVal = SCValXdr.decode(XdrReader(outerBytes.value.value))
         assertTrue(innerScVal is SCValXdr.Map, "Inner ScVal must be a Map (WebAuthn signature map)")
@@ -717,5 +743,41 @@ class SmartAccountAuthTest {
         assertTrue(storedAuthData.contentEquals(authenticatorData), "authenticator_data bytes must be preserved")
         assertTrue(storedClientData.contentEquals(clientData), "client_data bytes must be preserved")
         assertTrue(storedSig.contentEquals(compactSig), "signature bytes must be preserved")
+    }
+
+    // MARK: - buildAuthDigest Tests
+
+    @Test
+    fun testBuildAuthDigest_changesWithDifferentRuleIds() = runTest {
+        val signaturePayload = ByteArray(32) { it.toByte() }
+
+        val digest1 = SmartAccountAuth.buildAuthDigest(signaturePayload, listOf(1u))
+        val digest2 = SmartAccountAuth.buildAuthDigest(signaturePayload, listOf(2u))
+        val digest3 = SmartAccountAuth.buildAuthDigest(signaturePayload, listOf(1u, 2u))
+
+        assertEquals(32, digest1.size, "Auth digest must be 32 bytes")
+        assertTrue(!digest1.contentEquals(digest2), "Different rule IDs must produce different digests")
+        assertTrue(!digest1.contentEquals(digest3), "Different number of rule IDs must produce different digests")
+    }
+
+    @Test
+    fun testBuildAuthDigest_isConsistent() = runTest {
+        val signaturePayload = ByteArray(32) { it.toByte() }
+        val ruleIds = listOf(1u, 2u, 3u)
+
+        val digest1 = SmartAccountAuth.buildAuthDigest(signaturePayload, ruleIds)
+        val digest2 = SmartAccountAuth.buildAuthDigest(signaturePayload, ruleIds)
+
+        assertTrue(digest1.contentEquals(digest2), "Same inputs must produce identical digests")
+    }
+
+    @Test
+    fun testBuildAuthDigest_emptyRuleIdsProducesDifferentDigestThanNonEmpty() = runTest {
+        val signaturePayload = ByteArray(32) { it.toByte() }
+
+        val digestEmpty = SmartAccountAuth.buildAuthDigest(signaturePayload, emptyList())
+        val digestNonEmpty = SmartAccountAuth.buildAuthDigest(signaturePayload, listOf(0u))
+
+        assertTrue(!digestEmpty.contentEquals(digestNonEmpty), "Empty and non-empty rule IDs must differ")
     }
 }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/SmartAccountAuthTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/SmartAccountAuthTest.kt
@@ -780,4 +780,126 @@ class SmartAccountAuthTest {
 
         assertTrue(!digestEmpty.contentEquals(digestNonEmpty), "Empty and non-empty rule IDs must differ")
     }
+
+    // MARK: - contextRuleIds Codec Tests
+
+    @Test
+    fun testSignAuthEntry_contextRuleIdsArePreservedInPayload() = runTest {
+        val keypair = KeyPair.random()
+        val expirationLedger = 5000000u
+        val authEntry = createAddressAuthEntry()
+        val contextRuleIds = listOf(3u, 7u)
+
+        val payloadHash = SmartAccountAuth.buildAuthPayloadHash(
+            entry = authEntry,
+            expirationLedger = expirationLedger,
+            networkPassphrase = networkPassphrase
+        )
+
+        val sig = Ed25519Signature(publicKey = keypair.getPublicKey(), signature = keypair.sign(payloadHash))
+        val signer = ExternalSigner.ed25519(verifierAddress = contractAddress, publicKey = keypair.getPublicKey())
+
+        val signedEntry = SmartAccountAuth.signAuthEntry(
+            entry = authEntry,
+            signer = signer,
+            signature = sig,
+            expirationLedger = expirationLedger,
+            contextRuleIds = contextRuleIds
+        )
+
+        val credentials = (signedEntry.credentials as SorobanCredentialsXdr.Address).value
+        val outerMap = credentials.signature as SCValXdr.Map
+        val contextRuleIdsEntry = outerMap.value!!.value.first {
+            (it.key as? SCValXdr.Sym)?.value?.value == "context_rule_ids"
+        }
+        val ruleIdsVec = (contextRuleIdsEntry.`val` as SCValXdr.Vec).value!!.value
+        assertEquals(2, ruleIdsVec.size)
+        assertEquals(3u, (ruleIdsVec[0] as SCValXdr.U32).value.value)
+        assertEquals(7u, (ruleIdsVec[1] as SCValXdr.U32).value.value)
+    }
+
+    @Test
+    fun testSignAuthEntry_emptyContextRuleIdsProducesEmptyVec() = runTest {
+        val keypair = KeyPair.random()
+        val expirationLedger = 5000000u
+        val authEntry = createAddressAuthEntry()
+
+        val payloadHash = SmartAccountAuth.buildAuthPayloadHash(
+            entry = authEntry,
+            expirationLedger = expirationLedger,
+            networkPassphrase = networkPassphrase
+        )
+
+        val sig = Ed25519Signature(publicKey = keypair.getPublicKey(), signature = keypair.sign(payloadHash))
+        val signer = ExternalSigner.ed25519(verifierAddress = contractAddress, publicKey = keypair.getPublicKey())
+
+        // No contextRuleIds passed — defaults to empty
+        val signedEntry = SmartAccountAuth.signAuthEntry(
+            entry = authEntry,
+            signer = signer,
+            signature = sig,
+            expirationLedger = expirationLedger
+        )
+
+        val credentials = (signedEntry.credentials as SorobanCredentialsXdr.Address).value
+        val outerMap = credentials.signature as SCValXdr.Map
+        val contextRuleIdsEntry = outerMap.value!!.value.first {
+            (it.key as? SCValXdr.Sym)?.value?.value == "context_rule_ids"
+        }
+        val ruleIdsVec = (contextRuleIdsEntry.`val` as SCValXdr.Vec).value!!.value
+        assertEquals(0, ruleIdsVec.size, "Empty contextRuleIds should produce empty Vec")
+    }
+
+    @Test
+    fun testSignAuthEntry_secondSignerPreservesContextRuleIds() = runTest {
+        val keypair1 = KeyPair.random()
+        val keypair2 = KeyPair.random()
+        val expirationLedger = 5000000u
+        val authEntry = createAddressAuthEntry()
+        val contextRuleIds = listOf(5u)
+
+        val payloadHash = SmartAccountAuth.buildAuthPayloadHash(
+            entry = authEntry,
+            expirationLedger = expirationLedger,
+            networkPassphrase = networkPassphrase
+        )
+
+        val sig1 = Ed25519Signature(publicKey = keypair1.getPublicKey(), signature = keypair1.sign(payloadHash))
+        val signer1 = ExternalSigner.ed25519(verifierAddress = contractAddress, publicKey = keypair1.getPublicKey())
+
+        val entryAfterFirst = SmartAccountAuth.signAuthEntry(
+            entry = authEntry,
+            signer = signer1,
+            signature = sig1,
+            expirationLedger = expirationLedger,
+            contextRuleIds = contextRuleIds
+        )
+
+        // Second signer does NOT pass contextRuleIds — they should be preserved from the first call
+        val sig2 = Ed25519Signature(publicKey = keypair2.getPublicKey(), signature = keypair2.sign(payloadHash))
+        val signer2 = ExternalSigner.ed25519(verifierAddress = contractAddress, publicKey = keypair2.getPublicKey())
+
+        val entryAfterSecond = SmartAccountAuth.signAuthEntry(
+            entry = entryAfterFirst,
+            signer = signer2,
+            signature = sig2,
+            expirationLedger = expirationLedger
+        )
+
+        val credentials = (entryAfterSecond.credentials as SorobanCredentialsXdr.Address).value
+        val outerMap = credentials.signature as SCValXdr.Map
+
+        val contextRuleIdsEntry = outerMap.value!!.value.first {
+            (it.key as? SCValXdr.Sym)?.value?.value == "context_rule_ids"
+        }
+        val ruleIdsVec = (contextRuleIdsEntry.`val` as SCValXdr.Vec).value!!.value
+        assertEquals(1, ruleIdsVec.size)
+        assertEquals(5u, (ruleIdsVec[0] as SCValXdr.U32).value.value)
+
+        val signersEntry = outerMap.value!!.value.first {
+            (it.key as? SCValXdr.Sym)?.value?.value == "signers"
+        }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        assertEquals(2, signersMap.size, "Both signers must be present")
+    }
 }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/SmartAccountAuthTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/SmartAccountAuthTest.kt
@@ -17,6 +17,8 @@ import com.soneso.stellar.sdk.smartaccount.core.Ed25519Signature
 import com.soneso.stellar.sdk.smartaccount.core.ExternalSigner
 import com.soneso.stellar.sdk.smartaccount.core.PolicySignature
 import com.soneso.stellar.sdk.smartaccount.core.SmartAccountAuth
+import com.soneso.stellar.sdk.smartaccount.core.SmartAccountAuthPayload
+import com.soneso.stellar.sdk.smartaccount.core.SmartAccountAuthPayloadCodec
 import com.soneso.stellar.sdk.smartaccount.core.TransactionException
 import com.soneso.stellar.sdk.smartaccount.core.WebAuthnSignature
 import com.soneso.stellar.sdk.xdr.HashIDPreimageXdr
@@ -901,5 +903,226 @@ class SmartAccountAuthTest {
         }
         val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
         assertEquals(2, signersMap.size, "Both signers must be present")
+    }
+
+    // MARK: - SmartAccountAuthPayloadCodec Tests
+
+    @Test
+    fun testCodecRead_voidReturnsEmptyPayload() {
+        val payload = SmartAccountAuthPayloadCodec.read(SCValXdr.Void(SCValTypeXdr.SCV_VOID))
+        assertTrue(payload.signers.isEmpty())
+        assertTrue(payload.contextRuleIds.isEmpty())
+    }
+
+    @Test
+    fun testCodecRead_nonMapThrows() {
+        assertFailsWith<TransactionException.SigningFailed> {
+            SmartAccountAuthPayloadCodec.read(Scv.toUint32(42u))
+        }
+    }
+
+    @Test
+    fun testCodecWriteRead_roundTrip() {
+        val signer = DelegatedSigner("GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW")
+        val sigBytes = ByteArray(64) { it.toByte() }
+        val ruleIds = listOf(1u, 5u, 10u)
+
+        val original = SmartAccountAuthPayload(
+            signers = mutableMapOf(signer to sigBytes),
+            contextRuleIds = ruleIds
+        )
+
+        val scVal = SmartAccountAuthPayloadCodec.write(original)
+        val restored = SmartAccountAuthPayloadCodec.read(scVal)
+
+        assertEquals(1, restored.signers.size)
+        assertEquals(3, restored.contextRuleIds.size)
+        assertEquals(listOf(1u, 5u, 10u), restored.contextRuleIds)
+        assertTrue(restored.signers.values.first().contentEquals(sigBytes))
+    }
+
+    @Test
+    fun testCodecWriteRead_emptyPayloadRoundTrip() {
+        val original = SmartAccountAuthPayload(
+            signers = mutableMapOf(),
+            contextRuleIds = emptyList()
+        )
+        val scVal = SmartAccountAuthPayloadCodec.write(original)
+        val restored = SmartAccountAuthPayloadCodec.read(scVal)
+        assertTrue(restored.signers.isEmpty())
+        assertTrue(restored.contextRuleIds.isEmpty())
+    }
+
+    @Test
+    fun testCodecWrite_producesMapWithTwoEntries() {
+        val payload = SmartAccountAuthPayload(
+            signers = mutableMapOf(),
+            contextRuleIds = listOf(7u)
+        )
+        val scVal = SmartAccountAuthPayloadCodec.write(payload)
+        assertTrue(scVal is SCValXdr.Map)
+        val entries = (scVal as SCValXdr.Map).value!!.value
+        assertEquals(2, entries.size)
+        assertEquals("context_rule_ids", (entries[0].key as SCValXdr.Sym).value.value)
+        assertEquals("signers", (entries[1].key as SCValXdr.Sym).value.value)
+    }
+
+    @Test
+    fun testCodecUpsertSigner_replacesExisting() {
+        val signer = DelegatedSigner("GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW")
+        val payload = SmartAccountAuthPayload(
+            signers = mutableMapOf(signer to ByteArray(32) { 0x01 }),
+            contextRuleIds = emptyList()
+        )
+        val newBytes = ByteArray(32) { 0x02 }
+        SmartAccountAuthPayloadCodec.upsertSigner(payload, signer, newBytes)
+        assertEquals(1, payload.signers.size)
+        assertTrue(payload.signers.values.first().contentEquals(newBytes))
+    }
+
+    @Test
+    fun testCodecUpsertSigner_addsNewSigner() {
+        val signer1 = DelegatedSigner("GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW")
+        val signer2 = DelegatedSigner("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ")
+        val payload = SmartAccountAuthPayload(
+            signers = mutableMapOf(signer1 to ByteArray(32) { 0x01 }),
+            contextRuleIds = emptyList()
+        )
+        SmartAccountAuthPayloadCodec.upsertSigner(payload, signer2, ByteArray(32) { 0x02 })
+        assertEquals(2, payload.signers.size)
+    }
+
+    @Test
+    fun testCodecSignerFromScVal_parsesDelegated() {
+        val address = "GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW"
+        val signer = DelegatedSigner(address)
+        val scVal = signer.toScVal()
+        val parsed = SmartAccountAuthPayloadCodec.signerFromScVal(scVal)
+        assertTrue(parsed is DelegatedSigner)
+        assertEquals(address, (parsed as DelegatedSigner).address)
+    }
+
+    @Test
+    fun testCodecSignerFromScVal_parsesExternal() {
+        val verifier = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+        val keyData = ByteArray(65) { it.toByte() }
+        val signer = ExternalSigner(verifier, keyData)
+        val scVal = signer.toScVal()
+        val parsed = SmartAccountAuthPayloadCodec.signerFromScVal(scVal)
+        assertTrue(parsed is ExternalSigner)
+        assertEquals(verifier, (parsed as ExternalSigner).verifierAddress)
+        assertTrue(parsed.keyData.contentEquals(keyData))
+    }
+
+    @Test
+    fun testCodecSignerFromScVal_throwsOnNonVec() {
+        assertFailsWith<TransactionException.SigningFailed> {
+            SmartAccountAuthPayloadCodec.signerFromScVal(Scv.toUint32(42u))
+        }
+    }
+
+    @Test
+    fun testCodecSignerFromScVal_throwsOnUnknownTag() {
+        val badVec = Scv.toVec(listOf(Scv.toSymbol("Unknown"), Scv.toUint32(1u)))
+        assertFailsWith<TransactionException.SigningFailed> {
+            SmartAccountAuthPayloadCodec.signerFromScVal(badVec)
+        }
+    }
+
+    @Test
+    fun testCodecSignerFromScVal_throwsOnEmptyVec() {
+        val emptyVec = Scv.toVec(emptyList())
+        assertFailsWith<TransactionException.SigningFailed> {
+            SmartAccountAuthPayloadCodec.signerFromScVal(emptyVec)
+        }
+    }
+
+    @Test
+    fun testCodecWrite_signersSortedByXdrKey() {
+        val signer1 = DelegatedSigner("GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW")
+        val signer2 = DelegatedSigner("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ")
+
+        val payload = SmartAccountAuthPayload(
+            signers = mutableMapOf(
+                signer2 to ByteArray(32) { 0x02 },
+                signer1 to ByteArray(32) { 0x01 }
+            ),
+            contextRuleIds = emptyList()
+        )
+
+        val scVal = SmartAccountAuthPayloadCodec.write(payload)
+        val outerMap = (scVal as SCValXdr.Map).value!!.value
+        val signersEntry = outerMap.first { (it.key as? SCValXdr.Sym)?.value?.value == "signers" }
+        val signersMap = (signersEntry.`val` as SCValXdr.Map).value!!.value
+        assertEquals(2, signersMap.size)
+
+        fun xdrHex(scv: SCValXdr): String {
+            val w = XdrWriter()
+            scv.encode(w)
+            return w.toByteArray().joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
+        }
+        val firstHex = xdrHex(signersMap[0].key)
+        val secondHex = xdrHex(signersMap[1].key)
+        assertTrue(firstHex < secondHex, "Signers must be sorted by XDR key hex")
+    }
+
+    // MARK: - SmartAccountAuth Additional Edge Case Tests
+
+    @Test
+    fun testBuildAuthDigest_withEmptyPayloadIs32Bytes() = runTest {
+        val payload = ByteArray(32) { 0xFF.toByte() }
+        val digest = SmartAccountAuth.buildAuthDigest(payload, emptyList())
+        assertEquals(32, digest.size)
+    }
+
+    @Test
+    fun testSignAuthEntry_setsExpirationWithContextRuleIds() = runTest {
+        val keypair = KeyPair.random()
+        val expirationLedger = 9999999u
+        val authEntry = createAddressAuthEntry()
+        val contextRuleIds = listOf(1u, 2u)
+
+        val payloadHash = SmartAccountAuth.buildAuthPayloadHash(
+            entry = authEntry,
+            expirationLedger = expirationLedger,
+            networkPassphrase = networkPassphrase
+        )
+        val sig = Ed25519Signature(publicKey = keypair.getPublicKey(), signature = keypair.sign(payloadHash))
+        val signer = ExternalSigner.ed25519(verifierAddress = contractAddress, publicKey = keypair.getPublicKey())
+
+        val signedEntry = SmartAccountAuth.signAuthEntry(
+            entry = authEntry,
+            signer = signer,
+            signature = sig,
+            expirationLedger = expirationLedger,
+            contextRuleIds = contextRuleIds
+        )
+
+        val credentials = (signedEntry.credentials as SorobanCredentialsXdr.Address).value
+        assertEquals(expirationLedger, credentials.signatureExpirationLedger.value)
+    }
+
+    @Test
+    fun testAddRawSignatureMapEntry_contextRuleIdsAreSet() {
+        val entry = createAddressAuthEntry()
+        val signer = DelegatedSigner("GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW")
+        val contextRuleIds = listOf(3u, 8u)
+
+        val result = SmartAccountAuth.addRawSignatureMapEntry(
+            entry = entry,
+            signerKey = signer.toScVal(),
+            signatureValue = Scv.toBytes(byteArrayOf()),
+            contextRuleIds = contextRuleIds
+        )
+
+        val credentials = (result.credentials as SorobanCredentialsXdr.Address).value
+        val outerMap = credentials.signature as SCValXdr.Map
+        val ruleIdsEntry = outerMap.value!!.value.first {
+            (it.key as? SCValXdr.Sym)?.value?.value == "context_rule_ids"
+        }
+        val ruleIdsVec = (ruleIdsEntry.`val` as SCValXdr.Vec).value!!.value
+        assertEquals(2, ruleIdsVec.size)
+        assertEquals(3u, (ruleIdsVec[0] as SCValXdr.U32).value.value)
+        assertEquals(8u, (ruleIdsVec[1] as SCValXdr.U32).value.value)
     }
 }


### PR DESCRIPTION
## Description

Migrates the smart account SDK layer, demo app, and documentation to the OpenZeppelin smart account contracts v0.7.0-rc.2. Updates testnet contract addresses, signing flow, and context rule management.

### Auth payload and signing

- AuthPayload format changed from Vec-based to Map-based with `context_rule_ids` and `signers` fields
- Signing digest now binds context rule IDs: `sha256(payloadHash || contextRuleIds.toXDR())`
- New `SmartAccountAuthPayload` data class and `SmartAccountAuthPayloadCodec` for reading/writing the v0.7.0-rc.2 format
- `signAuthEntry()` accepts `contextRuleIds` parameter
- `addRawSignatureMapEntry()` accepts `contextRuleIds` parameter

### Context rule resolution

- 4-tier resolution algorithm: context type match, exact signer match, rule-signers-subset, selected-signers-subset (handles threshold scenarios)
- `resolveContextRuleIdsForEntry()` with overload accepting pre-fetched rules to avoid N+1 RPC calls
- `listContextRules()` returns fully parsed `ParsedContextRule` with `signerIds` and `policyIds`
- `ResolveContextRuleIds` callback on `submit()`, `executeAndSubmit()`, and `multiSignerTransfer()` for explicit per-entry rule selection
- Removed `MAX_CONTEXT_RULES` pre-validation in `addContextRule()` (no upper limit in v0.7.0-rc.2 contract)
- `addContextRule()` allows zero signers when at least one policy is present

### New APIs

- `executeAndSubmit()` for generic single-signer contract calls via the OZ `execute` entry point
- `ResolveContextRuleIds` type alias for per-entry context rule callbacks

### API changes

- `removeSigner()` takes `signerId: UInt` instead of `SmartAccountSigner`
- `removePolicy()` takes `policyId: UInt` instead of policy address string
- `signAuthEntries()` removed (unused public method with no equivalent in the TS SDK)
- `ParsedContextRule` includes `signerIds` and `policyIds` (positionally aligned)
- Contract error codes added: `MathOverflow`, `KeyDataTooLarge`, `ContextRuleIdsLengthMismatch`, `NameTooLong`, `UnauthorizedSigner`

### Transaction assembly and polling

- Use SDK `prepareTransaction()` instead of manual fee calculation in `submit()`, `submitMultiSignerTransaction()`, and `fundWallet()`
- Use SDK `pollTransaction()` with 30 attempts and 3-second intervals
- Proper `SendTransactionStatus` checks for ERROR and TRY_AGAIN_LATER
- Re-fetch deployer account before re-simulation to prevent `tx_bad_seq`
- Graceful fallback to on-chain signer lookup when storage read fails

### Demo app

- Updated contract addresses and WASM hash to v0.7.0-rc.2 testnet deployments
- Demo parsing delegated to SDK `listContextRules()`, removed dead parsing code
- Fixed Android WebAuthn `allowCredentials` to correctly constrain passkey selection
- Fixed macOS Account Signers screen to show credential ID instead of hex key data

### Tests and documentation

- Updated unit tests for new AuthPayload Map format
- Added tests for `buildAuthDigest`, contextRuleIds preservation, and `execute` function usage
- Updated API reference with new method signatures, `ResolveContextRuleIds` type, and examples