### PR TITLE
Add external wallet signing to smart account demo

### DIFF
--- a/smart-account-demo/README.md
+++ b/smart-account-demo/README.md
@@ -120,11 +120,21 @@ open StellarSmartDemo.xcodeproj
 ```
 
 In Xcode:
-1. Add the swift-sodium package if not already added (File > Add Packages > `https://github.com/jedisct1/swift-sodium`). Select the Clibsodium product.
-2. Select the StellarSmartDemo scheme and an iOS 16.0+ simulator.
-3. Run (Cmd+R).
+1. Resolve packages: File -> Packages -> Resolve Package Versions (downloads swift-sodium and reown-swift dependencies).
+2. Set your signing team: select the StellarSmartDemo target -> Signing & Capabilities -> Team. This is required for both simulator and device builds and must be set after every `xcodegen generate`.
+3. Select the StellarSmartDemo scheme and an iOS 16.0+ simulator.
+4. Run (Cmd+R).
 
-**Running on a physical device**: The default configuration targets the iOS simulator. To run on a physical iPhone, change the framework dependency path in `iosApp/project.yml` from `iosSimulatorArm64` to `iosArm64`, regenerate the Xcode project with `xcodegen generate`, select your device in Xcode, and build. You also need a valid signing team configured in the Signing & Capabilities tab.
+**Switching between simulator and physical device:**
+
+The framework dependency in `project.yml` (line 55) must match the target platform. After changing it, run `xcodegen generate` to regenerate the Xcode project, then set your signing team again.
+
+| Target | Framework path in project.yml line 55 |
+|--------|---------------------------------------|
+| Simulator | `../shared/build/bin/iosSimulatorArm64/debugFramework/shared.framework` |
+| Physical device | `../shared/build/bin/iosArm64/debugFramework/shared.framework` |
+
+The pre-build script automatically builds the correct Kotlin framework based on the selected target platform. You only need to change the framework dependency path and regenerate.
 
 ### macOS
 
@@ -201,10 +211,40 @@ All testnet configuration is centralized in `shared/src/commonMain/kotlin/com/so
 | `DEFAULT_INDEXER_URL` | Credential-to-contract address lookup service |
 | `DEFAULT_RP_ID` | WebAuthn Relying Party ID (`soneso.com`) |
 | `RP_NAME` | Display name for passkey prompts |
+| `REOWN_PROJECT_ID` | Reown (WalletConnect) project ID for external wallet connection |
 
 DEMO token settings (`DEMO_TOKEN_*`) control the deterministic deployment and minting of a custom Soroban token used for testing transfers.
 
 Known policy contracts (threshold, spending limit, weighted threshold) are defined in `KNOWN_POLICIES`.
+
+## External Wallet Connection (Freighter)
+
+The demo supports connecting an external Stellar wallet (Freighter) as a delegated signer, as an alternative to entering a secret key manually.
+
+| Platform | Method | Requirement |
+|----------|--------|-------------|
+| Web | Freighter browser extension | Install from [freighter.app](https://www.freighter.app/) |
+| Android | WalletConnect v2 (Reown) | Freighter Mobile on the same device |
+| iOS | WalletConnect v2 (Reown) | Freighter Mobile on the same device |
+| macOS | Not available | Use secret key entry |
+
+Wallet connection buttons are hidden on simulators and emulators since WalletConnect requires the wallet app on a real device.
+
+### Reown Project ID
+
+Android and iOS use the [Reown](https://cloud.reown.com/) (WalletConnect v2) SDK. A project ID is required. Set `REOWN_PROJECT_ID` in `DemoConfig.kt`. Register for a free project ID at [cloud.reown.com](https://cloud.reown.com/).
+
+### iOS App Group (required for device builds)
+
+The Reown SDK requires an App Group for relay session storage. The entitlement `group.com.soneso.stellar.smartdemo` is configured in `iosApp/StellarSmartDemo/StellarSmartDemo.entitlements`.
+
+To run on a physical iOS device, register this App Group in your Apple Developer account:
+
+1. Go to [developer.apple.com](https://developer.apple.com/account/resources/identifiers/list/applicationGroup) -> Certificates, Identifiers & Profiles -> Identifiers -> App Groups
+2. Click **+** and register `group.com.soneso.stellar.smartdemo`
+3. In Xcode, refresh the App Group capability (Signing & Capabilities -> App Groups -> refresh button)
+
+This is not needed for simulator builds (wallet connection is disabled on simulators).
 
 ## Quick Reference
 

--- a/smart-account-demo/androidApp/build.gradle.kts
+++ b/smart-account-demo/androidApp/build.gradle.kts
@@ -42,4 +42,10 @@ kotlin {
 dependencies {
     implementation(project(":smart-account-demo:shared"))
     implementation("androidx.activity:activity-compose:1.8.2")
+
+    // Reown (WalletConnect v2) for external wallet connection via Freighter Mobile.
+    // com.reown:android-core provides CoreClient (relay, pairing, metadata).
+    // com.reown:sign provides SignClient (session proposal, request/response, delegates).
+    implementation("com.reown:android-core:1.6.12")
+    implementation("com.reown:sign:1.6.12")
 }

--- a/smart-account-demo/androidApp/src/main/AndroidManifest.xml
+++ b/smart-account-demo/androidApp/src/main/AndroidManifest.xml
@@ -4,16 +4,29 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".SmartDemoApplication"
         android:allowBackup="true"
         android:label="Smart Account Demo"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTop">
+
+            <!-- App launcher intent -->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!-- Deep link return from Freighter Mobile / WalletConnect redirect -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="stellar-smartdemo" />
             </intent-filter>
         </activity>
 

--- a/smart-account-demo/androidApp/src/main/java/com/soneso/stellar/smartdemo/android/MainActivity.kt
+++ b/smart-account-demo/androidApp/src/main/java/com/soneso/stellar/smartdemo/android/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.soneso.stellar.smartdemo.android
 
+import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -9,31 +11,44 @@ import com.soneso.smartdemo.config.DemoConfig
 import com.soneso.smartdemo.platform.initAndroidClipboard
 import com.soneso.smartdemo.state.ActivityLogState
 import com.soneso.smartdemo.state.DemoState
+import com.soneso.smartdemo.wallet.ReownConnector
 import com.soneso.stellar.sdk.smartaccount.AndroidStorageAdapter
 import com.soneso.stellar.sdk.smartaccount.AndroidWebAuthnProvider
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         initAndroidClipboard(this)
 
-        // Initialize Smart Account Kit with Android-specific providers
+        // Register the Reown wallet connector so shared code can trigger wallet flows.
+        // Skipped on emulators (WalletConnect requires Freighter Mobile on a real device)
+        // and when REOWN_PROJECT_ID is blank. This heuristic covers the standard Android
+        // emulator (ranchu/goldfish) and SDK-based images. Some third-party emulators
+        // (e.g., Genymotion) may not be detected — wallet connection will timeout on those.
+        val isEmulator = Build.HARDWARE == "ranchu" || Build.HARDWARE == "goldfish" ||
+            Build.PRODUCT.contains("sdk") || Build.FINGERPRINT.contains("generic")
+        if (!isEmulator && DemoConfig.REOWN_PROJECT_ID.isNotBlank()) {
+            DemoState.setWalletConnector(ReownConnector(applicationContext))
+        }
+
+        // Initialize Smart Account Kit with Android-specific providers.
         lifecycleScope.launch {
             try {
-                // Create storage adapter using encrypted SharedPreferences
+                // Create storage adapter using encrypted SharedPreferences.
                 val storage = AndroidStorageAdapter(applicationContext)
 
-                // Create WebAuthn provider for passkey authentication
-                // rpId must match the domain configured in assetlinks.json
+                // Create WebAuthn provider for passkey authentication.
+                // rpId must match the domain configured in assetlinks.json.
                 val webauthnProvider = AndroidWebAuthnProvider(
                     context = this@MainActivity,
                     rpId = DemoConfig.DEFAULT_RP_ID,
                     rpName = DemoConfig.RP_NAME
                 )
 
-                // Store platform providers in DemoState so shared code can use them
+                // Store platform providers in DemoState so shared code can use them.
                 DemoState.setWebAuthnProvider(webauthnProvider)
                 DemoState.setStorage(storage)
 
@@ -46,5 +61,18 @@ class MainActivity : ComponentActivity() {
         setContent {
             App()
         }
+    }
+
+    /**
+     * Called when the activity receives a new intent after creation (e.g. the deep link
+     * redirect URI `stellar-smartdemo://request` sent by Freighter Mobile on return).
+     *
+     * The Reown SDK handles the relay connection internally via its WebSocket; this callback
+     * exists to satisfy the `singleTop` launch mode contract and ensure the activity is
+     * brought to the foreground correctly after the wallet redirects back.
+     */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
     }
 }

--- a/smart-account-demo/androidApp/src/main/java/com/soneso/stellar/smartdemo/android/SmartDemoApplication.kt
+++ b/smart-account-demo/androidApp/src/main/java/com/soneso/stellar/smartdemo/android/SmartDemoApplication.kt
@@ -1,0 +1,61 @@
+package com.soneso.stellar.smartdemo.android
+
+import android.app.Application
+import android.util.Log
+import com.reown.android.Core
+import com.reown.android.CoreClient
+import com.reown.android.relay.ConnectionType
+import com.reown.sign.client.Sign
+import com.reown.sign.client.SignClient
+import com.soneso.smartdemo.config.DemoConfig
+
+/**
+ * Application subclass that initializes Reown CoreClient and SignClient at app start.
+ *
+ * Both clients must be initialized before any Activity is created so that the
+ * relay connection is available when the wallet connector is first used.
+ * Initialization is skipped when REOWN_PROJECT_ID is blank to allow the app
+ * to run without wallet connection support during development.
+ */
+class SmartDemoApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        val projectId = DemoConfig.REOWN_PROJECT_ID
+        if (projectId.isBlank()) {
+            Log.w(TAG, "REOWN_PROJECT_ID is not set. Wallet connection via Freighter Mobile will not work.")
+            return
+        }
+
+        CoreClient.initialize(
+            application = this,
+            projectId = projectId,
+            metaData = Core.Model.AppMetaData(
+                name = "Stellar Smart Account Demo",
+                description = "Smart account demo app for the KMP Stellar SDK",
+                url = "https://soneso.com",
+                icons = listOf("https://soneso.com/icon.png"),
+                redirect = "stellar-smartdemo://request"
+            ),
+            connectionType = ConnectionType.AUTOMATIC,
+            onError = { error ->
+                Log.e(TAG, "CoreClient initialization error: ${error.throwable.message}", error.throwable)
+            }
+        )
+
+        SignClient.initialize(
+            init = Sign.Params.Init(core = CoreClient),
+            onSuccess = {
+                Log.d(TAG, "SignClient initialized successfully")
+            },
+            onError = { error ->
+                Log.e(TAG, "SignClient initialization error: ${error.throwable.message}", error.throwable)
+            }
+        )
+    }
+
+    private companion object {
+        private const val TAG = "SmartDemoApplication"
+    }
+}

--- a/smart-account-demo/build.gradle.kts
+++ b/smart-account-demo/build.gradle.kts
@@ -1,2 +1,10 @@
 // Smart Account Demo - root build file
-// This module is intentionally empty; subprojects define their own plugins and dependencies.
+// Subprojects define their own plugins and dependencies.
+
+subprojects {
+    repositories {
+        // Required by Reown (WalletConnect v2) transitive dependencies:
+        // com.github.komputing.kethereum, com.github.multiformats, com.walletconnect.Scarlet
+        maven("https://jitpack.io")
+    }
+}

--- a/smart-account-demo/iosApp/StellarSmartDemo/Info.plist
+++ b/smart-account-demo/iosApp/StellarSmartDemo/Info.plist
@@ -18,8 +18,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.soneso.stellar.smartdemo</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>stellar-smartdemo</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
-	<integer>1</integer>
+	<string>1</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UISupportedInterfaceOrientations</key>

--- a/smart-account-demo/iosApp/StellarSmartDemo/StellarSmartDemo.entitlements
+++ b/smart-account-demo/iosApp/StellarSmartDemo/StellarSmartDemo.entitlements
@@ -6,5 +6,9 @@
 	<array>
 		<string>webcredentials:soneso.com?mode=developer</string>
 	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.soneso.stellar.smartdemo</string>
+	</array>
 </dict>
 </plist>

--- a/smart-account-demo/iosApp/StellarSmartDemo/StellarSmartDemoApp.swift
+++ b/smart-account-demo/iosApp/StellarSmartDemo/StellarSmartDemoApp.swift
@@ -7,34 +7,88 @@
 //
 
 import SwiftUI
+import WalletConnectSign
 import shared
 
-// MARK: - Passkey Configuration
-//
-// This app demonstrates Stellar Smart Accounts with passkey authentication.
-// Passkeys (WebAuthn) require:
-//
-// 1. iOS 16.0+ deployment target (configured in project.yml)
-// 2. Associated Domains entitlement (see project.yml for setup)
-// 3. apple-app-site-association file hosted on your domain
-//
-// For development/testing:
-// - Passkeys may not work on iOS Simulator (platform limitation)
-// - Test on real devices for full passkey functionality
-// - Use a test domain or skip domain validation during development
-//
-// The Smart Account Kit is initialized in PlatformInit.ios.kt with:
-// - AppleWebAuthnProvider (Touch ID / Face ID integration)
-// - UserDefaultsStorageAdapter (credential persistence)
+// MARK: - App
 
 @main
 struct StellarSmartDemoApp: App {
+
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onOpenURL { url in
+                    // Forward deep link envelopes from the wallet app back to
+                    // the WalletConnect Sign client so it can process responses
+                    // that arrive via universal or custom-scheme links.
+                    appDelegate.handleOpenURL(url)
+                }
         }
     }
 }
