### PR TITLE
Merge hotfix v1.3.1: allow lowercase letters in asset codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-04-03
+
+### Fixed
+- Allow lowercase letters (a-z) in asset codes, matching JS and Python Stellar SDK validation (fixes #14)
+
 ## [1.3.0] - 2026-02-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stellar SDK for Kotlin Multiplatform
 
-[![Version](https://img.shields.io/badge/version-1.3.0-blue)](https://github.com/Soneso/kmp-stellar-sdk/releases)
+[![Version](https://img.shields.io/badge/version-1.3.1-blue)](https://github.com/Soneso/kmp-stellar-sdk/releases)
 [![Kotlin Multiplatform](https://img.shields.io/badge/Kotlin-Multiplatform-blueviolet?logo=kotlin)](https://kotlinlang.org/docs/multiplatform.html)
 [![Maven Central](https://img.shields.io/maven-central/v/com.soneso.stellar/stellar-sdk)](https://search.maven.org/artifact/com.soneso.stellar/stellar-sdk)
 [![codecov](https://codecov.io/gh/Soneso/kmp-stellar-sdk/branch/main/graph/badge.svg)](https://codecov.io/gh/Soneso/kmp-stellar-sdk)
@@ -73,7 +73,7 @@ Add the SDK as a Maven dependency (recommended for most projects):
 ```kotlin
 // In your module's build.gradle.kts
 dependencies {
-    implementation("com.soneso.stellar:stellar-sdk:1.3.0")
+    implementation("com.soneso.stellar:stellar-sdk:1.3.1")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 
 allprojects {
     group = "com.soneso.stellar"
-    version = "1.3.0"
+    version = "1.3.1"
 
     repositories {
         mavenLocal()  // For testing locally published artifacts

--- a/compatibility/horizon/HORIZON_COMPATIBILITY_MATRIX.md
+++ b/compatibility/horizon/HORIZON_COMPATIBILITY_MATRIX.md
@@ -1,8 +1,8 @@
 # Horizon API vs KMP Stellar SDK Compatibility Matrix
 
-**Generated:** 2026-02-14 20:31:45
+**Generated:** 2026-04-03 17:48:30
 
-**SDK Version:** 1.3.0
+**SDK Version:** 1.3.1
 
 **Horizon Endpoints Discovered:** 52
 **Public API Endpoints (in matrix):** 50

--- a/compatibility/rpc/RPC_COMPATIBILITY_MATRIX.md
+++ b/compatibility/rpc/RPC_COMPATIBILITY_MATRIX.md
@@ -1,8 +1,8 @@
 # Soroban RPC vs KMP Stellar SDK Compatibility Matrix
 
-**Generated:** 2026-02-14 20:31:48
+**Generated:** 2026-04-03 17:48:31
 
-**SDK Version:** 1.3.0
+**SDK Version:** 1.3.1
 
 ## Overall Coverage
 

--- a/compatibility/sep/SEP-0001_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0001_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0001 (Stellar Info File) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 2.7.0<br>
 **SEP Status:** Active<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
 
 ## SEP Summary

--- a/compatibility/sep/SEP-0002_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0002_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0002 (Federation protocol) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 1.1.0<br>
 **SEP Status:** Final<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0002.md
 
 ## SEP Summary

--- a/compatibility/sep/SEP-0005_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0005_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0005 (Key Derivation Methods for Stellar Keys) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** N/A<br>
 **SEP Status:** Final<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0005.md
 
 ## SEP Summary

--- a/compatibility/sep/SEP-0006_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0006_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0006 (Deposit and Withdrawal API) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 4.3.0<br>
 **SEP Status:** Active (Interactive components are deprecated in favor of SEP-24)<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md
 
 ## SEP Summary
@@ -13,10 +13,10 @@ A programmatic API for anchors and wallets to handle deposits and withdrawals wi
 
 ## Overall Coverage
 
-**Total Coverage:** 100.0% (72/72 fields)
+**Total Coverage:** 100.0% (73/73 fields)
 
-- ✅ **Implemented:** 72/72
-- ❌ **Not Implemented:** 0/72
+- ✅ **Implemented:** 73/73
+- ❌ **Not Implemented:** 0/73
 - **Required Fields:** 100.0% (4/4)
 
 ## Implementation Status
@@ -101,7 +101,7 @@ A programmatic API for anchors and wallets to handle deposits and withdrawals wi
 | Deposit | 100.0% | 1/1 | 16 | 16 |
 | Deposit Exchange | 100.0% | 1/1 | 18 | 18 |
 | Info | 100.0% | N/A | 1 | 1 |
-| Withdraw | 100.0% | 1/1 | 17 | 17 |
+| Withdraw | 100.0% | 1/1 | 18 | 18 |
 | Withdraw Exchange | 100.0% | 1/1 | 20 | 20 |
 
 ## Detailed Field Comparison
@@ -163,6 +163,7 @@ A programmatic API for anchors and wallets to handle deposits and withdrawals wi
 | `asset_code` |  | ✅ | `assetCode` | Code of the on-chain asset the user wants to withdraw. The value passed must match one of the cod... |
 | `funding_method` | ✓ | ✅ | `fundingMethod` | A method supported by the Anchor for transferring or settling assets. Must match one of the value... |
 | `account` |  | ✅ | `account` | (optional) The classic account, muxed account, or contract account that the client will use as th... |
+| `memo` |  | ✅ | `memo` | (optional) This field should only be used if SEP-10 or SEP-45 authentication is not. It was origi... |
 | `lang` |  | ✅ | `lang` | (optional) Defaults to `en` if not specified or if the specified language is not supported. Langu... |
 | `on_change_callback` |  | ✅ | `onChangeCallback` | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of th... |
 | `amount` |  | ✅ | `amount` | (optional) The amount of the asset the user would like to withdraw. This field may be necessary f... |

--- a/compatibility/sep/SEP-0008_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0008_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0008 (Regulated Assets) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 1.7.4<br>
 **SEP Status:** Active<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md
 
 ## SEP Summary

--- a/compatibility/sep/SEP-0009_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0009_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0009 (Standard KYC Fields) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 1.17.0<br>
 **SEP Status:** Active<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0009.md
 
 ## SEP Summary

--- a/compatibility/sep/SEP-0010_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0010_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0010 (Stellar Web Authentication) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 3.4.1<br>
 **SEP Status:** Active<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md
 
 ## SEP Summary

--- a/compatibility/sep/SEP-0012_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0012_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0012 (KYC API) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 1.15.0<br>
 **SEP Status:** Active<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md
 
 ## SEP Summary

--- a/compatibility/sep/SEP-0024_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0024_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0024 (Hosted Deposit and Withdrawal) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 3.8.0<br>
 **SEP Status:** Active<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md
 
 ## SEP Summary

--- a/compatibility/sep/SEP-0030_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0030_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0030 (Account Recovery: multi-party recovery of Stellar accounts) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 0.8.1<br>
 **SEP Status:** Draft<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0030.md
 
 ## SEP Summary

--- a/compatibility/sep/SEP-0038_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0038_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0038 (Anchor RFQ API) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 2.5.0<br>
 **SEP Status:** Draft<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md
 
 ## SEP Summary

--- a/compatibility/sep/SEP-0045_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0045_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0045 (Stellar Web Authentication for Contract Accounts) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 0.1.1<br>
 **SEP Status:** Draft<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md
 
 ## SEP Summary

--- a/compatibility/sep/SEP-0053_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0053_COMPATIBILITY_MATRIX.md
@@ -1,10 +1,10 @@
 # SEP-0053 (Sign and Verify Messages) Compatibility Matrix
 
-**Generated:** 2026-02-14 20:32:36
+**Generated:** 2026-04-03 17:48:35
 
 **SEP Version:** 0.0.1<br>
 **SEP Status:** Draft<br>
-**SDK Version:** 1.3.0<br>
+**SDK Version:** 1.3.1<br>
 **SEP URL:** https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0053.md
 
 ## SEP Summary

--- a/demo/CLAUDE.md
+++ b/demo/CLAUDE.md
@@ -17,7 +17,7 @@ The demo app's **primary purpose** is to showcase SDK functionality for develope
 - Native Swift interop in macOS app (requires `export(project(":stellar-sdk"))`)
 - Direct framework access for educational purposes
 
-**Most external developers should use Maven artifacts** (`implementation("com.soneso.stellar:stellar-sdk:1.3.0")`):
+**Most external developers should use Maven artifacts** (`implementation("com.soneso.stellar:stellar-sdk:1.3.1")`):
 - Works perfectly for Compose Multiplatform apps (Android, iOS, Desktop, Web)
 - Standard KMP apps where SDK calls happen in Kotlin
 - Simpler dependency management

--- a/demo/README.md
+++ b/demo/README.md
@@ -6,7 +6,7 @@ A comprehensive Kotlin Multiplatform demo application showcasing the Stellar SDK
 
 This demo app demonstrates real-world usage of the Stellar SDK, including key generation, account management, payments, trustlines, and smart contract interactions. The demo's primary purpose is to showcase SDK functionality for developers learning how to use the SDK. The app follows a modern KMP architecture with shared business logic and platform-specific UIs.
 
-**Note for External Developers**: This demo uses project dependencies (`api(project(":stellar-sdk"))`) to showcase advanced native Swift interop in the macOS app. Most developers should use Maven artifacts (`implementation("com.soneso.stellar:stellar-sdk:1.3.0")`) which work perfectly for Compose Multiplatform and standard KMP apps. See [docs/platforms/](../docs/platforms/) for platform-specific setup instructions.
+**Note for External Developers**: This demo uses project dependencies (`api(project(":stellar-sdk"))`) to showcase advanced native Swift interop in the macOS app. Most developers should use Maven artifacts (`implementation("com.soneso.stellar:stellar-sdk:1.3.1")`) which work perfectly for Compose Multiplatform and standard KMP apps. See [docs/platforms/](../docs/platforms/) for platform-specific setup instructions.
 
 ## Screenshots
 

--- a/demo/macosApp/StellarDemo/Components/StellarTextField.swift
+++ b/demo/macosApp/StellarDemo/Components/StellarTextField.swift
@@ -62,7 +62,7 @@ import SwiftUI
 ///     placeholder: "USD, EUR, etc.",
 ///     text: $assetCode,
 ///     error: validationErrors["assetCode"],
-///     helpText: "1-12 uppercase alphanumeric characters"
+///     helpText: "1-12 alphanumeric characters"
 /// )
 /// ```
 struct StellarTextField: View {
@@ -258,7 +258,7 @@ struct StellarTextField_Previews: PreviewProvider {
                 label: "Asset Code",
                 placeholder: "USD, EUR, etc.",
                 text: .constant("USDC"),
-                helpText: "1-12 uppercase alphanumeric characters"
+                helpText: "1-12 alphanumeric characters"
             )
 
             // Secure text field with visibility toggle

--- a/demo/macosApp/StellarDemo/Utilities/FormValidation.swift
+++ b/demo/macosApp/StellarDemo/Utilities/FormValidation.swift
@@ -32,8 +32,8 @@ import Foundation
 ///
 /// ## Asset Codes
 ///
-/// Asset codes can be 1-12 characters long and must contain only uppercase letters (A-Z)
-/// and digits (0-9). Common examples: `USD`, `USDC`, `BTC`, `EURT`, `MYTOKEN`.
+/// Asset codes can be 1-12 alphanumeric characters (a-z, A-Z, 0-9).
+/// Common examples: `USD`, `USDC`, `BTC`, `yUSDC`, `yETH`.
 struct FormValidation {
 
     /// Validates an account ID field for UI display.
@@ -172,7 +172,7 @@ struct FormValidation {
     ///
     /// Asset codes identify issued assets (tokens) on the Stellar network. They must:
     /// - Be between 1 and 12 characters long
-    /// - Contain only uppercase letters (A-Z) and digits (0-9)
+    /// - Contain only alphanumeric characters (a-z, A-Z, 0-9)
     /// - Not be empty or blank
     ///
     /// Common examples:
@@ -288,13 +288,13 @@ struct FormValidation {
         if assetCode.count > 12 {
             return "Asset code cannot exceed 12 characters (got: \(assetCode.count))"
         }
-        // Validate asset code contains only alphanumeric characters (A-Z, 0-9)
-        let validCharacterSet = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+        // Validate asset code contains only alphanumeric characters (a-z, A-Z, 0-9)
+        let validCharacterSet = CharacterSet.alphanumerics
         if assetCode.rangeOfCharacter(from: validCharacterSet.inverted) != nil {
             let invalidChars = assetCode.filter { char in
                 !validCharacterSet.contains(char.unicodeScalars.first!)
             }
-            return "Asset code must contain only uppercase letters and digits. Invalid characters: '\(invalidChars)'"
+            return "Asset code must contain only alphanumeric characters (a-z, A-Z, 0-9). Invalid characters: '\(invalidChars)'"
         }
         return nil
     }

--- a/demo/macosApp/StellarDemo/Views/SendPaymentView.swift
+++ b/demo/macosApp/StellarDemo/Views/SendPaymentView.swift
@@ -152,7 +152,7 @@ struct SendPaymentScreen: View {
                     placeholder: "USD, EUR, USDC, etc.",
                     text: Binding(
                         get: { assetCode },
-                        set: { assetCode = $0.uppercased().trimmingCharacters(in: .whitespaces) }
+                        set: { assetCode = $0.trimmingCharacters(in: .whitespaces) }
                     ),
                     error: validationErrors["assetCode"]
                 )

--- a/demo/macosApp/StellarDemo/Views/TrustAssetView.swift
+++ b/demo/macosApp/StellarDemo/Views/TrustAssetView.swift
@@ -106,7 +106,7 @@ struct TrustAssetScreen: View {
                 label: "Asset Code",
                 placeholder: "USD, EUR, etc.",
                 text: $assetCode,
-                helpText: "1-12 uppercase alphanumeric characters"
+                helpText: "1-12 alphanumeric characters"
             )
             .onChange(of: assetCode) { _ in
                 validationError = nil
@@ -211,7 +211,7 @@ struct TrustAssetScreen: View {
                     .font(.system(size: 13))
                     .foregroundStyle(Material3Colors.onSecondaryContainer)
 
-                Text("• Asset code must be 1-12 uppercase alphanumeric characters")
+                Text("• Asset code must be 1-12 alphanumeric characters (a-z, A-Z, 0-9)")
                     .font(.system(size: 13))
                     .foregroundStyle(Material3Colors.onSecondaryContainer)
 

--- a/demo/shared/build.gradle.kts
+++ b/demo/shared/build.gradle.kts
@@ -113,7 +113,7 @@ kotlin {
                 api(project(":stellar-sdk"))
 
                 // Users consuming from Maven should use:
-                // api("com.soneso.stellar:stellar-sdk:1.3.0")
+                // api("com.soneso.stellar:stellar-sdk:1.3.1")
 
                 // ============================================================
                 // Coroutines

--- a/demo/shared/src/commonMain/kotlin/com/soneso/demo/stellar/TrustAsset.kt
+++ b/demo/shared/src/commonMain/kotlin/com/soneso/demo/stellar/TrustAsset.kt
@@ -77,7 +77,7 @@ sealed class TrustAssetResult {
  * - The account must have enough XLM to meet the base reserve requirement (0.5 XLM per trustline)
  * - Setting the limit to "0" removes the trustline (account must have zero balance of that asset)
  * - The maximum limit is approximately 922 trillion (922337203685.4775807)
- * - Asset codes must be 1-12 alphanumeric characters (uppercase letters and digits only)
+ * - Asset codes must be 1-12 alphanumeric characters (a-z, A-Z, 0-9)
  * - Both the account and issuer must be valid Stellar account IDs (G... addresses)
  *
  * @param accountId The account ID that will trust the asset (must start with 'G')

--- a/demo/shared/src/commonMain/kotlin/com/soneso/demo/ui/screens/SendPaymentScreen.kt
+++ b/demo/shared/src/commonMain/kotlin/com/soneso/demo/ui/screens/SendPaymentScreen.kt
@@ -355,7 +355,7 @@ class SendPaymentScreen : Screen {
                             OutlinedTextField(
                                 value = assetCode,
                                 onValueChange = {
-                                    assetCode = it.uppercase().trim()
+                                    assetCode = it.trim()
                                     validationErrors = validationErrors - "assetCode"
                                     paymentResult = null
                                 },

--- a/demo/shared/src/commonMain/kotlin/com/soneso/demo/ui/screens/TrustAssetScreen.kt
+++ b/demo/shared/src/commonMain/kotlin/com/soneso/demo/ui/screens/TrustAssetScreen.kt
@@ -230,8 +230,7 @@ class TrustAssetScreen : Screen {
                     OutlinedTextField(
                         value = assetCode,
                         onValueChange = {
-                            // Auto-uppercase for asset codes
-                            assetCode = it.uppercase().trim()
+                            assetCode = it.trim()
                             validationErrors = validationErrors - "assetCode"
                             trustResult = null
                         },
@@ -646,7 +645,7 @@ private fun TrustAssetErrorCard(error: TrustAssetResult.Error) {
                 TroubleshootingItem("Ensure the account has been funded (at least 0.5 XLM for reserve)")
                 TroubleshootingItem("Check that the secret seed matches the account ID")
                 TroubleshootingItem("Verify the asset issuer account exists on the network")
-                TroubleshootingItem("Asset codes must be uppercase letters and digits only")
+                TroubleshootingItem("Asset codes must be alphanumeric characters only (a-z, A-Z, 0-9)")
             }
                 }
         }

--- a/demo/shared/src/commonMain/kotlin/com/soneso/demo/util/ValidationUtil.kt
+++ b/demo/shared/src/commonMain/kotlin/com/soneso/demo/util/ValidationUtil.kt
@@ -33,8 +33,8 @@ package com.soneso.demo.util
  *
  * ## Asset Codes
  *
- * Asset codes can be 1-12 characters long and must contain only uppercase letters (A-Z)
- * and digits (0-9). Common examples: `USD`, `USDC`, `BTC`, `EURT`, `MYTOKEN`.
+ * Asset codes can be 1-12 alphanumeric characters (a-z, A-Z, 0-9).
+ * Common examples: `USD`, `USDC`, `BTC`, `yUSDC`, `yETH`.
  *
  * @see <a href="https://developers.stellar.org/docs/learn/encyclopedia/data-format/strkey">StrKey Encoding</a>
  * @see <a href="https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/accounts">Stellar Accounts</a>
@@ -189,7 +189,7 @@ object StellarValidation {
      *
      * Asset codes identify issued assets (tokens) on the Stellar network. They must:
      * - Be between 1 and 12 characters long
-     * - Contain only uppercase letters (A-Z) and digits (0-9)
+     * - Contain only alphanumeric characters (a-z, A-Z, 0-9)
      * - Not be empty or blank
      *
      * Common examples:
@@ -219,17 +219,8 @@ object StellarValidation {
         return when {
             assetCode.isBlank() -> "Asset code cannot be empty"
             assetCode.length > 12 -> "Asset code cannot exceed 12 characters (got: ${assetCode.length})"
-            else -> {
-                // Validate asset code contains only alphanumeric characters
-                val invalidChars = assetCode.filter { char ->
-                    char !in 'A'..'Z' && char !in '0'..'9'
-                }
-                if (invalidChars.isNotEmpty()) {
-                    "Asset code must contain only uppercase letters and digits. Invalid characters: '$invalidChars'"
-                } else {
-                    null
-                }
-            }
+            !Regex("^[a-zA-Z0-9]+$").matches(assetCode) -> "Asset code must contain only alphanumeric characters (a-z, A-Z, 0-9)"
+            else -> null
         }
     }
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ Add the SDK as a Maven dependency (recommended for most projects):
 ```kotlin
 // In your module's build.gradle.kts
 dependencies {
-    implementation("com.soneso.stellar:stellar-sdk:1.3.0")
+    implementation("com.soneso.stellar:stellar-sdk:1.3.1")
 }
 ```
 
@@ -41,7 +41,7 @@ includeBuild("/path/to/kmp-stellar-sdk")
 
 // In your module's build.gradle.kts
 dependencies {
-    implementation("com.soneso.stellar:stellar-sdk:1.3.0")
+    implementation("com.soneso.stellar:stellar-sdk:1.3.1")
 }
 ```
 
@@ -115,7 +115,7 @@ targets: [
 
 ```kotlin
 dependencies {
-    implementation("com.soneso.stellar:stellar-sdk:1.3.0")
+    implementation("com.soneso.stellar:stellar-sdk:1.3.1")
 }
 ```
 

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -46,7 +46,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("com.soneso.stellar:stellar-sdk:1.3.0")
+                implementation("com.soneso.stellar:stellar-sdk:1.3.1")
                 implementation(compose.runtime)
                 implementation(compose.material3)
             }

--- a/docs/platforms/javascript.md
+++ b/docs/platforms/javascript.md
@@ -46,7 +46,7 @@ kotlin {
     sourceSets {
         val jsMain by getting {
             dependencies {
-                implementation("com.soneso.stellar:stellar-sdk:1.3.0")
+                implementation("com.soneso.stellar:stellar-sdk:1.3.1")
 
                 // Optional: UI frameworks
                 implementation("org.jetbrains.kotlinx:kotlinx-html:0.9.1")

--- a/docs/platforms/jvm.md
+++ b/docs/platforms/jvm.md
@@ -53,7 +53,7 @@ android {
 }
 
 dependencies {
-    implementation("com.soneso.stellar:stellar-sdk:1.3.0")
+    implementation("com.soneso.stellar:stellar-sdk:1.3.1")
 
     // Android-specific
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
@@ -115,7 +115,7 @@ kotlin {
 }
 
 dependencies {
-    implementation("com.soneso.stellar:stellar-sdk:1.3.0")
+    implementation("com.soneso.stellar:stellar-sdk:1.3.1")
 
     // Server frameworks (optional)
     implementation("io.ktor:ktor-server-netty:2.3.8")

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         val desktopMain by getting {
             dependencies {
-                implementation("com.soneso.stellar:stellar-sdk:1.3.0")
+                implementation("com.soneso.stellar:stellar-sdk:1.3.1")
                 implementation(compose.desktop.currentOs)
             }
         }

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -16,7 +16,7 @@ Add the SDK to your Gradle project:
 ```kotlin
 // In your module's build.gradle.kts
 dependencies {
-    implementation("com.soneso.stellar:stellar-sdk:1.3.0")
+    implementation("com.soneso.stellar:stellar-sdk:1.3.1")
 }
 ```
 

--- a/docs/sdk-usage-examples.md
+++ b/docs/sdk-usage-examples.md
@@ -1691,7 +1691,7 @@ val asset = Asset.create("USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE3
 
 // Get canonical representation
 println(usdc.toString())  // "USDC:GA5Z..."
-// Asset codes: 1-12 uppercase A-Z characters or digits 0-9
+// Asset codes: 1-12 alphanumeric characters (a-z, A-Z, 0-9)
 
 // Check asset type
 when (asset) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,10 @@ kotlin.apple.xcodeCompatibility.nowarn=true
 kotlin.mpp.enableCInteropCommonization=true
 
 # SDK Version
-version=1.3.0
+version=1.3.1
 
 # Demo App Version
-demo.version=1.3.0
+demo.version=1.3.1
 
 # Android
 android.useAndroidX=true

--- a/releases/RELEASE_NOTES_1.3.1.md
+++ b/releases/RELEASE_NOTES_1.3.1.md
@@ -1,0 +1,33 @@
+# Release Notes - Version 1.3.1
+
+## Overview
+
+Version 1.3.1 is a hotfix release that corrects asset code validation to allow lowercase letters.
+
+## Fixed
+
+### Asset Code Validation
+
+Asset code validation was rejecting lowercase letters (a-z), preventing interaction with real mainnet assets that use lowercase characters (e.g., yUSDC, yETH). Validation now accepts both uppercase and lowercase letters, matching the behavior of the JS and Python Stellar SDKs.
+
+See [#14](https://github.com/Soneso/kmp-stellar-sdk/issues/14) for details.
+
+## Platform Support
+
+All platforms fully supported (unchanged from 1.3.0):
+- JVM (Android API 24+, Server Java 17+)
+- iOS (iOS 14.0+)
+- macOS (macOS 11.0+)
+- JavaScript (Browser and Node.js 14+)
+
+## Installation
+
+```kotlin
+dependencies {
+    implementation("com.soneso.stellar:stellar-sdk:1.3.1")
+}
+```
+
+---
+
+**Full Changelog**: https://github.com/Soneso/kmp-stellar-sdk/compare/v1.3.0...v1.3.1

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Asset.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Asset.kt
@@ -245,12 +245,8 @@ data object AssetTypeNative : Asset() {
  *
  * This sealed class represents assets that are issued by an account on the Stellar network.
  * All issued assets have:
- * - A code (1-12 alphanumeric characters)
+ * - A code (1-12 alphanumeric characters: a-z, A-Z, 0-9)
  * - An issuer (the account that created the asset)
- *
- * Asset codes must contain only:
- * - Uppercase letters (A-Z)
- * - Digits (0-9)
  *
  * The issuer must be a valid ed25519 public key (G... address).
  *
@@ -286,23 +282,15 @@ sealed class AssetTypeCreditAlphaNum : Asset() {
     }
 
     /**
-     * Validates that an asset code contains only valid characters.
-     *
-     * Valid characters are:
-     * - Uppercase letters (A-Z)
-     * - Digits (0-9)
+     * Validates that an asset code contains only alphanumeric characters (a-z, A-Z, 0-9).
+     * Matches the validation used by the JS and Python Stellar SDKs.
      *
      * @throws IllegalArgumentException if the code contains invalid characters
      */
     protected fun validateAssetCode(code: String) {
-        val invalidChars = code.filter { char ->
-            char !in 'A'..'Z' && char !in '0'..'9'
-        }
-
-        if (invalidChars.isNotEmpty()) {
+        if (!Regex("^[a-zA-Z0-9]+$").matches(code)) {
             throw IllegalArgumentException(
-                "Asset code '$code' contains invalid characters: '${invalidChars}'. " +
-                "Asset codes must contain only uppercase letters (A-Z) and digits (0-9)"
+                "Asset code is invalid (maximum alphanumeric, 12 characters at max)"
             )
         }
     }
@@ -342,8 +330,7 @@ sealed class AssetTypeCreditAlphaNum : Asset() {
  * This class is used for assets with short codes like "USD", "EUR", "BTC", etc.
  *
  * ## Validation
- * - Code length must be 1-4 characters
- * - Code must contain only uppercase letters (A-Z) and digits (0-9)
+ * - Code must be 1-4 alphanumeric characters (a-z, A-Z, 0-9)
  * - Issuer must be a valid ed25519 public key (G... address)
  *
  * ## Usage
@@ -411,8 +398,7 @@ class AssetTypeCreditAlphaNum4(
  * This class is used for assets with longer codes that don't fit in AlphaNum4.
  *
  * ## Validation
- * - Code length must be 5-12 characters
- * - Code must contain only uppercase letters (A-Z) and digits (0-9)
+ * - Code must be 5-12 alphanumeric characters (a-z, A-Z, 0-9)
  * - Issuer must be a valid ed25519 public key (G... address)
  *
  * ## Usage

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Util.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Util.kt
@@ -23,7 +23,7 @@ object Util {
      * @return The SDK version string (e.g., "1.0.0")
      */
     fun getSdkVersion(): String {
-        return "1.3.0"
+        return "1.3.1"
     }
 
     /**

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep38/exceptions/Sep38BadRequestException.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/sep/sep38/exceptions/Sep38BadRequestException.kt
@@ -55,7 +55,7 @@ package com.soneso.stellar.sdk.sep.sep38.exceptions
  * ```kotlin
  * fun validateQuoteRequest(request: Sep38PostQuoteRequest): String? {
  *     // Check asset format
- *     val assetPattern = Regex("^(stellar:[A-Z0-9]{1,12}:[A-Z0-9]{56}|iso4217:[A-Z]{3})$")
+ *     val assetPattern = Regex("^(stellar:[a-zA-Z0-9]{1,12}:[A-Z0-9]{56}|iso4217:[A-Z]{3})$")
  *     if (!request.sellAsset.matches(assetPattern)) {
  *         return "Invalid sellAsset format: ${request.sellAsset}"
  *     }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/AssetTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/AssetTest.kt
@@ -92,10 +92,16 @@ class AssetTest {
         assertDoesNotThrow { AssetTypeCreditAlphaNum4("A1B2", testIssuer) }
         assertDoesNotThrow { AssetTypeCreditAlphaNum12("ASSET123", testIssuer) }
 
-        // Invalid codes with lowercase letters
-        assertFailsWith<IllegalArgumentException> {
-            AssetTypeCreditAlphaNum4("usd", testIssuer)
-        }
+        // Valid codes with lowercase letters (issue #14)
+        assertDoesNotThrow { AssetTypeCreditAlphaNum4("usd", testIssuer) }
+        assertDoesNotThrow { AssetTypeCreditAlphaNum4("yBTC", testIssuer) }
+        assertDoesNotThrow { AssetTypeCreditAlphaNum4("yETH", testIssuer) }
+        assertDoesNotThrow { AssetTypeCreditAlphaNum12("yUSDC", testIssuer) }
+        assertDoesNotThrow { AssetTypeCreditAlphaNum12("yUSDC12345", testIssuer) }
+
+        // Valid codes with digits only
+        assertDoesNotThrow { AssetTypeCreditAlphaNum4("1234", testIssuer) }
+        assertDoesNotThrow { AssetTypeCreditAlphaNum12("12345", testIssuer) }
 
         // Invalid codes with special characters
         assertFailsWith<IllegalArgumentException> {
@@ -106,6 +112,17 @@ class AssetTest {
         }
         assertFailsWith<IllegalArgumentException> {
             AssetTypeCreditAlphaNum4("US D", testIssuer)
+        }
+
+        // Invalid: empty or wrong length
+        assertFailsWith<IllegalArgumentException> {
+            AssetTypeCreditAlphaNum4("", testIssuer)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            AssetTypeCreditAlphaNum4("TOOLONG", testIssuer)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            AssetTypeCreditAlphaNum12("ABCD", testIssuer)
         }
     }
 
@@ -407,6 +424,23 @@ class AssetTest {
         val xdr2 = asset2.toXdr()
         val restored2 = Asset.fromXdr(xdr2)
         assertEquals(asset2, restored2)
+    }
+
+    @Test
+    fun testXdrRoundTripLowercaseAssetCodes() {
+        // AlphaNum4 with lowercase (issue #14)
+        val yETH = AssetTypeCreditAlphaNum4("yETH", testIssuer)
+        val xdr1 = yETH.toXdr()
+        val restored1 = Asset.fromXdr(xdr1)
+        assertEquals(yETH, restored1)
+        assertEquals("yETH", (restored1 as AssetTypeCreditAlphaNum4).code)
+
+        // AlphaNum12 with lowercase
+        val yUSDC = AssetTypeCreditAlphaNum12("yUSDC", testIssuer)
+        val xdr2 = yUSDC.toXdr()
+        val restored2 = Asset.fromXdr(xdr2)
+        assertEquals(yUSDC, restored2)
+        assertEquals("yUSDC", (restored2 as AssetTypeCreditAlphaNum12).code)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Merge the v1.3.1 hotfix into main. This brings the asset code validation fix and version updates from the hotfix branch.

- Fix asset code validation to accept alphanumeric characters (a-z, A-Z, 0-9), matching JS and Python Stellar SDKs
- Remove auto-uppercase transformations from demo app input fields
- Update documentation and compatibility matrices to v1.3.1

Fixes #14