### PR TITLE
Smart accounts: add WebAuthn hybrid transport for cross-device passkey authentication

### DIFF
--- a/docs/smart-accounts/api-reference.md
+++ b/docs/smart-accounts/api-reference.md
@@ -3348,7 +3348,7 @@ interface WebAuthnProvider {
 
     suspend fun authenticate(
         challenge: ByteArray,
-        allowCredentialIds: List<ByteArray>? = null
+        allowCredentials: List<AllowCredential>? = null
     ): WebAuthnAuthenticationResult
 }
 
@@ -3368,6 +3368,40 @@ data class WebAuthnAuthenticationResult(
     val signature: ByteArray
 )
 ```
+
+**`authenticate` parameters**:
+- `challenge`: The challenge bytes to sign (authorization payload hash, 32 bytes).
+- `allowCredentials`: Optional list of `AllowCredential` descriptors. Constrains which passkeys the authenticator offers and indicates how the client can reach the authenticator. When null, discoverable credential selection is used. Including transport hints (e.g., `"hybrid"`) enables cross-device authentication flows such as QR code scanning.
+
+> **Breaking change (1.4.0)**: The `authenticate()` parameter was renamed from `allowCredentialIds: List<ByteArray>?` to `allowCredentials: List<AllowCredential>?`. Use `AllowCredential.fromIds()` to migrate existing `List<ByteArray>` values.
+
+---
+
+### AllowCredential
+
+A credential descriptor pairing a credential ID with optional transport hints. Used in `WebAuthnProvider.authenticate()` to constrain which passkeys the authenticator offers and to indicate how the client can reach the authenticator.
+
+```kotlin
+data class AllowCredential(
+    val id: ByteArray,
+    val transports: List<String>? = null
+) {
+    companion object {
+        fun fromId(id: ByteArray): AllowCredential
+        fun fromIds(ids: List<ByteArray>): List<AllowCredential>
+    }
+}
+```
+
+**Properties**:
+- `id`: The raw credential ID bytes.
+- `transports`: Optional list of transport hints. Recognized values include `"internal"`, `"hybrid"`, `"usb"`, `"ble"`, and `"nfc"`. When null, the authenticator uses its default transport selection. Unknown transport strings are passed through without validation.
+
+**Equality**: `equals()` and `hashCode()` use `contentEquals` / `contentHashCode` for the `id` byte array, ensuring correct comparison and collection behavior.
+
+**Factory methods**:
+- `AllowCredential.fromId(id)`: Creates an `AllowCredential` from a raw credential ID with no transport hints.
+- `AllowCredential.fromIds(ids)`: Creates a list of `AllowCredential` from raw credential IDs with no transport hints. Useful for migrating code that previously used `List<ByteArray>`.
 
 ---
 

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/flows/ContextRuleEditTypes.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/flows/ContextRuleEditTypes.kt
@@ -172,7 +172,8 @@ data class ContextRuleEditResult(
  * @param signers Selected signers from the signer picker dialog.
  * @return Mapped list of [SelectedSigner] ready for multi-signer operations.
  */
-fun buildSelectedSigners(signers: List<SmartAccountSigner>): List<SelectedSigner> {
+suspend fun buildSelectedSigners(signers: List<SmartAccountSigner>): List<SelectedSigner> {
+    val storage = DemoState.storage
     val result = mutableListOf<SelectedSigner>()
     for (signer in signers) {
         when (signer) {
@@ -180,11 +181,17 @@ fun buildSelectedSigners(signers: List<SmartAccountSigner>): List<SelectedSigner
                 val credIdStr = SmartAccountBuilders.getCredentialIdStringFromSigner(signer)
                 val credIdBytes = SmartAccountBuilders.getCredentialIdFromSigner(signer)
                 if (credIdStr != null) {
+                    // Look up stored credential for transport hints (enables cross-device auth).
+                    // Null transports is the correct fallback for credentials not in local storage.
+                    val transports = try {
+                        storage?.get(credIdStr)?.transports
+                    } catch (_: Exception) { null }
                     result.add(
                         SelectedSigner.Passkey(
                             credentialId = credIdStr,
                             credentialIdBytes = credIdBytes,
-                            keyData = signer.keyData
+                            keyData = signer.keyData,
+                            transports = transports
                         )
                     )
                 }

--- a/stellar-sdk/src/androidMain/kotlin/com/soneso/stellar/sdk/smartaccount/AndroidWebAuthnProvider.kt
+++ b/stellar-sdk/src/androidMain/kotlin/com/soneso/stellar/sdk/smartaccount/AndroidWebAuthnProvider.kt
@@ -26,6 +26,7 @@ import com.soneso.stellar.sdk.smartaccount.oz.OZConstants
 import com.soneso.stellar.sdk.smartaccount.core.WebAuthnException
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnAuthenticationResult
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnProvider
+import com.soneso.stellar.sdk.smartaccount.oz.AllowCredential
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnRegistrationResult
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -169,6 +170,9 @@ class AndroidWebAuthnProvider(
      *
      * @param challenge The challenge bytes to sign (authorization payload hash, typically
      *   32 bytes). Used as-is in the WebAuthn ceremony.
+     * @param allowCredentials Optional list of [AllowCredential] entries (credential ID plus
+     *   optional transport hints) to constrain the authenticator to specific credentials.
+     *   When null or empty, discoverable credential selection is used.
      * @return [WebAuthnAuthenticationResult] containing the credential ID, authenticator
      *   data, client data JSON, and DER-encoded ECDSA signature.
      * @throws WebAuthnException.Cancelled if the user cancels the authentication dialog.
@@ -177,9 +181,9 @@ class AndroidWebAuthnProvider(
      */
     override suspend fun authenticate(
         challenge: ByteArray,
-        allowCredentialIds: List<ByteArray>?
+        allowCredentials: List<AllowCredential>?
     ): WebAuthnAuthenticationResult {
-        val requestJson = buildAuthenticationRequestJson(challenge, allowCredentialIds)
+        val requestJson = buildAuthenticationRequestJson(challenge, allowCredentials)
 
         val getRequest = GetCredentialRequest(
             credentialOptions = listOf(
@@ -293,27 +297,39 @@ class AndroidWebAuthnProvider(
      * Builds the PublicKeyCredentialRequestOptions JSON for an authentication ceremony.
      *
      * Constructs a JSON string conforming to the WebAuthn specification's
-     * `PublicKeyCredentialRequestOptions` dictionary. When [allowCredentialIds] is
+     * `PublicKeyCredentialRequestOptions` dictionary. When [allowCredentials] is
      * provided, the `allowCredentials` array constrains the authenticator to only
-     * the specified credentials. When null or empty, discoverable credential selection
-     * is used (the user picks which passkey to use).
+     * the specified credentials and includes transport hints where available. When null
+     * or empty, discoverable credential selection is used (the user picks which passkey
+     * to use).
      *
      * @param challenge The challenge bytes (base64url encoded in the JSON)
-     * @param allowCredentialIds Optional list of credential ID bytes to constrain selection
+     * @param allowCredentials Optional list of [AllowCredential] entries to constrain selection.
+     *   Each entry carries a credential ID and optional transport hints (e.g. "internal",
+     *   "hybrid"). When an entry's transports list is non-null it is included in the JSON;
+     *   when null the transports field is omitted for that entry.
      * @return JSON string for the authentication request
      */
     private fun buildAuthenticationRequestJson(
         challenge: ByteArray,
-        allowCredentialIds: List<ByteArray>? = null
+        allowCredentials: List<AllowCredential>? = null
     ): String {
         val challengeB64 = base64UrlEncode(challenge)
 
-        val allowCredentials = if (!allowCredentialIds.isNullOrEmpty()) {
-            JsonArray(allowCredentialIds.map { credId ->
-                JsonObject(mapOf(
-                    "type" to JsonPrimitive("public-key"),
-                    "id" to JsonPrimitive(base64UrlEncode(credId))
-                ))
+        val allowCredentialsJson = if (!allowCredentials.isNullOrEmpty()) {
+            JsonArray(allowCredentials.map { cred ->
+                JsonObject(
+                    buildMap {
+                        put("type", JsonPrimitive("public-key"))
+                        put("id", JsonPrimitive(base64UrlEncode(cred.id)))
+                        if (cred.transports != null) {
+                            put(
+                                "transports",
+                                JsonArray(cred.transports.map { JsonPrimitive(it) })
+                            )
+                        }
+                    }
+                )
             })
         } else {
             JsonArray(emptyList())
@@ -325,7 +341,7 @@ class AndroidWebAuthnProvider(
                 "rpId" to JsonPrimitive(rpId),
                 "timeout" to JsonPrimitive(timeout),
                 "userVerification" to JsonPrimitive("required"),
-                "allowCredentials" to allowCredentials
+                "allowCredentials" to allowCredentialsJson
             )
         )
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZMultiSignerManager.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZMultiSignerManager.kt
@@ -55,11 +55,14 @@ sealed class SelectedSigner {
      * @property keyData Full key data (secp256r1 public key + credentialId bytes) for this
      *   passkey signer. When provided, the SDK uses it directly without an on-chain lookup.
      *   Must be supplied by the caller from the signer data already available client-side.
+     * @property transports Optional transport hints for this credential (e.g., "internal",
+     *   "hybrid"). Enables cross-device authentication flows such as QR code scanning.
      */
     data class Passkey(
         val credentialId: String? = null,
         val credentialIdBytes: ByteArray? = null,
-        val keyData: ByteArray? = null
+        val keyData: ByteArray? = null,
+        val transports: List<String>? = null
     ) : SelectedSigner() {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -72,6 +75,7 @@ sealed class SelectedSigner {
             if (keyData != null) {
                 if (other.keyData == null || !keyData.contentEquals(other.keyData)) return false
             } else if (other.keyData != null) return false
+            if (transports != other.transports) return false
             return true
         }
 
@@ -79,6 +83,7 @@ sealed class SelectedSigner {
             var result = credentialId?.hashCode() ?: 0
             result = 31 * result + (credentialIdBytes?.contentHashCode() ?: 0)
             result = 31 * result + (keyData?.contentHashCode() ?: 0)
+            result = 31 * result + (transports?.hashCode() ?: 0)
             return result
         }
     }
@@ -527,12 +532,16 @@ class OZMultiSignerManager internal constructor(
                             )
 
                         // Trigger WebAuthn authentication (one OS prompt per passkey signer).
-                        // Pass credentialIdBytes as allowCredentials so the browser uses
-                        // the correct passkey when multiple exist for this RP.
-                        val allowCredentialIds = selectedSigner.credentialIdBytes?.let { listOf(it) }
+                        // Pass credentialIdBytes with transport hints as allowCredentials so the
+                        // browser routes to the correct passkey when multiple exist for this RP.
+                        // null transports is the correct fallback for cross-device credentials
+                        // not yet stored locally.
+                        val allowCredentials = selectedSigner.credentialIdBytes?.let { idBytes ->
+                            listOf(AllowCredential(id = idBytes, transports = selectedSigner.transports))
+                        }
 
                         val authResult = try {
-                            webauthnProvider.authenticate(authDigest, allowCredentialIds)
+                            webauthnProvider.authenticate(authDigest, allowCredentials)
                         } catch (e: Exception) {
                             throw WebAuthnException.authenticationFailed(
                                 "WebAuthn authentication failed for passkey signer " +

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZTransactionOperations.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZTransactionOperations.kt
@@ -527,10 +527,13 @@ class OZTransactionOperations internal constructor(
                 // (g) Compute auth digest binding rule IDs to the payload hash
                 val authDigest = SmartAccountAuth.buildAuthDigest(payloadHash, resolvedContextRuleIds)
 
-                // (h) Authenticate with passkey using auth digest as challenge (triggers biometric prompt)
+                // (h) Authenticate with passkey using auth digest as challenge (triggers biometric prompt).
+                // Transport hints from storage allow the OS/browser to route to the correct authenticator
+                // without an extra discovery step. null transports is the correct fallback when the
+                // credential is not in local storage (e.g. cross-device credential).
                 val authResult = webauthnProvider.authenticate(
                     authDigest,
-                    allowCredentialIds = listOf(credIdBytes)
+                    allowCredentials = listOf(AllowCredential(id = credIdBytes, transports = stored?.transports))
                 )
 
                 // (i) Normalize DER signature to compact format with low-S

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZWalletOperations.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZWalletOperations.kt
@@ -837,14 +837,20 @@ class OZWalletOperations internal constructor(
         val challengeData = challenge ?: secureRandomBytes(32)
 
         // STEP 3: Call WebAuthn authentication
-        // Decode base64url credential IDs to byte arrays for the WebAuthn provider.
-        // When provided, the OS/browser only offers these specific passkeys.
-        val allowCredentialIds = credentialIds?.map { Util.base64urlDecode(it) }
+        // Decode base64url credential IDs and enrich with stored transport hints so the
+        // OS/browser can route to the correct authenticator without an extra round-trip.
+        // `stored` may be null for cross-device credentials not yet in local storage — in
+        // that case null transports is the correct fallback (browser uses its defaults).
+        val allowCredentials = credentialIds?.map { credIdStr ->
+            val idBytes = Util.base64urlDecode(credIdStr)
+            val stored = try { kit.getStorage().get(credIdStr) } catch (_: Exception) { null }
+            AllowCredential(id = idBytes, transports = stored?.transports)
+        }
 
         val authenticationResult = try {
             webauthnProvider.authenticate(
                 challenge = challengeData,
-                allowCredentialIds = allowCredentialIds
+                allowCredentials = allowCredentials
             )
         } catch (e: Exception) {
             throw WebAuthnException.authenticationFailed(

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/WebAuthnProvider.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/WebAuthnProvider.kt
@@ -9,6 +9,44 @@ package com.soneso.stellar.sdk.smartaccount.oz
 import com.soneso.stellar.sdk.Util
 
 /**
+ * A credential descriptor pairing a credential ID with optional transport hints.
+ *
+ * Used in [WebAuthnProvider.authenticate] to constrain which passkeys the
+ * authenticator offers and to indicate how the client can reach the authenticator
+ * (e.g., "internal", "hybrid", "usb", "ble", "nfc"). Including transport hints
+ * enables cross-device authentication flows such as QR code scanning.
+ *
+ * When [transports] is null, the authenticator uses its default transport selection.
+ * Unknown transport strings are passed through without validation — the browser or
+ * OS ignores values it does not recognize.
+ *
+ * @property id The raw credential ID bytes.
+ * @property transports Optional list of transport hints (e.g., "internal", "hybrid").
+ */
+data class AllowCredential(
+    val id: ByteArray,
+    val transports: List<String>? = null
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AllowCredential) return false
+        return id.contentEquals(other.id) && transports == other.transports
+    }
+
+    override fun hashCode(): Int {
+        return 31 * id.contentHashCode() + (transports?.hashCode() ?: 0)
+    }
+
+    companion object {
+        /** Creates an [AllowCredential] from a raw credential ID with no transport hints. */
+        fun fromId(id: ByteArray): AllowCredential = AllowCredential(id = id)
+
+        /** Creates a list of [AllowCredential] from raw credential IDs with no transport hints. */
+        fun fromIds(ids: List<ByteArray>): List<AllowCredential> = ids.map { fromId(it) }
+    }
+}
+
+/**
  * WebAuthn authentication result from a passkey ceremony.
  *
  * Contains the complete attestation data required to verify biometric or
@@ -215,15 +253,16 @@ interface WebAuthnProvider {
      * be signed to authorize the transaction.
      *
      * @param challenge The challenge bytes to sign (authorization payload hash, 32 bytes)
-     * @param allowCredentialIds Optional list of raw credential ID byte arrays to set
-     *   as allowCredentials in the WebAuthn request. Constrains which passkey the
-     *   authenticator uses. Required on web where the browser may otherwise pick
-     *   a different passkey than intended.
+     * @param allowCredentials Optional list of credential descriptors with transport hints.
+     *   Constrains which passkey the authenticator uses and indicates how the client can
+     *   reach the authenticator. When null, discoverable credential selection is used
+     *   (the user picks which passkey to use). Including transport hints (e.g., "hybrid")
+     *   enables cross-device authentication flows such as QR code scanning.
      * @return WebAuthnAuthenticationResult with signature and attestation data
      * @throws WebAuthnException if authentication fails or user cancels
      */
     suspend fun authenticate(
         challenge: ByteArray,
-        allowCredentialIds: List<ByteArray>? = null
+        allowCredentials: List<AllowCredential>? = null
     ): WebAuthnAuthenticationResult
 }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/smartaccount/SmartAccountKitTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/smartaccount/SmartAccountKitTest.kt
@@ -1479,7 +1479,7 @@ class SmartAccountKitTest {
 
             override suspend fun authenticate(
                 challenge: ByteArray,
-                allowCredentialIds: List<ByteArray>?
+                allowCredentials: List<AllowCredential>?
             ): WebAuthnAuthenticationResult {
                 throw NotImplementedError()
             }
@@ -2269,7 +2269,7 @@ class MockWebAuthnProvider(
 
     override suspend fun authenticate(
         challenge: ByteArray,
-        allowCredentialIds: List<ByteArray>?
+        allowCredentials: List<AllowCredential>?
     ): WebAuthnAuthenticationResult {
         if (shouldCancel) {
             throw Exception("User cancelled")

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/AllowCredentialTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/AllowCredentialTest.kt
@@ -1,0 +1,267 @@
+package com.soneso.stellar.sdk.unitTests.smartaccount
+
+import com.soneso.stellar.sdk.smartaccount.oz.AllowCredential
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AllowCredentialTest {
+
+    // --- Construction ---
+
+    @Test
+    fun constructionWithIdOnly() {
+        val id = byteArrayOf(0x01, 0x02, 0x03)
+        val credential = AllowCredential(id = id)
+
+        assertTrue(id.contentEquals(credential.id))
+        assertNull(credential.transports)
+    }
+
+    @Test
+    fun constructionWithIdAndTransports() {
+        val id = byteArrayOf(0x0A, 0x0B, 0x0C)
+        val transports = listOf("internal", "hybrid")
+        val credential = AllowCredential(id = id, transports = transports)
+
+        assertTrue(id.contentEquals(credential.id))
+        assertEquals(transports, credential.transports)
+    }
+
+    @Test
+    fun constructionWithExplicitNullTransports() {
+        val id = byteArrayOf(0x10, 0x20)
+        val credential = AllowCredential(id = id, transports = null)
+
+        assertTrue(id.contentEquals(credential.id))
+        assertNull(credential.transports)
+    }
+
+    // --- equals / contentEquals ---
+
+    @Test
+    fun equalsTwoInstancesWithSameByteContentAreEqual() {
+        // Different ByteArray references, same content
+        val id1 = byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
+        val id2 = byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
+        val transports = listOf("internal")
+
+        val credential1 = AllowCredential(id = id1, transports = transports)
+        val credential2 = AllowCredential(id = id2, transports = transports)
+
+        assertFalse(id1 === id2, "Precondition: id arrays must be distinct references")
+        assertEquals(credential1, credential2)
+    }
+
+    @Test
+    fun equalsWithNullTransportsBothNull() {
+        val id1 = byteArrayOf(0x01, 0x02)
+        val id2 = byteArrayOf(0x01, 0x02)
+
+        val credential1 = AllowCredential(id = id1, transports = null)
+        val credential2 = AllowCredential(id = id2, transports = null)
+
+        assertEquals(credential1, credential2)
+    }
+
+    @Test
+    fun notEqualWhenIdsDiffer() {
+        val credential1 = AllowCredential(id = byteArrayOf(0x01, 0x02))
+        val credential2 = AllowCredential(id = byteArrayOf(0x01, 0x03))
+
+        assertNotEquals(credential1, credential2)
+    }
+
+    @Test
+    fun notEqualWhenTransportsDiffer() {
+        val id = byteArrayOf(0x01, 0x02)
+        val credential1 = AllowCredential(id = id.copyOf(), transports = listOf("internal"))
+        val credential2 = AllowCredential(id = id.copyOf(), transports = listOf("usb"))
+
+        assertNotEquals(credential1, credential2)
+    }
+
+    @Test
+    fun notEqualWhenNullTransportsVsEmptyList() {
+        val id = byteArrayOf(0x01, 0x02)
+        val withNull = AllowCredential(id = id.copyOf(), transports = null)
+        val withEmpty = AllowCredential(id = id.copyOf(), transports = emptyList())
+
+        assertNotEquals(withNull, withEmpty)
+    }
+
+    @Test
+    fun notEqualWhenOneTransportsIsNullAndOtherIsNonNull() {
+        val id = byteArrayOf(0x01, 0x02)
+        val withNull = AllowCredential(id = id.copyOf(), transports = null)
+        val withValue = AllowCredential(id = id.copyOf(), transports = listOf("hybrid"))
+
+        assertNotEquals(withNull, withValue)
+        assertNotEquals(withValue, withNull)
+    }
+
+    @Test
+    fun equalsWithSelfReturnsTrue() {
+        val credential = AllowCredential(
+            id = byteArrayOf(0x01, 0x02, 0x03),
+            transports = listOf("internal")
+        )
+
+        @Suppress("SelfReferenceImmutableVar")
+        assertEquals(credential, credential)
+        assertTrue(credential == credential)
+    }
+
+    // --- hashCode ---
+
+    @Test
+    fun hashCodeConsistencyEqualObjectsHaveSameHashCode() {
+        val id1 = byteArrayOf(0x11, 0x22, 0x33)
+        val id2 = byteArrayOf(0x11, 0x22, 0x33)
+        val transports = listOf("internal", "usb")
+
+        val credential1 = AllowCredential(id = id1, transports = transports)
+        val credential2 = AllowCredential(id = id2, transports = transports)
+
+        assertEquals(credential1, credential2)
+        assertEquals(credential1.hashCode(), credential2.hashCode())
+    }
+
+    @Test
+    fun hashCodeDiffersForDifferentObjects() {
+        val credential1 = AllowCredential(id = byteArrayOf(0x01), transports = listOf("internal"))
+        val credential2 = AllowCredential(id = byteArrayOf(0x02), transports = listOf("internal"))
+
+        // Not a strict contract guarantee, but practically they must differ for this simple case
+        assertNotEquals(credential1.hashCode(), credential2.hashCode())
+    }
+
+    @Test
+    fun hashCodeNullVsNonNullTransportsDiffers() {
+        val id = byteArrayOf(0x01, 0x02)
+        val withNull = AllowCredential(id = id.copyOf(), transports = null)
+        val withValue = AllowCredential(id = id.copyOf(), transports = listOf("internal"))
+
+        assertNotEquals(withNull.hashCode(), withValue.hashCode())
+    }
+
+    // --- fromId factory ---
+
+    @Test
+    fun fromIdCreatesCredentialWithNullTransports() {
+        val id = byteArrayOf(0xAB.toByte(), 0xCD.toByte())
+        val credential = AllowCredential.fromId(id)
+
+        assertTrue(id.contentEquals(credential.id))
+        assertNull(credential.transports)
+    }
+
+    @Test
+    fun fromIdProducesEquivalentResultToDirectConstruction() {
+        val id = byteArrayOf(0x01, 0x02, 0x03, 0x04)
+        val fromFactory = AllowCredential.fromId(id)
+        val direct = AllowCredential(id = id)
+
+        assertEquals(direct, fromFactory)
+    }
+
+    // --- fromIds factory ---
+
+    @Test
+    fun fromIdsCreatesListWithAllNullTransports() {
+        val ids = listOf(
+            byteArrayOf(0x01),
+            byteArrayOf(0x02, 0x03),
+            byteArrayOf(0x04, 0x05, 0x06)
+        )
+
+        val credentials = AllowCredential.fromIds(ids)
+
+        assertEquals(ids.size, credentials.size)
+        ids.forEachIndexed { index, id ->
+            assertTrue(id.contentEquals(credentials[index].id))
+            assertNull(credentials[index].transports)
+        }
+    }
+
+    @Test
+    fun fromIdsEmptyListReturnsEmptyList() {
+        val credentials = AllowCredential.fromIds(emptyList())
+
+        assertTrue(credentials.isEmpty())
+    }
+
+    @Test
+    fun fromIdsSingleElementList() {
+        val id = byteArrayOf(0xFF.toByte(), 0x00)
+        val credentials = AllowCredential.fromIds(listOf(id))
+
+        assertEquals(1, credentials.size)
+        assertTrue(id.contentEquals(credentials[0].id))
+        assertNull(credentials[0].transports)
+    }
+
+    // --- transports values ---
+
+    @Test
+    fun commonTransportValuesArePreserved() {
+        val id = byteArrayOf(0x01)
+        val transports = listOf("internal", "hybrid", "usb", "ble", "nfc")
+        val credential = AllowCredential(id = id, transports = transports)
+
+        assertEquals(transports, credential.transports)
+        assertEquals(5, credential.transports!!.size)
+        assertTrue(credential.transports!!.contains("internal"))
+        assertTrue(credential.transports!!.contains("hybrid"))
+        assertTrue(credential.transports!!.contains("usb"))
+        assertTrue(credential.transports!!.contains("ble"))
+        assertTrue(credential.transports!!.contains("nfc"))
+    }
+
+    @Test
+    fun transportOrderIsPreserved() {
+        val id = byteArrayOf(0x01)
+        val transports = listOf("nfc", "usb", "internal")
+        val credential = AllowCredential(id = id, transports = transports)
+
+        assertEquals("nfc", credential.transports!![0])
+        assertEquals("usb", credential.transports!![1])
+        assertEquals("internal", credential.transports!![2])
+    }
+
+    // --- ByteArray reference semantics ---
+
+    @Test
+    fun idStoredByReferenceNotCopied() {
+        // Kotlin data classes do NOT deep-copy ByteArray fields.
+        // This test documents the actual behavior: mutating the original array
+        // is reflected in the stored id (no defensive copy is performed).
+        val originalId = byteArrayOf(0x01, 0x02, 0x03)
+        val credential = AllowCredential(id = originalId)
+
+        // Verify the stored id initially matches
+        assertTrue(byteArrayOf(0x01, 0x02, 0x03).contentEquals(credential.id))
+
+        // Mutate the original array
+        originalId[0] = 0xFF.toByte()
+
+        // The stored id reflects the mutation because it shares the same reference
+        assertEquals(0xFF.toByte(), credential.id[0])
+    }
+
+    @Test
+    fun copyOfIdIsIndependent() = runTest {
+        // When callers want isolation they must copy the array themselves.
+        val originalId = byteArrayOf(0x01, 0x02, 0x03)
+        val credential = AllowCredential(id = originalId.copyOf())
+
+        originalId[0] = 0xFF.toByte()
+
+        // credential.id was constructed from a copy — it is unaffected
+        assertEquals(0x01.toByte(), credential.id[0])
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/MockWebAuthnProvider.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/MockWebAuthnProvider.kt
@@ -9,6 +9,7 @@ package com.soneso.stellar.sdk.unitTests.smartaccount
 
 import com.soneso.stellar.sdk.smartaccount.core.WebAuthnException
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnAuthenticationResult
+import com.soneso.stellar.sdk.smartaccount.oz.AllowCredential
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnProvider
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnRegistrationResult
 
@@ -87,6 +88,10 @@ class MockWebAuthnProvider : WebAuthnProvider {
     var lastAuthenticateChallenge: ByteArray? = null
         private set
 
+    /** The most recent allowCredentials passed to [authenticate], or null if never called. */
+    var lastAuthenticateAllowCredentials: List<AllowCredential>? = null
+        private set
+
     // MARK: - WebAuthnProvider Implementation
 
     override suspend fun register(
@@ -106,10 +111,11 @@ class MockWebAuthnProvider : WebAuthnProvider {
 
     override suspend fun authenticate(
         challenge: ByteArray,
-        allowCredentialIds: List<ByteArray>?
+        allowCredentials: List<AllowCredential>?
     ): WebAuthnAuthenticationResult {
         authenticateCallCount++
         lastAuthenticateChallenge = challenge.copyOf()
+        lastAuthenticateAllowCredentials = allowCredentials
 
         authenticationException?.let { throw it }
 
@@ -132,6 +138,7 @@ class MockWebAuthnProvider : WebAuthnProvider {
         lastRegisterUserId = null
         lastRegisterUserName = null
         lastAuthenticateChallenge = null
+        lastAuthenticateAllowCredentials = null
     }
 
     // MARK: - Default Responses

--- a/stellar-sdk/src/jsMain/kotlin/com/soneso/stellar/sdk/smartaccount/JsWebAuthnProvider.kt
+++ b/stellar-sdk/src/jsMain/kotlin/com/soneso/stellar/sdk/smartaccount/JsWebAuthnProvider.kt
@@ -12,6 +12,7 @@ import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnCborParser
 import com.soneso.stellar.sdk.smartaccount.core.WebAuthnException
 import com.soneso.stellar.sdk.smartaccount.oz.OZConstants
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnAuthenticationResult
+import com.soneso.stellar.sdk.smartaccount.oz.AllowCredential
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnProvider
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnRegistrationResult
 import kotlinx.coroutines.await
@@ -249,8 +250,11 @@ class JsWebAuthnProvider(
      * normalization before submitting to the Stellar network.
      *
      * @param challenge The challenge bytes to sign (authorization payload hash, typically 32 bytes)
-     * @param allowCredentialIds Optional list of credential IDs to restrict authentication to
-     *        specific passkeys. If null, all registered passkeys are eligible.
+     * @param allowCredentials Optional list of credential descriptors with optional transport hints
+     *        to restrict authentication to specific passkeys. When [AllowCredential.transports] is
+     *        non-null, the transport hints are forwarded to the browser to enable cross-device
+     *        flows (e.g. QR code scanning via "hybrid"). If null, all registered passkeys for
+     *        this RP are eligible.
      * @return [WebAuthnAuthenticationResult] with credential ID, authenticator data,
      *         client data JSON, and DER-encoded signature
      * @throws WebAuthnException.NotSupported if WebAuthn is not available (e.g. Node.js)
@@ -259,7 +263,7 @@ class JsWebAuthnProvider(
      */
     override suspend fun authenticate(
         challenge: ByteArray,
-        allowCredentialIds: List<ByteArray>?
+        allowCredentials: List<AllowCredential>?
     ): WebAuthnAuthenticationResult {
         val credentials = getNavigatorCredentials()
             ?: throw WebAuthnException.notSupported(
@@ -282,10 +286,37 @@ class JsWebAuthnProvider(
 
         // Constrain which passkey the authenticator uses. Without this, the browser
         // may pick a different passkey than intended when multiple exist for this RP.
-        if (allowCredentialIds != null && allowCredentialIds.isNotEmpty()) {
-            val idBuffers = allowCredentialIds.map { it.toArrayBuffer() }.toTypedArray()
-            val jsAllowCreds = js("(function(buffers) { return buffers.map(function(buf) { return { type: 'public-key', id: buf }; }); })")
-            publicKey.allowCredentials = jsAllowCreds(idBuffers)
+        // When transport hints are present they are forwarded to enable cross-device
+        // flows (e.g. "hybrid" for QR-code scanning via a phone).
+        if (allowCredentials != null && allowCredentials.isNotEmpty()) {
+            val idBuffers = allowCredentials.map { it.id.toArrayBuffer() }.toTypedArray()
+            // Build a parallel array of transport arrays (JS Array<String> or null).
+            // Using js("null") for entries without hints avoids emitting a transports
+            // field entirely, which is required by the WebAuthn spec — omitting the field
+            // is different from passing an empty array.
+            val transportArrays: Array<dynamic> = allowCredentials.map { cred ->
+                if (cred.transports != null && cred.transports.isNotEmpty()) {
+                    cred.transports.toTypedArray().asDynamic()
+                } else {
+                    null.asDynamic()
+                }
+            }.toTypedArray()
+
+            val jsAllowCreds = js(
+                """
+                (function(buffers, transportsPerCred) {
+                    return buffers.map(function(buf, i) {
+                        var descriptor = { type: 'public-key', id: buf };
+                        var t = transportsPerCred[i];
+                        if (t !== null && t !== undefined && t.length > 0) {
+                            descriptor.transports = t;
+                        }
+                        return descriptor;
+                    });
+                })
+                """
+            )
+            publicKey.allowCredentials = jsAllowCreds(idBuffers, transportArrays)
         }
 
         options.publicKey = publicKey

--- a/stellar-sdk/src/jsTest/kotlin/com/soneso/stellar/sdk/smartaccount/JsWebAuthnGuardTest.kt
+++ b/stellar-sdk/src/jsTest/kotlin/com/soneso/stellar/sdk/smartaccount/JsWebAuthnGuardTest.kt
@@ -7,6 +7,7 @@
 
 package com.soneso.stellar.sdk.smartaccount
 
+import com.soneso.stellar.sdk.smartaccount.oz.AllowCredential
 import com.soneso.stellar.sdk.smartaccount.core.StorageException
 import com.soneso.stellar.sdk.smartaccount.core.WebAuthnException
 import com.soneso.stellar.sdk.smartaccount.oz.OZConstants
@@ -78,7 +79,7 @@ class JsWebAuthnGuardTest {
         val exception = assertFailsWith<WebAuthnException.NotSupported> {
             provider.authenticate(
                 challenge = testChallenge(),
-                allowCredentialIds = null
+                allowCredentials = null
             )
         }
         assertNotNull(exception.message)
@@ -100,7 +101,7 @@ class JsWebAuthnGuardTest {
         assertFailsWith<WebAuthnException.NotSupported> {
             provider.authenticate(
                 challenge = testChallenge(),
-                allowCredentialIds = listOf(ByteArray(32) { 0xAB.toByte() })
+                allowCredentials = AllowCredential.fromIds(listOf(ByteArray(32) { 0xAB.toByte() }))
             )
         }
     }

--- a/stellar-sdk/src/nativeMain/kotlin/com/soneso/stellar/sdk/smartaccount/AppleWebAuthnProvider.kt
+++ b/stellar-sdk/src/nativeMain/kotlin/com/soneso/stellar/sdk/smartaccount/AppleWebAuthnProvider.kt
@@ -11,6 +11,7 @@ import com.soneso.stellar.sdk.smartaccount.core.SmartAccountUtils
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnCborParser
 import com.soneso.stellar.sdk.smartaccount.oz.OZConstants
 import com.soneso.stellar.sdk.smartaccount.core.WebAuthnException
+import com.soneso.stellar.sdk.smartaccount.oz.AllowCredential
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnAuthenticationResult
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnProvider
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnRegistrationResult
@@ -214,9 +215,14 @@ class AppleWebAuthnProvider(
      * The challenge bytes are passed directly to the platform authenticator
      * without modification.
      *
+     * Transport hints in [AllowCredential.transports] are intentionally ignored.
+     * [ASAuthorizationPlatformPublicKeyCredentialDescriptor] has no API for transport
+     * hints — Apple manages hybrid and cross-device flows at the OS level.
+     *
      * @param challenge The challenge bytes to sign (authorization payload hash, typically 32 bytes)
-     * @param allowCredentialIds Optional list of credential IDs to restrict authentication to
-     *        specific passkeys. If null, all registered passkeys are eligible.
+     * @param allowCredentials Optional list of [AllowCredential] entries to restrict authentication
+     *        to specific passkeys. Only the credential ID is used; transport hints are ignored.
+     *        If null or empty, all registered passkeys for the relying party are eligible.
      * @return [WebAuthnAuthenticationResult] with credential ID, authenticator data,
      *         client data JSON, and DER-encoded signature
      * @throws WebAuthnException.Cancelled if the user dismissed the authentication dialog
@@ -226,7 +232,7 @@ class AppleWebAuthnProvider(
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override suspend fun authenticate(
         challenge: ByteArray,
-        allowCredentialIds: List<ByteArray>?
+        allowCredentials: List<AllowCredential>?
     ): WebAuthnAuthenticationResult {
         val challengeData = challenge.toNSData()
 
@@ -242,10 +248,13 @@ class AppleWebAuthnProvider(
 
         // Set allowed credentials to restrict which passkeys the system presents.
         // Without this, macOS shows a picker for all passkeys matching the RP ID.
-        if (!allowCredentialIds.isNullOrEmpty()) {
-            val descriptors = allowCredentialIds.map { credId ->
+        // Transport hints (AllowCredential.transports) are intentionally not passed to
+        // ASAuthorizationPlatformPublicKeyCredentialDescriptor — that API has no transport
+        // parameter; Apple handles hybrid/cross-device transport selection at the OS level.
+        if (!allowCredentials.isNullOrEmpty()) {
+            val descriptors = allowCredentials.map { allowCredential ->
                 platform.AuthenticationServices.ASAuthorizationPlatformPublicKeyCredentialDescriptor(
-                    credentialID = credId.toNSData()
+                    credentialID = allowCredential.id.toNSData()
                 )
             }
             request.allowedCredentials = descriptors


### PR DESCRIPTION
### Summary

- Replace `allowCredentialIds: List<ByteArray>?` with `allowCredentials: List<AllowCredential>?` in `WebAuthnProvider.authenticate()` to pair credential IDs with transport hints
- Transport hints (e.g., "internal", "hybrid") enable browsers and OS credential managers to offer QR code scanning for cross-device authentication
- Stored transports from credential registration are piped through all SDK call sites to the platform providers

### Changes

**SDK interface**
- `AllowCredential` data class with `id`, `transports`, `equals`/`hashCode`, and `fromId`/`fromIds` factory methods
- `WebAuthnProvider.authenticate()` signature updated
- `SelectedSigner.Passkey` gains `transports` field

**Platform providers**
- JS: includes `transports` array in `allowCredentials` JS objects when available
- Android: conditionally adds `transports` JSON field to credential descriptors
- Apple: accepts parameter, ignores transports (OS handles cross-device flows)

**Call sites**
- `OZWalletOperations.authenticatePasskey()`: looks up stored transports per credential
- `OZTransactionOperations`: passes stored transports from credential lookup
- `OZMultiSignerManager`: passes transports from `SelectedSigner.Passkey`

**Demo app**
- `buildSelectedSigners()` looks up stored credential transports (changed to `suspend fun` for async storage access; all callers are in coroutine scopes)

**Tests**
- 22 unit tests for `AllowCredential` (equality, hashCode, factories, transports)
- All test mocks and existing test call sites updated to match new signature
- Mock provider captures `lastAuthenticateAllowCredentials` for integration assertions

**Documentation**
- API reference updated with `AllowCredential` class and new `authenticate()` signature

### Breaking change

This changes the `WebAuthnProvider.authenticate()` interface signature from 1.4.0. The parameter `allowCredentialIds: List<ByteArray>?` is replaced by `allowCredentials: List<AllowCredential>?`. Migration: use `AllowCredential.fromIds(ids)` for callers that only have byte arrays.