+
+// MARK: - AppDelegate
+
+/// Application delegate that configures the Reown networking stack at launch.
+///
+/// Reown (WalletConnect v2) requires the `Networking`, `Pair`, and `Sign` singletons
+/// to be configured before any wallet operation is attempted. This delegate performs
+/// that setup and wires the resulting `ReownWalletHandlerImpl` into the Kotlin
+/// `DemoState` via `initSmartAccountKit`.
+///
+/// If `DemoConfig.REOWN_PROJECT_ID` is blank, wallet connection is silently disabled
+/// and the rest of the app runs normally without it.
+final class AppDelegate: NSObject, UIApplicationDelegate {
+
+    private var reownHandler: ReownWalletHandlerImpl?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        let projectId = DemoConfig.shared.REOWN_PROJECT_ID
+
+        #if !targetEnvironment(simulator)
+        if !projectId.isEmpty {
+            ReownWalletHandlerImpl.configure(projectId: projectId)
+            let handler = ReownWalletHandlerImpl()
+            self.reownHandler = handler
+            PlatformInit_iosKt.doInitSmartAccountKit(reownHandler: handler)
+        } else {
+            PlatformInit_iosKt.doInitSmartAccountKit(reownHandler: nil)
+        }
+        #else
+        // WalletConnect requires Freighter Mobile on the device.
+        // Skip wallet connector on simulator where it cannot work.
+        PlatformInit_iosKt.doInitSmartAccountKit(reownHandler: nil)
+        #endif
+
+        return true
+    }
+
+    /// Forwards WalletConnect link-mode envelopes to the Sign client.
+    ///
+    /// When a wallet app responds to a session or signing request via a deep link,
+    /// it opens the app with a URL containing a `wc_ev` query parameter. The Sign
+    /// client decodes the envelope and resolves the pending request.
+    func handleOpenURL(_ url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems,
+              queryItems.contains(where: { $0.name == "wc_ev" }) else {
+            return
+        }
+        do {
+            try Sign.instance.dispatchEnvelope(url.absoluteString)
+        } catch {
+            print("[AppDelegate] Failed to dispatch WalletConnect envelope: \(error.localizedDescription)")
+        }
+    }
+}
+
+// MARK: - Views
 
 struct ContentView: View {
     var body: some View {
@@ -45,8 +99,7 @@ struct ContentView: View {
 
 struct ComposeView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        let controller = MainViewControllerKt.MainViewController()
-        return controller
+        MainViewControllerKt.MainViewController()
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}

--- a/smart-account-demo/iosApp/StellarSmartDemo/Wallet/ReownWalletHandler.swift
+++ b/smart-account-demo/iosApp/StellarSmartDemo/Wallet/ReownWalletHandler.swift
@@ -1,0 +1,561 @@
+//
+//  ReownWalletHandler.swift
+//  StellarSmartDemo
+//
+//  Copyright (c) 2026 Soneso. All rights reserved.
+//
+
+import Foundation
+import Combine
+import UIKit
+import WalletConnectSign
+import WalletConnectNetworking
+import WalletConnectPairing
+import shared
+
+// MARK: - SocketFactory
+
+/// URLSessionWebSocket-based factory for the Reown networking layer.
+///
+/// This avoids a Starscream dependency by using Apple's built-in WebSocket support,
+/// which is available on iOS 13+. The Reown SDK requires a `WebSocketFactory` that
+/// produces `WebSocketConnecting`-conforming objects; this implementation wraps
+/// `URLSessionWebSocketTask`.
+private final class SocketFactory: WebSocketFactory {
+    func create(with url: URL) -> WebSocketConnecting {
+        return NativeWebSocket(url: url)
+    }
+}
+
+/// `URLSessionWebSocketTask`-backed `WebSocketConnecting` implementation.
+///
+/// Bridges Apple's native WebSocket API to the `WebSocketConnecting` protocol
+/// required by the Reown networking layer.
+private final class NativeWebSocket: NSObject, WebSocketConnecting, URLSessionWebSocketDelegate {
+    var isConnected: Bool = false
+    var onConnect: (() -> Void)?
+    var onDisconnect: ((Error?) -> Void)?
+    var onText: ((String) -> Void)?
+    var request: URLRequest
+
+    private var task: URLSessionWebSocketTask?
+    private lazy var session: URLSession = {
+        URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+    }()
+
+    init(url: URL) {
+        self.request = URLRequest(url: url)
+        super.init()
+    }
+
+    func connect() {
+        task = session.webSocketTask(with: request)
+        task?.resume()
+        listen()
+    }
+
+    func disconnect() {
+        task?.cancel(with: .normalClosure, reason: nil)
+    }
+
+    func write(string: String, completion: (() -> Void)?) {
+        task?.send(.string(string)) { _ in
+            completion?()
+        }
+    }
+
+    private func listen() {
+        task?.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let message):
+                switch message {
+                case .string(let text):
+                    self.onText?(text)
+                case .data(let data):
+                    print("[NativeWebSocket] Received unexpected binary message (\(data.count) bytes)")
+                @unknown default:
+                    break
+                }
+                self.listen()
+            case .failure:
+                break
+            }
+        }
+    }
+
+    // MARK: URLSessionWebSocketDelegate
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didOpenWithProtocol protocol: String?
+    ) {
+        isConnected = true
+        onConnect?()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        isConnected = false
+        onDisconnect?(nil)
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if isConnected {
+            isConnected = false
+            onDisconnect?(error)
+        }
+    }
+}
+
+// MARK: - ReownWalletHandlerImpl
+
+/// Reown WalletConnectSign-based implementation of the Kotlin `ReownHandler` protocol.
+///
+/// This class acts as the dApp-side WalletConnect peer. It:
+/// 1. Configures `Networking`, `Pair`, and `Sign` during `configure(projectId:)`.
+/// 2. Exposes the callback-based interface that `ReownConnectorBridge` calls from Kotlin.
+/// 3. Manages one active session at a time and stores the connected Stellar address.
+///
+/// Stellar namespace:
+/// - Chain IDs: `stellar:testnet` (Testnet) and `stellar:pubnet` (Mainnet)
+/// - Methods: `stellar_signAuthEntry`
+/// - Network passphrases: mapped from the chain ID in the settled namespace.
+///
+/// Thread safety:
+/// All publisher subscriptions and completions are dispatched to the main queue.
+/// The stored session and address are accessed only from the main queue.
+final class ReownWalletHandlerImpl: NSObject, ReownHandler {
+
+    // MARK: - Constants
+
+    private static let stellarNamespaceKey = "stellar"
+    private static let signMethod = "stellar_signAuthEntry"
+    private static let testnetChain = "stellar:testnet"
+    private static let pubnetChain = "stellar:pubnet"
+    private static let testnetPassphrase = "Test SDF Network ; September 2015"
+    private static let pubnetPassphrase = "Public Global Stellar Network ; September 2015"
+    private static let connectionTimeout: TimeInterval = 120.0
+    /// Timeout for waiting for a sign response (app-level, in seconds).
+    /// Aligned with Android (SIGNING_TIMEOUT_MS = 120_000).
+    private static let signingTimeout: TimeInterval = 120.0
+
+    /// TTL for the WalletConnect Request object. Must be between 300 and 604800 seconds.
+    /// Using the protocol minimum of 300 seconds.
+    private static let requestTtl: TimeInterval = 300.0
+
+    // MARK: - State
+
+    /// Lock protecting `activeSession` and `connectedAddress` which may be read from
+    /// background threads via the synchronous `isConnected` / `getConnectedAddress` methods.
+    private let stateLock = NSLock()
+
+    /// Active WalletConnect session, set when `sessionSettlePublisher` fires.
+    /// Access under `stateLock`.
+    private var activeSession: Session?
+
+    /// Stellar G-address extracted from the settled session namespace.
+    /// Access under `stateLock`.
+    private var connectedAddress: String?
+
+    /// Combine subscriptions.
+    private var cancellables = Set<AnyCancellable>()
+
+    /// Pending connection completion. Set in `connect`, resolved in `sessionSettlePublisher`.
+    private var pendingConnectCompletion: ((WalletConnectionBridge?, String?) -> Void)?
+
+    /// Pending sign completions keyed by request ID string.
+    private var pendingSignCompletions: [String: (String?, String?) -> Void] = [:]
+
+    // MARK: - Configuration
+
+    /// Configures the Reown networking stack.
+    ///
+    /// Must be called once before any other method, typically in the app delegate.
+    /// Subsequent calls are no-ops (the singletons guard against re-configuration).
+    ///
+    /// - Parameter projectId: Reown cloud project ID from https://cloud.reown.com.
+    static func configure(projectId: String) {
+        Networking.configure(
+            groupIdentifier: "group.com.soneso.stellar.smartdemo",
+            projectId: projectId,
+            socketFactory: SocketFactory()
+        )
+
+        let metadata = AppMetadata(
+            name: "Stellar Smart Account Demo",
+            description: "Stellar Smart Account Demo powered by the KMP Stellar SDK.",
+            url: "https://soneso.com",
+            icons: ["https://soneso.com/icon.png"],
+            redirect: try! AppMetadata.Redirect(
+                native: "stellar-smartdemo://",
+                universal: nil
+            )
+        )
+        Pair.configure(metadata: metadata)
+        Sign.configure(crypto: DefaultCryptoProvider())
+    }
+
+    // MARK: - Lifecycle
+
+    override init() {
+        super.init()
+        subscribeToPublishers()
+    }
+
+    // MARK: - ReownHandler (connect)
+
+    func connect(completion: @escaping (WalletConnectionBridge?, String?) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+
+            // If a session is already active, return it immediately.
+            if let session = self.activeSession, let address = self.connectedAddress {
+                let walletName = session.peer.name
+                completion(WalletConnectionBridge(address: address, walletName: walletName), nil)
+                return
+            }
+
+            self.pendingConnectCompletion = completion
+
+            Task {
+                do {
+                    let uri = try await self.startSession()
+                    await self.openWalletUri(uri.absoluteString)
+                } catch {
+                    DispatchQueue.main.async {
+                        self.pendingConnectCompletion = nil
+                        completion(nil, error.localizedDescription)
+                    }
+                }
+            }
+
+            // Connection timeout watchdog.
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.connectionTimeout) { [weak self] in
+                guard let self else { return }
+                if let pending = self.pendingConnectCompletion {
+                    self.pendingConnectCompletion = nil
+                    pending(nil, "Wallet connection timed out after \(Int(Self.connectionTimeout)) seconds.")
+                }
+            }
+        }
+    }
+
+    // MARK: - ReownHandler (disconnect)
+
+    func disconnect(address: String, completion: @escaping (String?) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                completion(nil)
+                return
+            }
+
+            guard let session = self.activeSession else {
+                // No active session to disconnect — treat as success.
+                completion(nil)
+                return
+            }
+
+            Task {
+                do {
+                    try await Sign.instance.disconnect(topic: session.topic)
+                    DispatchQueue.main.async {
+                        self.stateLock.lock()
+                        self.activeSession = nil
+                        self.connectedAddress = nil
+                        self.stateLock.unlock()
+                        completion(nil)
+                    }
+                } catch {
+                    DispatchQueue.main.async {
+                        completion(error.localizedDescription)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - ReownHandler (signAuthEntry)
+
+    func signAuthEntry(preimageXdr: String, address: String, completion: @escaping (String?, String?) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                completion(nil, "Handler deallocated.")
+                return
+            }
+
+            guard let session = self.activeSession else {
+                completion(nil, "No active wallet session. Connect a wallet before signing.")
+                return
+            }
+
+            guard let chain = self.primaryChain(for: session) else {
+                completion(nil, "Wallet session has no Stellar namespace.")
+                return
+            }
+
+            Task {
+                do {
+                    let params = AnyCodable(["entryXdr": preimageXdr])
+                    let request = try Request(
+                        topic: session.topic,
+                        method: Self.signMethod,
+                        params: params,
+                        chainId: chain,
+                        ttl: Self.requestTtl
+                    )
+
+                    let requestIdKey = request.id.string
+
+                    DispatchQueue.main.async {
+                        self.pendingSignCompletions[requestIdKey] = completion
+                    }
+
+                    try await Sign.instance.request(params: request)
+                    await self.openWalletForSigning(session: session, requestId: request.id.string)
+
+                    // Signing timeout watchdog.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + Self.requestTtl) { [weak self] in
+                        guard let self else { return }
+                        if let pending = self.pendingSignCompletions.removeValue(forKey: requestIdKey) {
+                            pending(nil, "Signing request timed out after \(Int(Self.requestTtl)) seconds.")
+                        }
+                    }
+                } catch {
+                    DispatchQueue.main.async {
+                        completion(nil, error.localizedDescription)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - ReownHandler (synchronous)
+
+    func isConnected(address: String) -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return connectedAddress == address && activeSession != nil
+    }
+
+    func getConnectedAddress() -> String? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return connectedAddress
+    }
+
+    func getNetworkPassphrase(completion: @escaping (String?) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let session = self.activeSession else {
+                completion(nil)
+                return
+            }
+            let passphrase = self.networkPassphrase(for: session)
+            completion(passphrase)
+        }
+    }
+
+    // MARK: - Publisher subscriptions
+
+    private func subscribeToPublishers() {
+        Sign.instance.sessionSettlePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] (session, _) in
+                guard let self else { return }
+                self.handleSessionSettled(session)
+            }
+            .store(in: &cancellables)
+
+        Sign.instance.sessionResponsePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] response in
+                guard let self else { return }
+                self.handleSessionResponse(response)
+            }
+            .store(in: &cancellables)
+
+        Sign.instance.sessionDeletePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] (_, _) in
+                guard let self else { return }
+                self.stateLock.lock()
+                self.activeSession = nil
+                self.connectedAddress = nil
+                self.stateLock.unlock()
+            }
+            .store(in: &cancellables)
+
+        // Restore any previously settled sessions on startup.
+        let sessions = Sign.instance.getSessions()
+        if let existing = sessions.first,
+           let address = stellarAddress(from: existing) {
+            stateLock.lock()
+            activeSession = existing
+            connectedAddress = address
+            stateLock.unlock()
+        }
+    }
+
+    // MARK: - Session helpers
+
+    private func startSession() async throws -> URL {
+        let methods: Set<String> = [Self.signMethod]
+        let chains: [Blockchain] = [
+            Blockchain(Self.testnetChain)!,
+            Blockchain(Self.pubnetChain)!
+        ]
+
+        let stellarNamespace = ProposalNamespace(
+            chains: chains,
+            methods: methods,
+            events: ["accountsChanged"]
+        )
+        let namespaces: [String: ProposalNamespace] = [Self.stellarNamespaceKey: stellarNamespace]
+
+        let uri = try await Sign.instance.connect(namespaces: namespaces)
+        guard let url = URL(string: uri.absoluteString) else {
+            throw ReownError.invalidUri
+        }
+        return url
+    }
+
+    private func handleSessionSettled(_ session: Session) {
+        guard let address = stellarAddress(from: session) else {
+            pendingConnectCompletion?(nil, "Wallet session has no Stellar account address.")
+            pendingConnectCompletion = nil
+            return
+        }
+
+        stateLock.lock()
+        activeSession = session
+        connectedAddress = address
+        stateLock.unlock()
+
+        let bridge = WalletConnectionBridge(
+            address: address,
+            walletName: session.peer.name
+        )
+        pendingConnectCompletion?(bridge, nil)
+        pendingConnectCompletion = nil
+    }
+
+    private func handleSessionResponse(_ response: WalletConnectSign.Response) {
+        let idKey = response.id.string
+        guard let completion = pendingSignCompletions.removeValue(forKey: idKey) else { return }
+
+        switch response.result {
+        case .response(let anyCodable):
+            // Freighter returns { signedAuthEntry: "base64...", signerAddress: "G..." }
+            // via WalletConnect. Extract the signedAuthEntry from the dictionary.
+            if let dict = anyCodable.value as? [String: Any],
+               let signedAuthEntry = dict["signedAuthEntry"] as? String {
+                completion(signedAuthEntry, nil)
+            } else if let signature = anyCodable.value as? String {
+                // Plain string fallback (some wallets may return the signature directly)
+                completion(signature, nil)
+            } else {
+                completion(nil, "Wallet returned an unexpected response format.")
+            }
+        case .error(let rpcError):
+            completion(nil, rpcError.message)
+        }
+    }
+
+    // MARK: - Address / namespace extraction
+
+    private func stellarAddress(from session: Session) -> String? {
+        guard let namespace = session.namespaces[Self.stellarNamespaceKey] else { return nil }
+        // Accounts are formatted as "stellar:testnet:GADDR..." or "stellar:pubnet:GADDR...".
+        return namespace.accounts.first.map { account in
+            // The address is the portion after the last colon.
+            String(account.address)
+        }
+    }
+
+    private func primaryChain(for session: Session) -> Blockchain? {
+        guard let namespace = session.namespaces[Self.stellarNamespaceKey],
+              let firstAccount = namespace.accounts.first else { return nil }
+        // Blockchain is "namespace:chain", e.g. "stellar:testnet"
+        return Blockchain("\(firstAccount.namespace):\(firstAccount.reference)")
+    }
+
+    private func networkPassphrase(for session: Session) -> String? {
+        guard let chain = primaryChain(for: session) else { return nil }
+        switch chain.absoluteString {
+        case Self.testnetChain: return Self.testnetPassphrase
+        case Self.pubnetChain: return Self.pubnetPassphrase
+        default: return nil
+        }
+    }
+
+    // MARK: - Deep link helpers
+
+    @MainActor
+    private func openWalletUri(_ uriString: String) {
+        // Freighter Mobile's deep link format (from the Reown wallet registry):
+        //   freighterwallet://wc-redirect?uri={RFC3986 percent-encoded WC URI}
+        //
+        // The WC URI contains ?, &, = characters that must be fully encoded.
+        // Using .alphanumerics ensures all special characters are encoded.
+        guard let encoded = uriString.addingPercentEncoding(withAllowedCharacters: .alphanumerics),
+              let url = URL(string: "freighterwallet://wc-redirect?uri=\(encoded)") else {
+            print("[ReownWalletHandler] Failed to build Freighter deep link")
+            return
+        }
+        print("[ReownWalletHandler] Opening Freighter via wc-redirect deep link")
+        UIApplication.shared.open(url) { success in
+            if !success {
+                print("[ReownWalletHandler] Could not open Freighter — is it installed?")
+            }
+        }
+    }
+
+    @MainActor
+    private func openWalletForSigning(session: Session, requestId: String) {
+        // Redirect the user back to the wallet to approve the signing request.
+        let redirectUrl = session.peer.redirect?.native ?? session.peer.redirect?.universal
+        if let redirectString = redirectUrl, let url = URL(string: redirectString) {
+            UIApplication.shared.open(url)
+        }
+    }
+}
+
+// MARK: - DefaultCryptoProvider
+
+/// Minimal `CryptoProvider` stub for the Reown SDK.
+///
+/// WalletConnectSign requires a `CryptoProvider` conformance. Both methods
+/// (`recoverPubKey` and `keccak256`) are only used by Ethereum-specific
+/// components (ENS resolver, EIP-191/1271 verification, EIP-55 encoding)
+/// for SIWE authentication flows. The WalletConnectSign module never calls
+/// them during standard session management, pairing, or request/response.
+/// They are dead code paths for Stellar — return empty Data to satisfy the
+/// protocol requirement.
+final class DefaultCryptoProvider: CryptoProvider {
+
+    func recoverPubKey(signature: EthereumSignature, message: Data) throws -> Data {
+        return Data()
+    }
+
+    func keccak256(_ data: Data) -> Data {
+        return Data()
+    }
+}
+
+// MARK: - ReownError
+
+private enum ReownError: LocalizedError {
+    case invalidUri
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidUri:
+            return "WalletConnect produced an invalid pairing URI."
+        }
+    }
+}

--- a/smart-account-demo/iosApp/project.yml
+++ b/smart-account-demo/iosApp/project.yml
@@ -13,6 +13,9 @@ packages:
   swift-sodium:
     url: https://github.com/jedisct1/swift-sodium
     from: 0.9.1
+  reown-swift:
+    url: https://github.com/reown-com/reown-swift
+    from: 2.0.0
 targets:
   StellarSmartDemo:
     type: application
@@ -25,18 +28,24 @@ targets:
       path: StellarSmartDemo/Info.plist
       properties:
         CFBundleShortVersionString: "0.1.0"
-        CFBundleVersion: 1
+        CFBundleVersion: "1"
         UILaunchStoryboardName: LaunchScreen
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CADisableMinimumFrameDurationOnPhone: true
+        CFBundleURLTypes:
+          - CFBundleURLName: com.soneso.stellar.smartdemo
+            CFBundleURLSchemes:
+              - stellar-smartdemo
     entitlements:
       path: StellarSmartDemo/StellarSmartDemo.entitlements
       properties:
         com.apple.developer.associated-domains:
           - webcredentials:soneso.com?mode=developer
+        com.apple.security.application-groups:
+          - group.com.soneso.stellar.smartdemo
     settings:
       FRAMEWORK_SEARCH_PATHS:
         - $(inherited)
@@ -50,6 +59,12 @@ targets:
         embed: true
       - package: swift-sodium
         product: Clibsodium
+      - package: reown-swift
+        product: WalletConnect
+      - package: reown-swift
+        product: WalletConnectNetworking
+      - package: reown-swift
+        product: WalletConnectPairing
     preBuildScripts:
       - script: |
           cd "$SRCROOT/../.."

--- a/smart-account-demo/shared/build.gradle.kts
+++ b/smart-account-demo/shared/build.gradle.kts
@@ -97,6 +97,11 @@ kotlin {
             dependencies {
                 implementation("androidx.activity:activity-compose:1.8.2")
                 implementation("androidx.appcompat:appcompat:1.6.1")
+
+                // Reown (WalletConnect v2) for external wallet connection via Freighter Mobile.
+                // Required by ReownConnector which implements WalletConnector for Android.
+                implementation("com.reown:android-core:1.6.12")
+                implementation("com.reown:sign:1.6.12")
             }
         }
 
@@ -140,6 +145,8 @@ kotlin {
         val jsMain by getting {
             dependencies {
                 implementation(compose.html.core)
+                // Freighter browser extension API for web wallet signing
+                implementation(npm("@stellar/freighter-api", "6.0.1"))
             }
         }
     }

--- a/smart-account-demo/shared/src/androidMain/kotlin/com/soneso/smartdemo/wallet/ReownConnector.kt
+++ b/smart-account-demo/shared/src/androidMain/kotlin/com/soneso/smartdemo/wallet/ReownConnector.kt
@@ -1,0 +1,486 @@
+package com.soneso.smartdemo.wallet
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import com.reown.android.CoreClient
+import com.reown.sign.client.Sign
+import com.reown.sign.client.SignClient
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * WalletConnect v2 (Reown SignClient) implementation of [WalletConnector] for Android.
+ *
+ * Connects to Freighter Mobile via deep link using the Stellar WalletConnect namespace:
+ * - Chain: `stellar:testnet`
+ * - Methods: `["stellar_signAuthEntry"]`
+ *
+ * Session lifecycle:
+ * 1. [connect] creates a pairing via CoreClient.Pairing, proposes a session with the Stellar
+ *    namespace, opens Freighter via deep link, then waits for session approval via the dapp
+ *    delegate callback.
+ * 2. [signAuthEntry] sends a `stellar_signAuthEntry` request to the active session and waits
+ *    for the wallet to approve and return a base64-encoded Ed25519 signature.
+ * 3. [disconnect] terminates the active WalletConnect session.
+ *
+ * Must be instantiated after [SmartDemoApplication.onCreate] completes so that SignClient is
+ * already initialized.
+ *
+ * @param context Android application context used for launching deep links.
+ */
+class ReownConnector(private val context: Context) : WalletConnector {
+
+    private val connectMutex = Mutex()
+
+    /** Topic of the active WalletConnect session, null if not connected. */
+    @Volatile
+    private var sessionTopic: String? = null
+
+    /** G-address from the active session's approved accounts. */
+    @Volatile
+    private var connectedAddress: String? = null
+
+    /**
+     * Deferred awaited during [connect] until the wallet approves or rejects the session.
+     * Protected by [connectMutex] — only one session proposal may be in flight at a time.
+     */
+    @Volatile
+    private var pendingSessionDeferred: CompletableDeferred<Sign.Model.ApprovedSession>? = null
+
+    /**
+     * Map from request ID to the deferred awaited in [signAuthEntry].
+     * Synchronized on itself because multiple concurrent signing requests are supported.
+     */
+    private val pendingRequestDeferreds = mutableMapOf<Long, CompletableDeferred<Sign.Model.SessionRequestResponse>>()
+
+    // -------------------------------------------------------------------------
+    // Dapp delegate — handles async callbacks from SignClient
+    // Declared before init block so the property is initialized when setDappDelegate is called.
+    // -------------------------------------------------------------------------
+
+    private val dappDelegate = object : SignClient.DappDelegate {
+
+        override fun onSessionApproved(approvedSession: Sign.Model.ApprovedSession) {
+            Log.d(TAG, "onSessionApproved: topic=${approvedSession.topic}")
+            pendingSessionDeferred?.complete(approvedSession)
+        }
+
+        override fun onSessionRejected(rejectedSession: Sign.Model.RejectedSession) {
+            Log.w(TAG, "onSessionRejected: reason=${rejectedSession.reason}")
+            pendingSessionDeferred?.completeExceptionally(
+                WalletConnectionException("Wallet rejected the session: ${rejectedSession.reason}")
+            )
+        }
+
+        override fun onSessionRequestResponse(response: Sign.Model.SessionRequestResponse) {
+            val requestId = response.result.id
+            Log.d(TAG, "onSessionRequestResponse: requestId=$requestId")
+            synchronized(pendingRequestDeferreds) {
+                pendingRequestDeferreds[requestId]?.complete(response)
+            }
+        }
+
+        override fun onProposalExpired(proposal: Sign.Model.ExpiredProposal) {
+            Log.w(TAG, "onProposalExpired: pairingTopic=${proposal.pairingTopic}")
+            // Do not fail the deferred here. In mobile-to-mobile flows, the relay
+            // connection is suspended while the user is in Freighter. The SDK may
+            // fire onProposalExpired before the relay reconnects and delivers the
+            // session approval. Let the connect() timeout handle the actual failure.
+        }
+
+        override fun onRequestExpired(request: Sign.Model.ExpiredRequest) {
+            Log.w(TAG, "onRequestExpired: requestId=${request.id}")
+            synchronized(pendingRequestDeferreds) {
+                pendingRequestDeferreds[request.id]?.completeExceptionally(
+                    WalletSigningException("Signing request expired before the wallet responded.")
+                )
+            }
+        }
+
+        override fun onSessionDelete(deletedSession: Sign.Model.DeletedSession) {
+            Log.d(TAG, "onSessionDelete: $deletedSession")
+            val currentTopic = sessionTopic
+            if (currentTopic != null &&
+                deletedSession is Sign.Model.DeletedSession.Success &&
+                deletedSession.topic == currentTopic
+            ) {
+                sessionTopic = null
+                connectedAddress = null
+                Log.i(TAG, "Session deleted by wallet. Local state cleared.")
+            }
+        }
+
+        override fun onSessionUpdate(updatedSession: Sign.Model.UpdatedSession) {
+            Log.d(TAG, "onSessionUpdate: topic=${updatedSession.topic}")
+        }
+
+        override fun onSessionExtend(session: Sign.Model.Session) {
+            Log.d(TAG, "onSessionExtend: topic=${session.topic}")
+        }
+
+        override fun onSessionEvent(sessionEvent: Sign.Model.SessionEvent) {
+            Log.d(TAG, "onSessionEvent: name=${sessionEvent.name}")
+        }
+
+        override fun onConnectionStateChange(state: Sign.Model.ConnectionState) {
+            Log.d(TAG, "onConnectionStateChange: isAvailable=${state.isAvailable}")
+        }
+
+        override fun onError(error: Sign.Model.Error) {
+            Log.e(TAG, "SignClient delegate error: ${error.throwable.message}", error.throwable)
+        }
+    }
+
+    init {
+        SignClient.setDappDelegate(dappDelegate)
+    }
+
+    // -------------------------------------------------------------------------
+    // WalletConnector implementation
+    // -------------------------------------------------------------------------
+
+    override suspend fun connect(): WalletConnection? {
+        val deferred = CompletableDeferred<Sign.Model.ApprovedSession>()
+
+        connectMutex.withLock {
+            if (pendingSessionDeferred != null) {
+                throw WalletConnectionException("A connection attempt is already in progress.")
+            }
+            pendingSessionDeferred = deferred
+        }
+
+        return try {
+            val pairingUri = createPairingAndConnect()
+
+            // Launch Freighter (or any WalletConnect-compatible wallet) via deep link.
+            launchWalletDeepLink(pairingUri)
+
+            val session = withTimeoutOrNull(SESSION_TIMEOUT_MS) { deferred.await() }
+                ?: throw WalletConnectionException("Wallet did not respond within the timeout period.")
+
+            val address = extractAddressFromSession(session)
+
+            connectMutex.withLock {
+                sessionTopic = session.topic
+                connectedAddress = address
+            }
+
+            Log.d(TAG, "Session established: topic=${session.topic}, address=$address")
+            WalletConnection(address = address, walletName = WALLET_NAME)
+        } catch (e: WalletConnectionException) {
+            throw e
+        } catch (e: Exception) {
+            throw WalletConnectionException("Failed to connect to wallet: ${e.message}", e)
+        } finally {
+            connectMutex.withLock { pendingSessionDeferred = null }
+        }
+    }
+
+    override suspend fun disconnect(address: String) {
+        val topic: String
+
+        connectMutex.withLock {
+            if (connectedAddress != address) return
+            topic = sessionTopic ?: return
+            sessionTopic = null
+            connectedAddress = null
+        }
+
+        val disconnectDeferred = CompletableDeferred<Unit>()
+
+        SignClient.disconnect(
+            disconnect = Sign.Params.Disconnect(sessionTopic = topic),
+            onSuccess = { _ -> disconnectDeferred.complete(Unit) },
+            onError = { error ->
+                // Local state is already cleared; log but do not propagate.
+                Log.w(TAG, "SignClient.disconnect error: ${error.throwable.message}")
+                disconnectDeferred.complete(Unit)
+            }
+        )
+
+        withTimeoutOrNull(DISCONNECT_TIMEOUT_MS) { disconnectDeferred.await() }
+        Log.d(TAG, "Disconnected session: topic=$topic")
+    }
+
+    override suspend fun signAuthEntry(authEntryPreimageXdr: String, address: String): String {
+        // Snapshot session state under the mutex to avoid a race with onSessionDelete
+        val topic = connectMutex.withLock {
+            if (connectedAddress == address) sessionTopic else null
+        }
+        if (topic == null) {
+            throw WalletSigningException("No active wallet session for address $address.")
+        }
+
+        val sendDeferred = CompletableDeferred<Sign.Model.SentRequest>()
+
+        val request = Sign.Params.Request(
+            sessionTopic = topic,
+            method = METHOD_SIGN_AUTH_ENTRY,
+            params = buildSignParams(authEntryPreimageXdr),
+            chainId = STELLAR_CHAIN_ID
+        )
+
+        SignClient.request(
+            request = request,
+            onSuccess = { sentRequest -> sendDeferred.complete(sentRequest) },
+            onError = { error ->
+                sendDeferred.completeExceptionally(
+                    WalletSigningException(
+                        "Failed to send sign request: ${error.throwable.message}",
+                        error.throwable
+                    )
+                )
+            }
+        )
+
+        val sentRequest = try {
+            withTimeoutOrNull(REQUEST_SEND_TIMEOUT_MS) { sendDeferred.await() }
+                ?: throw WalletSigningException("Timed out waiting for request send acknowledgement.")
+        } catch (e: WalletSigningException) {
+            throw e
+        } catch (e: Exception) {
+            throw WalletSigningException("Failed to send sign request: ${e.message}", e)
+        }
+
+        // Open Freighter so the user can see and approve the signing request.
+        // The request was sent via the relay; Freighter needs to be in the foreground.
+        openWalletForSigning()
+
+        val responseDeferred = CompletableDeferred<Sign.Model.SessionRequestResponse>()
+        synchronized(pendingRequestDeferreds) {
+            pendingRequestDeferreds[sentRequest.requestId] = responseDeferred
+        }
+
+        return try {
+            val response = withTimeoutOrNull(SIGNING_TIMEOUT_MS) { responseDeferred.await() }
+                ?: throw WalletSigningException("Wallet did not respond to signing request within the timeout period.")
+
+            parseSignAuthEntryResponse(response)
+        } finally {
+            synchronized(pendingRequestDeferreds) {
+                pendingRequestDeferreds.remove(sentRequest.requestId)
+            }
+        }
+    }
+
+    override fun isConnected(address: String): Boolean =
+        connectedAddress == address && sessionTopic != null
+
+    override fun getConnectedAddress(): String? = connectedAddress
+
+    override suspend fun getNetworkPassphrase(): String? = null
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a WalletConnect pairing and proposes a session with the Stellar namespace.
+     *
+     * Must be called from a coroutine. [CoreClient.Pairing.create] is a blocking call and must
+     * run on [Dispatchers.IO] (the caller uses `withContext(Dispatchers.IO)`).
+     * [SignClient.connect] fires its callbacks asynchronously; this function bridges them via
+     * [CompletableDeferred] so the caller can suspend until the URI is available.
+     *
+     * @return The WalletConnect pairing URI (`wc:...`) to pass to the wallet via deep link.
+     * @throws WalletConnectionException if pairing creation or session proposal fails.
+     */
+    private suspend fun createPairingAndConnect(): String {
+        val pairingErrorHolder = arrayOfNulls<Throwable>(1)
+
+        // CoreClient.Pairing.create is a blocking call — must run on IO dispatcher.
+        val pairing = withContext(Dispatchers.IO) {
+            CoreClient.Pairing.create(
+                onError = { error -> pairingErrorHolder[0] = error.throwable }
+            )
+        } ?: run {
+            val cause = pairingErrorHolder[0]
+            throw WalletConnectionException(
+                "Failed to create pairing: ${cause?.message ?: "Reown CoreClient may not be initialized."}",
+                cause
+            )
+        }
+
+        val connectDeferred = CompletableDeferred<String>()
+
+        val requiredNamespaces = mapOf(
+            STELLAR_NAMESPACE to Sign.Model.Namespace.Proposal(
+                chains = listOf(STELLAR_CHAIN_ID),
+                methods = listOf(METHOD_SIGN_AUTH_ENTRY),
+                events = emptyList()
+            )
+        )
+
+        val connectParams = Sign.Params.Connect(
+            namespaces = requiredNamespaces,
+            pairing = pairing
+        )
+
+        // onSuccess delivers the pairing URI. It fires asynchronously inside a coroutine scope
+        // launched by SignClient, so we suspend with connectDeferred.await() below.
+        SignClient.connect(
+            connect = connectParams,
+            onSuccess = { uri -> connectDeferred.complete(uri) },
+            onError = { error ->
+                connectDeferred.completeExceptionally(
+                    WalletConnectionException(
+                        "Session proposal failed: ${error.throwable.message}",
+                        error.throwable
+                    )
+                )
+            }
+        )
+
+        return try {
+            withTimeoutOrNull(REQUEST_SEND_TIMEOUT_MS) { connectDeferred.await() }
+                ?: throw WalletConnectionException("Timed out waiting for session proposal URI.")
+        } catch (e: WalletConnectionException) {
+            throw e
+        } catch (e: Exception) {
+            throw WalletConnectionException("Session proposal failed: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Launches the wallet app via a WalletConnect URI deep link.
+     *
+     * Freighter Mobile's deep link format (from the Reown wallet registry):
+     *   freighterwallet://wc-redirect?uri={RFC3986 percent-encoded WC URI}
+     */
+    private fun launchWalletDeepLink(wcUri: String) {
+        try {
+            val encoded = Uri.encode(wcUri, "")
+            val freighterUri = Uri.parse("freighterwallet://wc-redirect?uri=$encoded")
+            val intent = Intent(Intent.ACTION_VIEW, freighterUri).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+            context.startActivity(intent)
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not launch Freighter Mobile: ${e.message}")
+        }
+    }
+
+    /**
+     * Opens Freighter to the foreground so the user can approve a signing request.
+     * The request is already delivered via the relay; Freighter just needs to be visible.
+     */
+    private fun openWalletForSigning() {
+        try {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("freighterwallet://")).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+            context.startActivity(intent)
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not bring Freighter to foreground: ${e.message}")
+        }
+    }
+
+    /**
+     * Extracts the first G-address from the session's approved accounts.
+     *
+     * Account entries use the format `stellar:testnet:<G-address>`.
+     */
+    private fun extractAddressFromSession(session: Sign.Model.ApprovedSession): String {
+        val accounts = session.namespaces[STELLAR_NAMESPACE]?.accounts
+            ?: throw WalletConnectionException("Session does not contain a '$STELLAR_NAMESPACE' namespace.")
+        if (accounts.isEmpty()) {
+            throw WalletConnectionException("Session was approved with no accounts in the '$STELLAR_NAMESPACE' namespace.")
+        }
+        // Format: stellar:testnet:GABC... — take everything after the second colon.
+        val entry = accounts.first()
+        val parts = entry.split(":")
+        if (parts.size < 3) {
+            throw WalletConnectionException("Unexpected account entry format in session: $entry")
+        }
+        return parts.drop(2).joinToString(":")
+    }
+
+    /**
+     * Builds the JSON params for a `stellar_signAuthEntry` request.
+     *
+     * Freighter expects `requestParams` to be an object: `{"entryXdr":"<base64>"}`.
+     * The Reown SDK wraps this as `request.params` in the JSON-RPC message.
+     */
+    private fun buildSignParams(authEntryPreimageXdr: String): String {
+        val escaped = authEntryPreimageXdr
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+        return """{"entryXdr":"$escaped"}"""
+    }
+
+    /**
+     * Parses the wallet's response to a `stellar_signAuthEntry` request.
+     *
+     * Freighter returns: { signedAuthEntry: "base64...", signerAddress: "G..." }
+     *
+     * In Reown 1.6.12, JsonRpcResult.result is Any? — it may be a deserialized Map,
+     * a JSON string, or a plain string depending on the relay response format.
+     */
+    private fun parseSignAuthEntryResponse(response: Sign.Model.SessionRequestResponse): String {
+        return when (val jsonRpcResponse = response.result) {
+            is Sign.Model.JsonRpcResponse.JsonRpcResult -> {
+                val result = jsonRpcResponse.result
+                    ?: throw WalletSigningException("Wallet returned null result")
+
+                Log.d(TAG, "Sign response: class=${result::class.java.name}")
+
+                // Freighter returns: {"signedAuthEntry":"<base64>","signerAddress":"G..."}
+                //
+                // On iOS (Swift), the Reown SDK gives this as a dictionary (AnyCodable).
+                // On Android (Kotlin), the Reown engine converts it to a String using
+                // Map.toString(), producing: {signedAuthEntry=<base64>, signerAddress=G...}
+                // This is NOT valid JSON — it uses = instead of : and has no quotes.
+                // See: reown-kotlin EngineMapper.kt — `result = result.toString()`
+                //
+                // Parse the signedAuthEntry value from this format.
+                val str = result.toString()
+                val prefix = "signedAuthEntry="
+                val startIndex = str.indexOf(prefix)
+                if (startIndex < 0) {
+                    throw WalletSigningException("Response missing signedAuthEntry: $str")
+                }
+                val valueStart = startIndex + prefix.length
+                // The value ends at ", signerAddress=" or at "}"
+                val nextField = str.indexOf(", ", valueStart)
+                val valueEnd = if (nextField >= 0) nextField else str.indexOf("}", valueStart)
+                if (valueEnd < 0) {
+                    throw WalletSigningException("Could not parse signedAuthEntry value from: $str")
+                }
+                str.substring(valueStart, valueEnd)
+            }
+            is Sign.Model.JsonRpcResponse.JsonRpcError -> {
+                throw WalletSigningException(
+                    "Wallet rejected the signing request: ${jsonRpcResponse.message} (code ${jsonRpcResponse.code})"
+                )
+            }
+        }
+    }
+
+
+    private companion object {
+        private const val TAG = "ReownConnector"
+
+        private const val STELLAR_NAMESPACE = "stellar"
+        private const val STELLAR_CHAIN_ID = "stellar:testnet"
+        private const val METHOD_SIGN_AUTH_ENTRY = "stellar_signAuthEntry"
+        private const val WALLET_NAME = "Freighter"
+
+        /** Maximum time to wait for the wallet to approve the session after the deep link opens. */
+        private const val SESSION_TIMEOUT_MS = 120_000L
+
+        /** Maximum time to wait for the request send acknowledgement from SignClient. */
+        private const val REQUEST_SEND_TIMEOUT_MS = 30_000L
+
+        /** Maximum time to wait for a signing response from the wallet. */
+        private const val SIGNING_TIMEOUT_MS = 120_000L
+
+        /** Maximum time to wait for the disconnect call to complete. */
+        private const val DISCONNECT_TIMEOUT_MS = 10_000L
+    }
+}

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/config/DemoConfig.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/config/DemoConfig.kt
@@ -93,6 +93,16 @@ object DemoConfig {
      *  Acts as a safety cap to prevent unbounded iteration if the active count is stale.
      *  The contract uses monotonically increasing IDs with gaps from removed rules. */
     val MAX_CONTEXT_RULE_SCAN_ID = 25u
+
+    // -- Reown (WalletConnect) --
+
+    /**
+     * Reown (WalletConnect) project ID for external wallet connection via Freighter Mobile.
+     * Required for wallet connection on Android and iOS real devices. Not needed for
+     * simulators, emulators, or web (which uses the Freighter browser extension directly).
+     * Register for a free project ID at https://cloud.reown.com/.
+     */
+    const val REOWN_PROJECT_ID = ""
 }
 
 /**

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/flows/MainScreenFlow.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/flows/MainScreenFlow.kt
@@ -51,6 +51,7 @@ suspend fun initializeKit(
     // This bridges the ExternalWalletAdapter interface to in-memory Ed25519 keypairs,
     // enabling multi-signer transfers where a delegated Stellar account co-signs.
     val externalSignerManagerAdapter = ExternalSignerManagerAdapter()
+    externalSignerManagerAdapter.walletConnector = DemoState.walletConnector
 
     // Build the SDK configuration from DemoConfig constants.
     // takeIf { isNotBlank() } ensures blank strings are treated as absent (no relayer/indexer).

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/state/DemoState.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/state/DemoState.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.soneso.smartdemo.util.ExternalSignerManagerAdapter
+import com.soneso.smartdemo.wallet.WalletConnector
 import com.soneso.stellar.sdk.smartaccount.oz.OZSmartAccountKit
 import com.soneso.stellar.sdk.smartaccount.oz.StorageAdapter
 import com.soneso.stellar.sdk.smartaccount.oz.WebAuthnProvider
@@ -30,6 +31,11 @@ object DemoState {
 
     /** Platform-specific storage adapter, set by platform entry points. */
     var storage: StorageAdapter? = null
+        private set
+
+    /** Platform-specific wallet connector for external wallet signing (Freighter).
+     *  Set by platform entry points. Null on macOS where wallet connection is not supported. */
+    var walletConnector: WalletConnector? = null
         private set
 
     /** Whether a wallet is currently connected. */
@@ -76,6 +82,10 @@ object DemoState {
         storage = storageAdapter
     }
 
+    fun setWalletConnector(connector: WalletConnector?) {
+        walletConnector = connector
+    }
+
     fun setConnected(connected: Boolean, contract: String? = null, credential: String? = null) {
         isConnected = connected
         contractId = contract
@@ -107,6 +117,9 @@ object DemoState {
         externalSignerManager = null
         webauthnProvider = null
         storage = null
+        // walletConnector is NOT reset — it is a platform-level singleton
+        // injected at app startup. Wallet sessions are disconnected in the
+        // disconnect flow before reset() is called.
         isConnected = false
         isDeployed = false
         contractId = null

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/ui/components/SignerPickerDialog.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/ui/components/SignerPickerDialog.kt
@@ -55,10 +55,14 @@ import androidx.compose.ui.window.DialogProperties
 import com.soneso.stellar.sdk.KeyPair
 import com.soneso.stellar.sdk.smartaccount.core.DelegatedSigner
 import com.soneso.stellar.sdk.smartaccount.core.ExternalSigner
+import com.soneso.smartdemo.config.DemoConfig
+import com.soneso.smartdemo.state.DemoState
 import com.soneso.smartdemo.util.formatSignerForDisplay
 import com.soneso.smartdemo.util.truncateAddress
 import com.soneso.stellar.sdk.smartaccount.core.SmartAccountBuilders
 import com.soneso.stellar.sdk.smartaccount.core.SmartAccountSigner
+import com.soneso.smartdemo.wallet.WalletConnector
+import com.soneso.smartdemo.wallet.WalletConnection
 import kotlinx.coroutines.launch
 
 /**
@@ -72,11 +76,23 @@ data class DelegatedSignerKeyPair(
 )
 
 /**
+ * Represents how a delegated signer has been authorized for signing.
+ */
+private sealed class DelegatedSignerAuth {
+    /** Authorized via a manually-entered secret key. */
+    data class SecretKey(val keyPair: KeyPair) : DelegatedSignerAuth()
+
+    /** Authorized via an externally connected wallet (e.g., Freighter). */
+    data class Wallet(val connection: WalletConnection) : DelegatedSignerAuth()
+}
+
+/**
  * A dialog component for selecting signers in multi-signature transactions.
  *
  * Displays categorized lists of available signers (passkey, delegated, Ed25519)
  * and allows the user to select which ones to use for authorization. For delegated
- * signers, the user can enter a Stellar secret key to enable signing.
+ * signers, the user can enter a Stellar secret key or connect an external wallet
+ * (where available) to enable signing.
  *
  * @param isOpen Whether the dialog is visible
  * @param onDismiss Called when the dialog is dismissed without confirming
@@ -101,17 +117,32 @@ fun SignerPickerDialog(
     if (!isOpen) return
 
     val scope = rememberCoroutineScope()
+    val walletConnector = DemoState.walletConnector
 
     // Selection state: track selected signer unique keys
     val selectedSignerKeys = remember { mutableStateMapOf<String, Boolean>() }
 
-    // Delegated signer secret key state
-    val delegatedKeyPairs = remember { mutableStateMapOf<String, DelegatedSignerKeyPair>() }
+    // Delegated signer auth state — covers both secret-key and wallet-connected signers
+    val delegatedSignerAuth = remember { mutableStateMapOf<String, DelegatedSignerAuth>() }
+
+    // Secret key input state
     var secretKeyInputAddress by remember { mutableStateOf<String?>(null) }
     var secretKeyValue by remember { mutableStateOf("") }
     var secretKeyError by remember { mutableStateOf<String?>(null) }
     var isValidatingKey by remember { mutableStateOf(false) }
     var secretKeyVisible by remember { mutableStateOf(false) }
+
+    // Wallet connection state — address of the signer currently being connected (loading state)
+    var walletConnectingAddress by remember { mutableStateOf<String?>(null) }
+
+    // Per-signer wallet error messages
+    val walletErrors = remember { mutableStateMapOf<String, String>() }
+
+    // Track which signer address has an active wallet connection
+    // (only one delegated signer may have a wallet connection at a time)
+    val walletConnectedAddress: String? = delegatedSignerAuth.entries
+        .firstOrNull { it.value is DelegatedSignerAuth.Wallet }
+        ?.key
 
     // Categorize signers
     val passkeySigners = remember(availableSigners) {
@@ -132,7 +163,7 @@ fun SignerPickerDialog(
         }
     }
 
-    // Auto-select active passkey and signers with stored keypairs on open
+    // Auto-select active passkey and signers with stored auth on open
     LaunchedEffect(isOpen, activeCredentialId, availableSigners) {
         if (isOpen) {
             // Auto-select the active passkey
@@ -145,8 +176,8 @@ fun SignerPickerDialog(
                 }
             }
 
-            // Auto-select delegated signers that already have keypairs stored
-            for ((address, _) in delegatedKeyPairs) {
+            // Auto-select delegated signers that already have auth stored
+            for ((address, _) in delegatedSignerAuth) {
                 val matchingSigner = delegatedSigners.find { it.address == address }
                 if (matchingSigner != null) {
                     selectedSignerKeys[matchingSigner.uniqueKey] = true
@@ -155,15 +186,31 @@ fun SignerPickerDialog(
         }
     }
 
-    // Clean up secret key state on dismiss
+    // Clean up state when the dialog closes. DisposableEffect fires onDispose when
+    // isOpen changes in either direction. When opening (false->true), delegatedSignerAuth
+    // is empty so the disconnect is a no-op. When closing (true->false), any active
+    // wallet session is disconnected. Backgrounding does not trigger disposal.
     DisposableEffect(isOpen) {
         onDispose {
             secretKeyValue = ""
             secretKeyError = null
             secretKeyInputAddress = null
             secretKeyVisible = false
-            // Clear stored keypairs and selection state on dialog close
-            delegatedKeyPairs.clear()
+            walletErrors.clear()
+
+            val addressToDisconnect = delegatedSignerAuth.entries
+                .firstOrNull { it.value is DelegatedSignerAuth.Wallet }
+                ?.key
+            if (addressToDisconnect != null && walletConnector != null) {
+                scope.launch {
+                    try {
+                        walletConnector.disconnect(addressToDisconnect)
+                    } catch (_: Throwable) {
+                        // Best-effort disconnect — ignore errors on cleanup
+                    }
+                }
+            }
+            delegatedSignerAuth.clear()
             selectedSignerKeys.clear()
         }
     }
@@ -239,16 +286,21 @@ fun SignerPickerDialog(
                     if (delegatedSigners.isNotEmpty()) {
                         SignerSectionHeader(label = "Stellar Account Signers")
                         delegatedSigners.forEach { signer ->
-                            val hasKeyPair = delegatedKeyPairs.containsKey(signer.address)
+                            val signerAuth = delegatedSignerAuth[signer.address]
+                            val hasKeyPair = signerAuth is DelegatedSignerAuth.SecretKey
+                            val isWalletConnected = signerAuth is DelegatedSignerAuth.Wallet
                             val isSelected = selectedSignerKeys[signer.uniqueKey] == true
                             val isEnteringKey = secretKeyInputAddress == signer.address
+                            val isConnecting = walletConnectingAddress == signer.address
+                            val isAnotherWalletConnected = walletConnectedAddress != null &&
+                                walletConnectedAddress != signer.address
 
                             DelegatedSignerRow(
                                 signer = signer,
                                 hasKeyPair = hasKeyPair,
                                 isSelected = isSelected,
                                 onToggle = {
-                                    if (hasKeyPair) {
+                                    if (hasKeyPair || isWalletConnected) {
                                         selectedSignerKeys[signer.uniqueKey] =
                                             !(selectedSignerKeys[signer.uniqueKey] ?: false)
                                     }
@@ -259,6 +311,74 @@ fun SignerPickerDialog(
                                     secretKeyValue = ""
                                     secretKeyError = null
                                     secretKeyVisible = false
+                                },
+                                walletAvailable = walletConnector != null,
+                                isWalletConnected = isWalletConnected,
+                                isAnotherWalletConnected = isAnotherWalletConnected,
+                                walletConnecting = isConnecting,
+                                walletError = walletErrors[signer.address],
+                                onConnectWalletClick = {
+                                    walletErrors.remove(signer.address)
+                                    walletConnectingAddress = signer.address
+                                    scope.launch {
+                                        try {
+                                            val connector = walletConnector ?: return@launch
+                                            val connection = connector.connect()
+                                            if (connection == null) {
+                                                // User cancelled — nothing to do
+                                                return@launch
+                                            }
+
+                                            // Verify address matches
+                                            if (connection.address != signer.address) {
+                                                walletErrors[signer.address] =
+                                                    "Connected wallet address does not match this signer. " +
+                                                        "Expected: ${signer.address}, got: ${connection.address}"
+                                                return@launch
+                                            }
+
+                                            // Verify network
+                                            val networkPassphrase = walletConnector.getNetworkPassphrase()
+                                            if (networkPassphrase != null &&
+                                                networkPassphrase != DemoConfig.NETWORK_PASSPHRASE
+                                            ) {
+                                                walletErrors[signer.address] =
+                                                    "Wallet is connected to a different network."
+                                                // Disconnect the mismatched session
+                                                try {
+                                                    walletConnector.disconnect(connection.address)
+                                                } catch (_: Throwable) {
+                                                    // Best-effort
+                                                }
+                                                return@launch
+                                            }
+
+                                            // Success
+                                            delegatedSignerAuth[signer.address] =
+                                                DelegatedSignerAuth.Wallet(connection)
+                                            selectedSignerKeys[signer.uniqueKey] = true
+                                        } catch (e: Throwable) {
+                                            walletErrors[signer.address] =
+                                                "Connection failed: ${e.message ?: "Unknown error"}"
+                                        } finally {
+                                            walletConnectingAddress = null
+                                        }
+                                    }
+                                },
+                                onDisconnectWalletClick = {
+                                    val auth = delegatedSignerAuth[signer.address]
+                                    delegatedSignerAuth.remove(signer.address)
+                                    selectedSignerKeys[signer.uniqueKey] = false
+                                    walletErrors.remove(signer.address)
+                                    if (auth is DelegatedSignerAuth.Wallet && walletConnector != null) {
+                                        scope.launch {
+                                            try {
+                                                walletConnector.disconnect(signer.address)
+                                            } catch (_: Throwable) {
+                                                // Best-effort
+                                            }
+                                        }
+                                    }
                                 }
                             )
 
@@ -300,8 +420,9 @@ fun SignerPickerDialog(
                                                     return@launch
                                                 }
 
-                                                // Store the keypair and auto-select the signer
-                                                delegatedKeyPairs[signer.address] = DelegatedSignerKeyPair(keyPair)
+                                                // Store the auth and auto-select the signer
+                                                delegatedSignerAuth[signer.address] =
+                                                    DelegatedSignerAuth.SecretKey(keyPair)
                                                 selectedSignerKeys[signer.uniqueKey] = true
                                                 secretKeyInputAddress = null
                                                 secretKeyValue = ""
@@ -360,7 +481,12 @@ fun SignerPickerDialog(
                         val selected = availableSigners.filter { signer ->
                             selectedSignerKeys[signer.uniqueKey] == true
                         }
-                        val keyPairs = delegatedKeyPairs.mapValues { (_, value) -> value.keyPair }
+                        // Build the delegated keypairs map from secret-key-authorized signers only.
+                        // Wallet-authorized signers are handled separately by the caller via
+                        // WalletConnector.signAuthEntry and do not need a local KeyPair.
+                        val keyPairs = delegatedSignerAuth
+                            .filterValues { it is DelegatedSignerAuth.SecretKey }
+                            .mapValues { (_, auth) -> (auth as DelegatedSignerAuth.SecretKey).keyPair }
                         onConfirm(selected, keyPairs)
                     }
                 )
@@ -523,6 +649,13 @@ private fun PasskeySignerRow(
     }
 }
 
+/**
+ * Row for a delegated (Stellar account) signer.
+ *
+ * Supports two authorization modes: entering a secret key directly, or connecting
+ * an external wallet (e.g., Freighter). The wallet option is hidden when
+ * [walletAvailable] is false (e.g., macOS).
+ */
 @Composable
 private fun DelegatedSignerRow(
     signer: DelegatedSigner,
@@ -530,86 +663,217 @@ private fun DelegatedSignerRow(
     isSelected: Boolean,
     onToggle: () -> Unit,
     isEnteringKey: Boolean,
-    onEnterKeyClick: () -> Unit
+    onEnterKeyClick: () -> Unit,
+    walletAvailable: Boolean,
+    isWalletConnected: Boolean,
+    isAnotherWalletConnected: Boolean,
+    walletConnecting: Boolean,
+    walletError: String?,
+    onConnectWalletClick: () -> Unit,
+    onDisconnectWalletClick: () -> Unit
 ) {
+    val isAuthorized = hasKeyPair || isWalletConnected
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(bottom = if (isEnteringKey) 0.dp else 8.dp)
-            .clickable(enabled = hasKeyPair, onClick = onToggle),
+            .clickable(enabled = isAuthorized, onClick = onToggle),
         colors = CardDefaults.cardColors(
-            containerColor = if (isSelected && hasKeyPair) {
+            containerColor = if (isSelected && isAuthorized) {
                 MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
             } else {
                 MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
             }
         )
     ) {
-        Row(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .padding(12.dp)
         ) {
-            Checkbox(
-                checked = isSelected,
-                onCheckedChange = { onToggle() },
-                enabled = hasKeyPair
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = truncateAddress(signer.address, 6),
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Medium,
-                    fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.onSurface
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Checkbox(
+                    checked = isSelected,
+                    onCheckedChange = { onToggle() },
+                    enabled = isAuthorized
                 )
-                Spacer(modifier = Modifier.height(2.dp))
-                if (hasKeyPair) {
+                Spacer(modifier = Modifier.width(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = "Ready to sign",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = Color(0xFF4CAF50)
+                        text = truncateAddress(signer.address, 6),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurface
                     )
-                } else {
-                    Text(
-                        text = "Enter secret key to enable signing",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    when {
+                        hasKeyPair -> Text(
+                            text = "Ready to sign",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color(0xFF4CAF50)
+                        )
+                        isWalletConnected -> Text(
+                            text = "Freighter - Ready to sign",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color(0xFF4CAF50)
+                        )
+                        else -> Text(
+                            text = "Enter secret key or connect wallet to enable signing",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                // Badge on the right
+                when {
+                    hasKeyPair -> {
+                        Surface(
+                            color = Color(0xFF4CAF50),
+                            shape = MaterialTheme.shapes.small
+                        ) {
+                            Text(
+                                text = "Verified",
+                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = Color.White
+                            )
+                        }
+                    }
+                    isWalletConnected -> {
+                        Surface(
+                            color = Color(0xFF1565C0),
+                            shape = MaterialTheme.shapes.small
+                        ) {
+                            Text(
+                                text = "Freighter",
+                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = Color.White
+                            )
+                        }
+                    }
                 }
             }
-            if (!hasKeyPair && !isEnteringKey) {
-                OutlinedButton(
-                    onClick = onEnterKeyClick,
-                    modifier = Modifier.height(32.dp),
-                    contentPadding = ButtonDefaults.ButtonWithIconContentPadding
+
+            // Action buttons row — shown when no auth is present and not in key-entry mode
+            if (!isAuthorized && !isEnteringKey && !walletConnecting) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    verticalAlignment = Alignment.Top,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.Key,
-                        contentDescription = null,
-                        modifier = Modifier.size(14.dp)
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = "Enter Key",
-                        style = MaterialTheme.typography.labelSmall
-                    )
+                    OutlinedButton(
+                        onClick = onEnterKeyClick,
+                        modifier = Modifier.height(32.dp),
+                        contentPadding = ButtonDefaults.ButtonWithIconContentPadding
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Key,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = "Enter Key",
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
+
+                    if (walletAvailable) {
+                        Column {
+                            OutlinedButton(
+                                onClick = onConnectWalletClick,
+                                enabled = !isAnotherWalletConnected,
+                                modifier = Modifier.height(32.dp),
+                                contentPadding = ButtonDefaults.ButtonWithIconContentPadding
+                            ) {
+                                Text(
+                                    text = "Connect Wallet",
+                                    style = MaterialTheme.typography.labelSmall
+                                )
+                            }
+                            Text(
+                                text = "Freighter only",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                                modifier = Modifier.padding(start = 4.dp, top = 2.dp)
+                            )
+                        }
+                    }
                 }
             }
-            if (hasKeyPair) {
-                Surface(
-                    color = Color(0xFF4CAF50),
-                    shape = MaterialTheme.shapes.small
+
+            // Connecting / loading state
+            if (walletConnecting) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    OutlinedButton(
+                        onClick = onEnterKeyClick,
+                        modifier = Modifier.height(32.dp),
+                        contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
+                        enabled = false
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Key,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = "Enter Key",
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
+                    OutlinedButton(
+                        onClick = {},
+                        enabled = false,
+                        modifier = Modifier.height(32.dp),
+                        contentPadding = ButtonDefaults.ButtonWithIconContentPadding
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(14.dp),
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = "Connecting...",
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
+                }
+            }
+
+            // Disconnect button for wallet-connected signers
+            if (isWalletConnected) {
+                Spacer(modifier = Modifier.height(8.dp))
+                TextButton(
+                    onClick = onDisconnectWalletClick,
+                    contentPadding = ButtonDefaults.TextButtonContentPadding
                 ) {
                     Text(
-                        text = "Verified",
-                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                        text = "Disconnect",
                         style = MaterialTheme.typography.labelSmall,
-                        color = Color.White
+                        color = MaterialTheme.colorScheme.error
                     )
                 }
+            }
+
+            // Error message
+            if (walletError != null) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = "Error: $walletError",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error
+                )
             }
         }
     }

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/ui/screens/SignerManagementSection.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/ui/screens/SignerManagementSection.kt
@@ -268,6 +268,57 @@ fun SignerManagementSection(
 
                 when (signerAddMode) {
                     SignerAddMode.DELEGATED -> {
+                        if (DemoState.walletConnector != null) {
+                            var isGettingAddress by remember { mutableStateOf(false) }
+
+                            Column(
+                                verticalArrangement = Arrangement.spacedBy(4.dp)
+                            ) {
+                                OutlinedButton(
+                                    onClick = {
+                                        scope.launch {
+                                            isGettingAddress = true
+                                            try {
+                                                val connection = DemoState.walletConnector?.connect()
+                                                if (connection != null) {
+                                                    onDelegatedAddressChanged(connection.address)
+                                                    onFieldErrorsChanged(fieldErrors - "delegatedAddress")
+                                                    // Ephemeral connection — fetch address only, then clean up
+                                                    try {
+                                                        DemoState.walletConnector?.disconnect(connection.address)
+                                                    } catch (_: Exception) { }
+                                                }
+                                            } catch (e: Exception) {
+                                                onFieldErrorsChanged(
+                                                    fieldErrors + ("delegatedAddress" to
+                                                            "Failed to get address from wallet: ${e.message}")
+                                                )
+                                            } finally {
+                                                isGettingAddress = false
+                                            }
+                                        }
+                                    },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    enabled = !isGettingAddress && !isSubmitting
+                                ) {
+                                    if (isGettingAddress) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(16.dp),
+                                            strokeWidth = 2.dp,
+                                            color = MaterialTheme.colorScheme.primary
+                                        )
+                                        Spacer(modifier = Modifier.width(8.dp))
+                                    }
+                                    Text("Get Address from Wallet")
+                                }
+                                Text(
+                                    text = "Freighter only",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+
                         OutlinedTextField(
                             value = delegatedAddress,
                             onValueChange = {

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/util/ExternalSignerManagerAdapter.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/util/ExternalSignerManagerAdapter.kt
@@ -1,27 +1,25 @@
 package com.soneso.smartdemo.util
 
 /**
- * Implements ExternalWalletAdapter using in-memory Ed25519 keypairs for multi-signer transfers.
+ * Implements ExternalWalletAdapter for multi-signer transfers using two signing backends:
  *
- * This adapter is used with OZSmartAccountConfig.externalWallet so that
- * OZMultiSignerManager.multiSignerTransfer() can sign auth entries for delegated
- * (SelectedSigner.Wallet) signers whose secret keys are provided by the user.
+ * 1. **In-memory Ed25519 keypairs** — from secret key entry in the signer picker dialog.
+ * 2. **External wallet connector** — from a connected Freighter wallet (web or mobile).
  *
- * When multiSignerTransfer encounters a SelectedSigner.Wallet, the SDK:
- *   1. Validates via canSignFor()
- *   2. Builds the auth entry and preimage internally
- *   3. Calls signAuthEntry() with the base64-encoded HashIDPreimage XDR
+ * The SDK's OZExternalSignerManager routes SelectedSigner.Wallet signers to this adapter.
+ * This adapter reports capabilities via canSignFor() and handles signing via signAuthEntry().
  *
- * signAuthEntry() in this adapter:
+ * For keypair signers, signAuthEntry():
  *   1. Decodes the HashIDPreimage from base64
  *   2. SHA-256 hashes the preimage bytes
  *   3. Ed25519-signs the hash with the registered keypair
  *   4. Returns the raw 64-byte signature as base64
  *
- * The SDK handles auth entry construction and the {public_key, signature} format.
- * Keypairs are held in memory only and cleared when removeAll() is called.
+ * For wallet-connected signers, signAuthEntry() delegates to WalletConnector.signAuthEntry()
+ * which handles signing externally (Freighter extension or WalletConnect).
  */
 
+import com.soneso.smartdemo.wallet.WalletConnector
 import com.soneso.stellar.sdk.KeyPair
 import com.soneso.stellar.sdk.crypto.getSha256Crypto
 import com.soneso.stellar.sdk.smartaccount.oz.ConnectedWallet
@@ -30,12 +28,15 @@ import com.soneso.stellar.sdk.smartaccount.oz.SignAuthEntryOptions
 import com.soneso.stellar.sdk.smartaccount.oz.SignAuthEntryResult
 
 /**
- * In-memory ExternalWalletAdapter for keypair-based delegated signers.
+ * ExternalWalletAdapter supporting both keypair and external wallet signing.
  */
 class ExternalSignerManagerAdapter : ExternalWalletAdapter {
 
     // Keypairs indexed by G-address. Populated via addFromSecret().
     private val keypairsByAddress = mutableMapOf<String, KeyPair>()
+
+    /** External wallet connector for Freighter signing. Set by DemoState injection. */
+    var walletConnector: WalletConnector? = null
 
     /**
      * Registers an Ed25519 keypair signer from a Stellar secret key (S...).
@@ -73,8 +74,14 @@ class ExternalSignerManagerAdapter : ExternalWalletAdapter {
     /** Not supported — returns null. Use addFromSecret() to register keypairs. */
     override suspend fun connect(): ConnectedWallet? = null
 
-    /** Clears all registered keypair signers. */
+    /** Clears all registered keypair signers and disconnects any active wallet session. */
     override suspend fun disconnect() {
+        // Disconnect wallet session if active
+        walletConnector?.let { connector ->
+            connector.getConnectedAddress()?.let { address ->
+                connector.disconnect(address)
+            }
+        }
         removeAll()
     }
 
@@ -96,13 +103,25 @@ class ExternalSignerManagerAdapter : ExternalWalletAdapter {
     ): SignAuthEntryResult {
         val address = options?.address
             ?: throw IllegalArgumentException(
-                "signAuthEntry requires options.address to identify the keypair"
+                "signAuthEntry requires options.address to identify the signer"
             )
 
+        // Check wallet connector first for wallet-connected addresses
+        walletConnector?.let { connector ->
+            if (connector.isConnected(address)) {
+                val signature = connector.signAuthEntry(preimageXdr, address)
+                return SignAuthEntryResult(
+                    signedAuthEntry = signature,
+                    signerAddress = address
+                )
+            }
+        }
+
+        // Fall back to keypair signing
         val keypair = keypairsByAddress[address]
             ?: throw IllegalStateException(
-                "No keypair registered for address $address. " +
-                    "Call addFromSecret() before invoking multiSignerTransfer()."
+                "No signer available for address $address. " +
+                    "Register a keypair via addFromSecret() or connect a wallet."
             )
 
         // Decode the preimage XDR and hash it
@@ -125,13 +144,14 @@ class ExternalSignerManagerAdapter : ExternalWalletAdapter {
     override fun getConnectedWallets(): List<ConnectedWallet> = emptyList()
 
     /**
-     * Returns true if a keypair has been registered for the given address via addFromSecret().
+     * Returns true if a keypair or wallet connection is available for the given address.
      *
-     * This synchronous form is required by ExternalWalletAdapter and is called by
-     * OZMultiSignerManager.multiSignerTransfer().
+     * Checks keypairs first (from secret key entry), then the wallet connector
+     * (from Freighter connection). Called synchronously by the SDK.
      */
     override fun canSignFor(address: String): Boolean {
-        return keypairsByAddress.containsKey(address)
+        if (keypairsByAddress.containsKey(address)) return true
+        return walletConnector?.isConnected(address) == true
     }
 
     /** Not supported — returns null. */

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/wallet/WalletConnector.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/wallet/WalletConnector.kt
@@ -1,0 +1,97 @@
+package com.soneso.smartdemo.wallet
+
+/**
+ * Abstraction for connecting an external Stellar wallet (e.g., Freighter) to the demo app.
+ *
+ * Platform implementations:
+ * - Web: [FreighterConnector] using @stellar/freighter-api (browser extension)
+ * - Android: [ReownConnector] using Reown SignClient (WalletConnect v2)
+ * - iOS: [ReownConnector] using Reown Swift SDK (WalletConnect v2)
+ * - macOS: Not available (null connector)
+ *
+ * Injected via [DemoState.setWalletConnector] by platform entry points before UI renders.
+ */
+interface WalletConnector {
+
+    /**
+     * Initiates a wallet connection and returns the connected account details.
+     *
+     * @return The connected wallet info, or null if the user cancelled or the wallet is unavailable
+     * @throws WalletConnectionException on connection errors
+     */
+    suspend fun connect(): WalletConnection?
+
+    /**
+     * Disconnects the wallet session for the given address.
+     *
+     * Cleans up any active WalletConnect session or local state.
+     *
+     * @param address The G-address to disconnect
+     */
+    suspend fun disconnect(address: String)
+
+    /**
+     * Signs a Soroban auth entry preimage using the connected wallet.
+     *
+     * The wallet performs SHA-256 hashing and Ed25519 signing internally.
+     * The returned value must be a base64-encoded raw 64-byte Ed25519 signature.
+     *
+     * @param authEntryPreimageXdr Base64-encoded HashIdPreimage XDR
+     * @param address The G-address of the signer in the wallet
+     * @return Base64-encoded raw Ed25519 signature (64 bytes)
+     * @throws WalletSigningException if the wallet rejects or fails to sign
+     */
+    suspend fun signAuthEntry(authEntryPreimageXdr: String, address: String): String
+
+    /**
+     * Returns true if a wallet session is active for the given address.
+     */
+    fun isConnected(address: String): Boolean
+
+    /**
+     * Returns the G-address of the currently connected wallet, or null if not connected.
+     */
+    fun getConnectedAddress(): String?
+
+    /**
+     * Returns the network passphrase reported by the connected wallet, or null if unavailable.
+     *
+     * Used to verify the wallet is on the same network as the demo app.
+     */
+    suspend fun getNetworkPassphrase(): String?
+}
+
+/**
+ * Information about a successfully connected wallet.
+ *
+ * @property address The Stellar G-address from the wallet
+ * @property walletName Human-readable wallet name (e.g., "Freighter")
+ */
+data class WalletConnection(
+    val address: String,
+    val walletName: String
+)
+
+/**
+ * Thrown when wallet connection fails.
+ */
+class WalletConnectionException(
+    message: String,
+    cause: Throwable? = null
+) : Exception(message, cause)
+
+/**
+ * Thrown when the wallet rejects or fails to sign an auth entry.
+ */
+class WalletSigningException(
+    message: String,
+    cause: Throwable? = null
+) : Exception(message, cause)
+
+/**
+ * Thrown when the connected wallet is on a different network than expected.
+ */
+class WalletNetworkMismatchException(
+    val expected: String,
+    val actual: String
+) : Exception("Wallet is connected to a different network. Expected: $expected, got: $actual")

--- a/smart-account-demo/shared/src/commonTest/kotlin/com/soneso/smartdemo/wallet/ExternalSignerManagerAdapterWalletTest.kt
+++ b/smart-account-demo/shared/src/commonTest/kotlin/com/soneso/smartdemo/wallet/ExternalSignerManagerAdapterWalletTest.kt
@@ -1,0 +1,389 @@
+//
+//  ExternalSignerManagerAdapterWalletTest.kt
+//  KMP Stellar SDK - Smart Account Demo
+//
+//  Copyright (c) 2026 Soneso. All rights reserved.
+//
+
+package com.soneso.smartdemo.wallet
+
+import com.soneso.smartdemo.util.ExternalSignerManagerAdapter
+import com.soneso.stellar.sdk.KeyPair
+import com.soneso.stellar.sdk.smartaccount.oz.SignAuthEntryOptions
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the wallet connector integration in [ExternalSignerManagerAdapter].
+ *
+ * Covers:
+ * - canSignFor routing for wallet-connected addresses and keypair addresses
+ * - signAuthEntry delegation to WalletConnector for wallet-connected addresses
+ * - signAuthEntry keypair path when wallet connector is present but not for that address
+ * - Error propagation from WalletConnector
+ * - disconnect lifecycle
+ */
+class ExternalSignerManagerAdapterWalletTest {
+
+    // MARK: - Mock WalletConnector
+
+    private class MockWalletConnector : WalletConnector {
+        var connectedAddr: String? = null
+        var signResult: String? = null
+        var signError: Throwable? = null
+        var connectResult: WalletConnection? = null
+        var networkPassphrase: String? = null
+
+        val signAuthEntryCalls = mutableListOf<Pair<String, String>>() // preimage to address
+        val disconnectCalls = mutableListOf<String>()
+
+        override suspend fun connect(): WalletConnection? = connectResult
+
+        override suspend fun disconnect(address: String) {
+            disconnectCalls.add(address)
+            if (connectedAddr == address) {
+                connectedAddr = null
+            }
+        }
+
+        override suspend fun signAuthEntry(authEntryPreimageXdr: String, address: String): String {
+            signAuthEntryCalls.add(authEntryPreimageXdr to address)
+            signError?.let { throw it }
+            return signResult ?: throw WalletSigningException("No mock result configured")
+        }
+
+        override fun isConnected(address: String): Boolean = connectedAddr == address
+
+        override fun getConnectedAddress(): String? = connectedAddr
+
+        override suspend fun getNetworkPassphrase(): String? = networkPassphrase
+    }
+
+    // MARK: - Helpers
+
+    companion object {
+        /** A valid 56-character Stellar G-address used as a mock wallet-connected address.
+         *  This is the Stellar testnet Friendbot address — chosen because it is well-known
+         *  and guaranteed to be a valid G-address format with correct checksum. */
+        private const val MOCK_WALLET_ADDRESS = "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR"
+    }
+
+    @OptIn(kotlin.io.encoding.ExperimentalEncodingApi::class)
+    private val testPreimage: String
+        get() = kotlin.io.encoding.Base64.encode("test-preimage-data".encodeToByteArray())
+
+    private fun createAdapter(): ExternalSignerManagerAdapter = ExternalSignerManagerAdapter()
+
+    // MARK: - canSignFor Tests
+
+    @Test
+    fun testCanSignFor_walletConnectedAddress() = runTest {
+        val adapter = createAdapter()
+        val mock = MockWalletConnector()
+        mock.connectedAddr = MOCK_WALLET_ADDRESS
+        adapter.walletConnector = mock
+
+        assertTrue(adapter.canSignFor(MOCK_WALLET_ADDRESS))
+    }
+
+    @Test
+    fun testCanSignFor_keypairAddress() = runTest {
+        val adapter = createAdapter()
+        val keypair = KeyPair.random()
+        val address = adapter.addFromSecret(keypair.getSecretSeed()!!.concatToString())
+
+        assertTrue(adapter.canSignFor(address))
+    }
+
+    @Test
+    fun testCanSignFor_unknownAddress_returnsFalse() = runTest {
+        val adapter = createAdapter()
+        val unknownAddress = KeyPair.random().getAccountId()
+
+        assertFalse(adapter.canSignFor(unknownAddress))
+    }
+
+    @Test
+    fun testCanSignFor_unknownAddress_withWalletConnectorSet_returnsFalse() = runTest {
+        val adapter = createAdapter()
+        val mock = MockWalletConnector()
+        mock.connectedAddr = MOCK_WALLET_ADDRESS
+        adapter.walletConnector = mock
+
+        // A different address — not connected by the wallet
+        val differentAddress = KeyPair.random().getAccountId()
+        assertFalse(adapter.canSignFor(differentAddress))
+    }
+
+    @Test
+    fun testCanSignFor_noWalletConnector_returnsFalse() = runTest {
+        val adapter = createAdapter()
+        adapter.walletConnector = null
+
+        assertFalse(adapter.canSignFor(MOCK_WALLET_ADDRESS))
+    }
+
+    // MARK: - signAuthEntry delegation to wallet
+
+    @Test
+    fun testSignAuthEntry_delegatesToWallet_forWalletConnectedAddress() = runTest {
+        val adapter = createAdapter()
+        val mock = MockWalletConnector()
+        val walletAddress = MOCK_WALLET_ADDRESS
+        mock.connectedAddr = walletAddress
+        mock.signResult = "mockSignatureBase64"
+        adapter.walletConnector = mock
+
+        val result = adapter.signAuthEntry(
+            preimageXdr = testPreimage,
+            options = SignAuthEntryOptions(address = walletAddress)
+        )
+
+        assertEquals("mockSignatureBase64", result.signedAuthEntry)
+        assertEquals(walletAddress, result.signerAddress)
+        assertEquals(1, mock.signAuthEntryCalls.size)
+        assertEquals(testPreimage, mock.signAuthEntryCalls[0].first)
+        assertEquals(walletAddress, mock.signAuthEntryCalls[0].second)
+    }
+
+    @Test
+    fun testSignAuthEntry_usesKeypair_notWallet_forKeypairAddress() = runTest {
+        val adapter = createAdapter()
+        val keypair = KeyPair.random()
+        val keypairAddress = adapter.addFromSecret(keypair.getSecretSeed()!!.concatToString())
+
+        // Wallet is connected but for a different address
+        val mock = MockWalletConnector()
+        mock.connectedAddr = MOCK_WALLET_ADDRESS
+        mock.signResult = "walletSignature"
+        adapter.walletConnector = mock
+
+        val result = adapter.signAuthEntry(
+            preimageXdr = testPreimage,
+            options = SignAuthEntryOptions(address = keypairAddress)
+        )
+
+        // Wallet must not have been called
+        assertEquals(0, mock.signAuthEntryCalls.size)
+
+        // Result must be a valid non-empty base64 signature
+        assertNotNull(result.signedAuthEntry)
+        assertTrue(result.signedAuthEntry.isNotEmpty())
+        assertEquals(keypairAddress, result.signerAddress)
+    }
+
+    @Test
+    fun testSignAuthEntry_throwsForUnknownAddress() = runTest {
+        val adapter = createAdapter()
+
+        assertFailsWith<IllegalStateException> {
+            adapter.signAuthEntry(
+                preimageXdr = testPreimage,
+                options = SignAuthEntryOptions(address = MOCK_WALLET_ADDRESS)
+            )
+        }
+    }
+
+    @Test
+    fun testSignAuthEntry_throwsWhenOptionsAddressIsNull() = runTest {
+        val adapter = createAdapter()
+
+        assertFailsWith<IllegalArgumentException> {
+            adapter.signAuthEntry(
+                preimageXdr = testPreimage,
+                options = null
+            )
+        }
+    }
+
+    @Test
+    fun testSignAuthEntry_propagatesWalletSigningException() = runTest {
+        val adapter = createAdapter()
+        val mock = MockWalletConnector()
+        val walletAddress = MOCK_WALLET_ADDRESS
+        mock.connectedAddr = walletAddress
+        mock.signError = WalletSigningException("User rejected the signing request")
+        adapter.walletConnector = mock
+
+        val exception = assertFailsWith<WalletSigningException> {
+            adapter.signAuthEntry(
+                preimageXdr = testPreimage,
+                options = SignAuthEntryOptions(address = walletAddress)
+            )
+        }
+
+        assertEquals("User rejected the signing request", exception.message)
+    }
+
+    @Test
+    fun testSignAuthEntry_propagatesArbitraryWalletErrors() = runTest {
+        val adapter = createAdapter()
+        val mock = MockWalletConnector()
+        val walletAddress = MOCK_WALLET_ADDRESS
+        mock.connectedAddr = walletAddress
+        mock.signError = RuntimeException("Network timeout")
+        adapter.walletConnector = mock
+
+        assertFailsWith<RuntimeException> {
+            adapter.signAuthEntry(
+                preimageXdr = testPreimage,
+                options = SignAuthEntryOptions(address = walletAddress)
+            )
+        }
+    }
+
+    // MARK: - disconnect Tests
+
+    @Test
+    fun testDisconnect_clearsWalletSession() = runTest {
+        val adapter = createAdapter()
+        val mock = MockWalletConnector()
+        val walletAddress = MOCK_WALLET_ADDRESS
+        mock.connectedAddr = walletAddress
+        adapter.walletConnector = mock
+
+        assertTrue(adapter.canSignFor(walletAddress))
+
+        adapter.disconnect()
+
+        assertTrue(mock.disconnectCalls.contains(walletAddress))
+        assertFalse(adapter.canSignFor(walletAddress))
+    }
+
+    @Test
+    fun testDisconnect_withNoWalletConnector_doesNotThrow() = runTest {
+        val adapter = createAdapter()
+        adapter.walletConnector = null
+
+        // Must not throw
+        adapter.disconnect()
+    }
+
+    @Test
+    fun testDisconnect_clearsKeypairSigners() = runTest {
+        val adapter = createAdapter()
+        val keypair = KeyPair.random()
+        val address = adapter.addFromSecret(keypair.getSecretSeed()!!.concatToString())
+
+        assertTrue(adapter.canSignFor(address))
+
+        adapter.disconnect()
+
+        assertFalse(adapter.canSignFor(address))
+    }
+
+    @Test
+    fun testDisconnect_doesNotCallWalletWhenNotConnected() = runTest {
+        val adapter = createAdapter()
+        val mock = MockWalletConnector()
+        mock.connectedAddr = null // no active wallet session
+        adapter.walletConnector = mock
+
+        adapter.disconnect()
+
+        assertEquals(0, mock.disconnectCalls.size)
+    }
+
+    // MARK: - Wallet takes precedence over keypair
+
+    @Test
+    fun testSignAuthEntry_walletTakesPrecedence_overKeypair_forSameAddress() = runTest {
+        // Edge case: both wallet and keypair exist for the same address.
+        // The adapter checks wallet first; the wallet path must be taken.
+        val adapter = createAdapter()
+
+        val keypair = KeyPair.random()
+        val address = adapter.addFromSecret(keypair.getSecretSeed()!!.concatToString())
+
+        val mock = MockWalletConnector()
+        mock.connectedAddr = address
+        mock.signResult = "walletSignatureTakesPrecedence"
+        adapter.walletConnector = mock
+
+        val result = adapter.signAuthEntry(
+            preimageXdr = testPreimage,
+            options = SignAuthEntryOptions(address = address)
+        )
+
+        assertEquals("walletSignatureTakesPrecedence", result.signedAuthEntry)
+        assertEquals(1, mock.signAuthEntryCalls.size)
+    }
+
+    // MARK: - addFromSecret / canSignFor interaction
+
+    @Test
+    fun testAddFromSecret_derivesCorrectAddress() = runTest {
+        val adapter = createAdapter()
+        val keypair = KeyPair.random()
+        val expectedAddress = keypair.getAccountId()
+        val secretSeed = keypair.getSecretSeed()!!.concatToString()
+
+        val returnedAddress = adapter.addFromSecret(secretSeed)
+
+        assertEquals(expectedAddress, returnedAddress)
+        assertTrue(adapter.canSignFor(returnedAddress))
+    }
+
+    @Test
+    fun testRemove_preventsCanSignFor() = runTest {
+        val adapter = createAdapter()
+        val keypair = KeyPair.random()
+        val address = adapter.addFromSecret(keypair.getSecretSeed()!!.concatToString())
+
+        assertTrue(adapter.canSignFor(address))
+        adapter.remove(address)
+        assertFalse(adapter.canSignFor(address))
+    }
+
+    @Test
+    fun testRemoveAll_preventsCanSignForAllKeypairs() = runTest {
+        val adapter = createAdapter()
+        val kp1 = KeyPair.random()
+        val kp2 = KeyPair.random()
+        val addr1 = adapter.addFromSecret(kp1.getSecretSeed()!!.concatToString())
+        val addr2 = adapter.addFromSecret(kp2.getSecretSeed()!!.concatToString())
+
+        assertTrue(adapter.canSignFor(addr1))
+        assertTrue(adapter.canSignFor(addr2))
+
+        adapter.removeAll()
+
+        assertFalse(adapter.canSignFor(addr1))
+        assertFalse(adapter.canSignFor(addr2))
+    }
+
+    // MARK: - getConnectedWallets
+
+    @Test
+    fun testGetConnectedWallets_returnsEmptyList() = runTest {
+        val adapter = createAdapter()
+        val keypair = KeyPair.random()
+        adapter.addFromSecret(keypair.getSecretSeed()!!.concatToString())
+
+        // Keypair signers are not surfaced as ConnectedWallet objects
+        assertTrue(adapter.getConnectedWallets().isEmpty())
+    }
+
+    // MARK: - connect / reconnect
+
+    @Test
+    fun testConnect_returnsNull() = runTest {
+        val adapter = createAdapter()
+        // connect() is not supported — must return null without throwing
+        val result = adapter.connect()
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun testReconnect_returnsNull() = runTest {
+        val adapter = createAdapter()
+        // reconnect() is not supported — must return null without throwing
+        val result = adapter.reconnect("freighter")
+        assertEquals(null, result)
+    }
+}

--- a/smart-account-demo/shared/src/iosMain/kotlin/com/soneso/smartdemo/MainViewController.kt
+++ b/smart-account-demo/shared/src/iosMain/kotlin/com/soneso/smartdemo/MainViewController.kt
@@ -14,20 +14,14 @@ import platform.UIKit.UIViewController
 /**
  * Creates the main UIViewController for the iOS app.
  *
- * This function initializes the Smart Account Kit with Apple-specific providers
- * (AppleWebAuthnProvider and UserDefaultsStorageAdapter) before creating the
- * Compose UI controller.
- *
- * The initialization happens asynchronously on the main coroutine scope, so the
- * UI will load immediately while the kit initializes in the background.
+ * Platform initialization (AppleWebAuthnProvider, UserDefaultsStorageAdapter, and the
+ * optional Reown wallet connector) is performed by the Swift AppDelegate via
+ * [initSmartAccountKit] before this function is called. The Compose UI controller
+ * is therefore created with all providers already set in [DemoState].
  *
  * @return UIViewController wrapping the Compose Multiplatform UI
  */
 fun MainViewController(): UIViewController {
-    // Initialize Smart Account Kit with iOS-specific providers
-    initSmartAccountKit()
-
-    // Return Compose UI controller
     return ComposeUIViewController {
         App()
     }

--- a/smart-account-demo/shared/src/iosMain/kotlin/com/soneso/smartdemo/PlatformInit.ios.kt
+++ b/smart-account-demo/shared/src/iosMain/kotlin/com/soneso/smartdemo/PlatformInit.ios.kt
@@ -11,6 +11,8 @@ package com.soneso.smartdemo
 import com.soneso.smartdemo.config.DemoConfig
 import com.soneso.smartdemo.state.ActivityLogState
 import com.soneso.smartdemo.state.DemoState
+import com.soneso.smartdemo.wallet.ReownConnectorBridge
+import com.soneso.smartdemo.wallet.ReownHandler
 import com.soneso.stellar.sdk.smartaccount.AppleWebAuthnProvider
 import com.soneso.stellar.sdk.smartaccount.UserDefaultsStorageAdapter
 
@@ -21,9 +23,15 @@ import com.soneso.stellar.sdk.smartaccount.UserDefaultsStorageAdapter
  * in [DemoState]. The shared [MainScreen] LaunchedEffect picks these up and
  * initializes the SDK kit asynchronously.
  *
+ * If [DemoConfig.REOWN_PROJECT_ID] is non-blank, a [ReownConnectorBridge] backed by the
+ * provided [reownHandler] is installed as the wallet connector. The Swift app delegate
+ * creates the [ReownHandler] (using the Reown WalletConnectSign SDK) and passes it here.
+ *
  * Runs synchronously so providers are available on first Compose composition.
+ *
+ * @param reownHandler Swift-implemented Reown handler. Null if WalletConnect is not configured.
  */
-fun initSmartAccountKit() {
+fun initSmartAccountKit(reownHandler: ReownHandler? = null) {
     try {
         val webauthnProvider = AppleWebAuthnProvider(
             rpId = DemoConfig.DEFAULT_RP_ID,
@@ -36,7 +44,14 @@ fun initSmartAccountKit() {
 
         DemoState.setWebAuthnProvider(webauthnProvider)
         DemoState.setStorage(storage)
-        ActivityLogState.info("iOS providers initialized")
+
+        if (reownHandler != null && DemoConfig.REOWN_PROJECT_ID.isNotBlank()) {
+            val connector = ReownConnectorBridge(reownHandler)
+            DemoState.setWalletConnector(connector)
+            ActivityLogState.info("iOS providers initialized (wallet connector enabled)")
+        } else {
+            ActivityLogState.info("iOS providers initialized")
+        }
     } catch (e: Exception) {
         ActivityLogState.error("Failed to initialize iOS providers: ${e.message}")
     }

--- a/smart-account-demo/shared/src/iosMain/kotlin/com/soneso/smartdemo/wallet/ReownConnectorBridge.kt
+++ b/smart-account-demo/shared/src/iosMain/kotlin/com/soneso/smartdemo/wallet/ReownConnectorBridge.kt
@@ -1,0 +1,240 @@
+//
+//  ReownConnectorBridge.kt
+//  Smart Account Demo
+//
+//  Copyright (c) 2026 Soneso. All rights reserved.
+//
+
+package com.soneso.smartdemo.wallet
+
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Callback interface that Swift implements to provide Reown WalletConnect operations.
+ *
+ * All async methods use completion-handler callbacks so they can be called from Kotlin/Native
+ * without requiring Swift async/await bridging. Kotlin wraps each callback via
+ * [suspendCancellableCoroutine].
+ *
+ * The [result] parameter carries the successful value; [error] carries a human-readable
+ * error message. Exactly one of the two will be non-null on every callback invocation.
+ *
+ * Swift conforms to this interface by subclassing or implementing via an ObjC class,
+ * then passes the instance to [ReownConnectorBridge].
+ */
+interface ReownHandler {
+
+    /**
+     * Initiates a WalletConnect session and waits for the wallet to approve it.
+     *
+     * The implementation should:
+     * 1. Create a WalletConnect URI via `Sign.instance.connect`.
+     * 2. Open the wallet app via the URI deep link.
+     * 3. Wait for `sessionSettlePublisher` to confirm the session.
+     * 4. Extract the Stellar account address from the settled session namespace.
+     *
+     * @param completion Called with ([WalletConnectionBridge], null) on success, or
+     *        (null, errorMessage) on failure or cancellation by the user.
+     */
+    fun connect(completion: (WalletConnectionBridge?, String?) -> Unit)
+
+    /**
+     * Terminates the active WalletConnect session for the given address.
+     *
+     * @param address The Stellar G-address whose session should be disconnected.
+     * @param completion Called with (null) on success, or (errorMessage) on failure.
+     */
+    fun disconnect(address: String, completion: (String?) -> Unit)
+
+    /**
+     * Requests the wallet to sign a Soroban auth entry preimage.
+     *
+     * The wallet receives a `stellar_signAuthEntry` JSON-RPC request, hashes the
+     * preimage with SHA-256, signs with Ed25519, and returns the base64-encoded
+     * raw 64-byte signature.
+     *
+     * @param preimageXdr Base64-encoded HashIdPreimage XDR.
+     * @param address The Stellar G-address of the signer.
+     * @param completion Called with (base64Signature, null) on success, or
+     *        (null, errorMessage) on rejection or timeout.
+     */
+    fun signAuthEntry(preimageXdr: String, address: String, completion: (String?, String?) -> Unit)
+
+    /**
+     * Returns true if an active WalletConnect session exists for the given address.
+     *
+     * Synchronous — checks in-memory session state only.
+     */
+    fun isConnected(address: String): Boolean
+
+    /**
+     * Returns the Stellar G-address of the currently connected wallet account, or null.
+     *
+     * Synchronous — returns cached state.
+     */
+    fun getConnectedAddress(): String?
+
+    /**
+     * Retrieves the network passphrase reported by the connected wallet's namespace.
+     *
+     * Freighter Mobile encodes the network in the Stellar namespace chain ID
+     * (e.g., `stellar:testnet` or `stellar:pubnet`). The bridge maps these to the
+     * corresponding Stellar network passphrases.
+     *
+     * @param completion Called with (passphrase) on success, or (null) if the wallet
+     *        is not connected or the network is not available.
+     */
+    fun getNetworkPassphrase(completion: (String?) -> Unit)
+}
+
+/**
+ * Swift-friendly representation of a successfully connected wallet account.
+ *
+ * Uses primitive types to avoid Kotlin class wrapping issues across the
+ * Kotlin/Native to Swift boundary.
+ *
+ * @property address The Stellar G-address from the wallet namespace.
+ * @property walletName Human-readable wallet name from the session peer metadata.
+ */
+data class WalletConnectionBridge(
+    val address: String,
+    val walletName: String
+)
+
+/**
+ * iOS implementation of [WalletConnector] that delegates to a Swift-provided [ReownHandler].
+ *
+ * The Swift side creates a [ReownHandler] implementation using the Reown Swift SDK
+ * (WalletConnectSign) and passes it to this bridge during app initialization.
+ * This class converts the callback-based [ReownHandler] interface into suspend functions.
+ *
+ * All suspend functions use [suspendCancellableCoroutine] to wrap the Swift callbacks,
+ * so coroutine cancellation propagates correctly.
+ *
+ * @param handler The Swift-provided Reown handler implementation.
+ */
+class ReownConnectorBridge(
+    private val handler: ReownHandler
+) : WalletConnector {
+
+    /**
+     * Connects to the external wallet via WalletConnect v2.
+     *
+     * Opens the wallet app via deep link and waits for the session to settle.
+     * Returns null if the user cancels the connection.
+     *
+     * @return [WalletConnection] on success, or null if the user cancelled.
+     * @throws [WalletConnectionException] on WalletConnect protocol errors.
+     */
+    override suspend fun connect(): WalletConnection? {
+        val bridge: WalletConnectionBridge? = suspendCancellableCoroutine { cont ->
+            handler.connect { result, error ->
+                resumeWith(cont, result, error, "WalletConnect connection failed")
+            }
+        }
+        return bridge?.let { WalletConnection(address = it.address, walletName = it.walletName) }
+    }
+
+    /**
+     * Disconnects the wallet session for the given Stellar address.
+     *
+     * @param address The G-address whose WalletConnect session to terminate.
+     * @throws [WalletConnectionException] if the disconnect call fails.
+     */
+    override suspend fun disconnect(address: String) {
+        suspendCancellableCoroutine { cont ->
+            handler.disconnect(address) { error ->
+                if (error != null) {
+                    cont.resumeWithException(WalletConnectionException(error))
+                } else {
+                    cont.resume(Unit)
+                }
+            }
+        }
+    }
+
+    /**
+     * Signs a Soroban auth entry using the connected wallet.
+     *
+     * Sends a `stellar_signAuthEntry` request to the wallet and waits for the response.
+     *
+     * @param authEntryPreimageXdr Base64-encoded HashIdPreimage XDR.
+     * @param address The G-address of the signer.
+     * @return Base64-encoded raw Ed25519 signature (64 bytes).
+     * @throws [WalletSigningException] if the wallet rejects or times out.
+     */
+    override suspend fun signAuthEntry(authEntryPreimageXdr: String, address: String): String {
+        return suspendCancellableCoroutine { cont ->
+            handler.signAuthEntry(authEntryPreimageXdr, address) { result, error ->
+                resumeWithString(cont, result, error, "Wallet signing failed")
+            }
+        }
+    }
+
+    /**
+     * Returns true if a WalletConnect session is active for the given address.
+     */
+    override fun isConnected(address: String): Boolean = handler.isConnected(address)
+
+    /**
+     * Returns the G-address of the currently connected wallet, or null.
+     */
+    override fun getConnectedAddress(): String? = handler.getConnectedAddress()
+
+    /**
+     * Returns the network passphrase from the wallet's namespace, or null.
+     */
+    override suspend fun getNetworkPassphrase(): String? {
+        return suspendCancellableCoroutine { cont ->
+            handler.getNetworkPassphrase { passphrase ->
+                cont.resume(passphrase)
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resumes a [CancellableContinuation] with either the successful [result] or an exception
+ * derived from [error]. When both [result] and [error] are null, resumes with a null result
+ * (signals user cancellation for nullable continuations).
+ *
+ * @param cont The continuation to resume.
+ * @param result The successful value, or null if the operation failed or was cancelled.
+ * @param error Human-readable error message, or null on success.
+ * @param defaultErrorPrefix Prefix prepended to [error] when constructing the exception.
+ */
+private fun <T> resumeWith(
+    cont: CancellableContinuation<T?>,
+    result: T?,
+    error: String?,
+    defaultErrorPrefix: String
+) {
+    if (error != null) {
+        cont.resumeWithException(WalletConnectionException("$defaultErrorPrefix: $error"))
+    } else {
+        cont.resume(result)
+    }
+}
+
+/**
+ * Variant for non-nullable [String] results used by [signAuthEntry].
+ */
+private fun resumeWithString(
+    cont: CancellableContinuation<String>,
+    result: String?,
+    error: String?,
+    defaultErrorPrefix: String
+) {
+    when {
+        error != null -> cont.resumeWithException(WalletSigningException("$defaultErrorPrefix: $error"))
+        result != null -> cont.resume(result)
+        else -> cont.resumeWithException(WalletSigningException("$defaultErrorPrefix: no result returned"))
+    }
+}

--- a/smart-account-demo/shared/src/jsMain/kotlin/com/soneso/smartdemo/wallet/FreighterConnector.kt
+++ b/smart-account-demo/shared/src/jsMain/kotlin/com/soneso/smartdemo/wallet/FreighterConnector.kt
@@ -1,0 +1,138 @@
+package com.soneso.smartdemo.wallet
+
+import kotlinx.coroutines.await
+import kotlin.js.Promise
+
+// ---------------------------------------------------------------------------
+// External declarations for @stellar/freighter-api v6.x
+//
+// All functions return Promise<dynamic>. They always resolve (never reject).
+// Errors are returned in the `error` field: { code: number, message: string }.
+//
+// API shapes (from github.com/stellar/freighter/@stellar/freighter-api/src/):
+//   requestAccess()   -> { address: string, error?: {code,message} }
+//   signAuthEntry()   -> { signedAuthEntry: string|null, signerAddress: string, error?: {code,message} }
+//   getNetworkDetails() -> { networkPassphrase: string, network: string, ..., error?: {code,message} }
+// ---------------------------------------------------------------------------
+
+private external interface FreighterApi {
+    fun requestAccess(): Promise<dynamic>
+    fun signAuthEntry(entryXdr: String, opts: dynamic): Promise<dynamic>
+    fun getNetworkDetails(): Promise<dynamic>
+}
+
+private fun loadFreighterApi(): FreighterApi? {
+    return try {
+        js("require('@stellar/freighter-api')").unsafeCast<FreighterApi?>()
+    } catch (_: Throwable) {
+        null
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FreighterConnector
+// ---------------------------------------------------------------------------
+
+/**
+ * Web implementation of [WalletConnector] using the Freighter browser extension.
+ *
+ * Uses @stellar/freighter-api v6.x which returns objects with optional error fields.
+ * All API calls resolve (never reject); errors are in `response.error`.
+ *
+ * signAuthEntry opts uses `address` (the API maps it to `accountToSign` internally).
+ * The extension returns `signedAuthEntry` as a base64 string (API >= 4.2.0).
+ */
+class FreighterConnector : WalletConnector {
+
+    private var connectedAddress: String? = null
+
+    override suspend fun connect(): WalletConnection? {
+        val api = loadFreighterApi()
+            ?: throw WalletConnectionException("Freighter API module is not available.")
+
+        // requestAccess() -> { address: string, error?: {code, message} }
+        val result = api.requestAccess().await()
+
+        // Check for error (user rejection, extension not installed)
+        val error = result?.error
+        if (error != null && error != js("undefined")) {
+            val code = error.code
+            val message = error.message?.unsafeCast<String?>() ?: "Unknown error"
+            // code -4 = user rejected
+            if (code == -4) return null
+            throw WalletConnectionException("Freighter: $message")
+        }
+
+        val address = result?.address?.unsafeCast<String?>()
+        if (address.isNullOrBlank()) return null
+
+        connectedAddress = address
+        return WalletConnection(address = address, walletName = "Freighter")
+    }
+
+    override suspend fun disconnect(address: String) {
+        if (connectedAddress == address) {
+            connectedAddress = null
+        }
+    }
+
+    /**
+     * Signs a Soroban auth entry via the Freighter extension.
+     *
+     * signAuthEntry(xdr, {address}) -> { signedAuthEntry: string|null, signerAddress, error? }
+     * In v6.x the extension returns signedAuthEntry as a base64 string.
+     */
+    override suspend fun signAuthEntry(authEntryPreimageXdr: String, address: String): String {
+        val api = loadFreighterApi()
+            ?: throw WalletSigningException("Freighter API module is not available.")
+
+        val opts = js("{}")
+        opts.address = address
+
+        val result = api.signAuthEntry(authEntryPreimageXdr, opts).await()
+
+        // Check for error
+        val error = result?.error
+        if (error != null && error != js("undefined")) {
+            val message = error.message?.unsafeCast<String?>() ?: "Unknown error"
+            throw WalletSigningException("Freighter signing failed: $message")
+        }
+
+        val signedAuthEntry = result?.signedAuthEntry
+        if (signedAuthEntry == null || signedAuthEntry == js("undefined")) {
+            throw WalletSigningException("Freighter returned no signature for address $address")
+        }
+
+        // v6.x returns base64 string. Handle Buffer fallback for safety.
+        val signature: String = if (jsTypeOf(signedAuthEntry) == "string") {
+            signedAuthEntry.unsafeCast<String>()
+        } else {
+            // Buffer/Uint8Array fallback
+            js("btoa(String.fromCharCode.apply(null, new Uint8Array(signedAuthEntry)))").unsafeCast<String>()
+        }
+
+        if (signature.isBlank()) {
+            throw WalletSigningException("Freighter returned an empty signature for address $address")
+        }
+
+        return signature
+    }
+
+    override fun isConnected(address: String): Boolean = connectedAddress == address
+
+    override fun getConnectedAddress(): String? = connectedAddress
+
+    override suspend fun getNetworkPassphrase(): String? {
+        val api = loadFreighterApi() ?: return null
+        return try {
+            val details = api.getNetworkDetails().await()
+            val error = details?.error
+            if (error != null && error != js("undefined")) return null
+            val passphrase = details?.networkPassphrase
+            if (passphrase == null || passphrase == js("undefined")) return null
+            passphrase.unsafeCast<String>().takeIf { it.isNotBlank() }
+        } catch (_: Throwable) {
+            null
+        }
+    }
+}

--- a/smart-account-demo/webApp/package-lock.json
+++ b/smart-account-demo/webApp/package-lock.json
@@ -8,6 +8,7 @@
       "name": "smart-account-demo-webapp",
       "version": "0.1.0",
       "dependencies": {
+        "@stellar/freighter-api": "6.0.1",
         "libsodium-wrappers-sumo": "0.7.13"
       },
       "devDependencies": {
@@ -806,12 +807,66 @@
         "win32"
       ]
     },
+    "node_modules/@stellar/freighter-api": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.1.tgz",
+      "integrity": "sha512-eqwakEqSg+zoLuPpSbKyrX0pG8DQFzL/J5GtbfuMCmJI+h+oiC9pQ5C6QLc80xopZQKdGt8dUAFCmDMNdAG95w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "semver": "7.7.1"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -887,6 +942,26 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/libsodium-sumo": {
       "version": "0.7.16",
@@ -1014,6 +1089,18 @@
         "@rollup/rollup-win32-x64-gnu": "4.57.1",
         "@rollup/rollup-win32-x64-msvc": "4.57.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/source-map-js": {

--- a/smart-account-demo/webApp/package.json
+++ b/smart-account-demo/webApp/package.json
@@ -12,6 +12,7 @@
     "vite": "^7.3.1"
   },
   "dependencies": {
+    "@stellar/freighter-api": "6.0.1",
     "libsodium-wrappers-sumo": "0.7.13"
   }
 }

--- a/smart-account-demo/webApp/src/jsMain/kotlin/Main.kt
+++ b/smart-account-demo/webApp/src/jsMain/kotlin/Main.kt
@@ -4,6 +4,7 @@ import com.soneso.smartdemo.App
 import com.soneso.smartdemo.config.DemoConfig
 import com.soneso.smartdemo.state.ActivityLogState
 import com.soneso.smartdemo.state.DemoState
+import com.soneso.smartdemo.wallet.FreighterConnector
 import com.soneso.stellar.sdk.smartaccount.IndexedDBStorageAdapter
 import com.soneso.stellar.sdk.smartaccount.JsWebAuthnProvider
 import kotlinx.browser.document
@@ -13,6 +14,11 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
+    // Inject the Freighter wallet connector before any UI renders.
+    // FreighterConnector construction is synchronous -- no network calls occur here.
+    val walletConnector = FreighterConnector()
+    DemoState.setWalletConnector(walletConnector)
+
     // Initialize Smart Account Kit on launch
     MainScope().launch {
         try {


### PR DESCRIPTION
Add Freighter wallet connection as an alternative to manual secret key entry for delegated signers in multi-signer smart account transactions in the smart accounts demo app.

### What

Delegated signers can now connect their Freighter wallet to sign auth entries instead of entering a secret key manually. This works across three platforms:

| Platform | Method | Wallet |
|----------|--------|--------|
| Web | @stellar/freighter-api v6.0.1 | Freighter browser extension |
| Android | WalletConnect v2 (Reown SignClient 1.6.12) | Freighter Mobile |
| iOS | WalletConnect v2 (Reown Swift SDK 2.x) | Freighter Mobile |
| macOS | Not available | Secret key entry only |

### Architecture

- `WalletConnector` interface in commonMain with platform implementations
- `FreighterConnector` (web): direct browser extension API via JS interop
- `ReownConnector` (Android): Reown SignClient with deep link pairing
- `ReownConnectorBridge` + `ReownWalletHandler` (iOS): Kotlin bridge to Swift Reown SDK
- `ExternalSignerManagerAdapter` extended to delegate signing to the wallet connector
- Platform entry points inject the connector via `DemoState.setWalletConnector()`

### UI

- **SignerPickerDialog**: "Connect Wallet" button next to "Enter Key" for delegated signers. Address matching and network verification on connect. One wallet connection at a time.
- **SignerManagementSection**: "Get Address from Wallet" button to auto-fill a delegated signer G-address from the connected wallet (ephemeral connection).
- Both buttons hidden on simulators/emulators (WalletConnect requires Freighter Mobile on a real device) and on macOS.

### Configuration

- `REOWN_PROJECT_ID` in `DemoConfig.kt` — required for Android/iOS device builds. Register at cloud.reown.com.
- iOS requires an App Group entitlement (`group.com.soneso.stellar.smartdemo`) registered in the developer's Apple account for WalletConnect session storage.

### Tests

22 unit tests covering `ExternalSignerManagerAdapter` wallet connector integration: canSignFor routing, signAuthEntry delegation, error propagation, disconnect lifecycle, wallet/keypair precedence.

### Tested on

- Web (Chrome + Freighter browser extension)
- Android device (Seeker, Freighter Mobile)
- iOS device (iPhone, Freighter Mobile)
- Android emulator (connect wallet buttons hidden)
- iOS simulator (connect wallet buttons hidden)
