### PR TITLE
Fix XDR generator multi-case discriminant collapse

### DIFF
--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/xdr/BucketEntryXdr.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/xdr/BucketEntryXdr.kt
@@ -21,10 +21,9 @@ sealed class BucketEntryXdr {
   abstract val discriminant: BucketEntryTypeXdr
 
   data class LiveEntry(
+    override val discriminant: BucketEntryTypeXdr,
     val value: LedgerEntryXdr
-  ) : BucketEntryXdr() {
-    override val discriminant: BucketEntryTypeXdr = BucketEntryTypeXdr.LIVEENTRY
-  }
+  ) : BucketEntryXdr()
 
   data class DeadEntry(
     val value: LedgerKeyXdr
@@ -45,11 +44,11 @@ sealed class BucketEntryXdr {
       return when (discriminant) {
         BucketEntryTypeXdr.LIVEENTRY -> {
           val value = LedgerEntryXdr.decode(reader)
-          LiveEntry(value)
+          LiveEntry(discriminant, value)
         }
         BucketEntryTypeXdr.INITENTRY -> {
           val value = LedgerEntryXdr.decode(reader)
-          LiveEntry(value)
+          LiveEntry(discriminant, value)
         }
         BucketEntryTypeXdr.DEADENTRY -> {
           val value = LedgerKeyXdr.decode(reader)

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/xdr/InnerTransactionResultResultXdr.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/xdr/InnerTransactionResultResultXdr.kt
@@ -36,10 +36,9 @@ sealed class InnerTransactionResultResultXdr {
 
   /** txFEE_BUMP_INNER_SUCCESS is not included */
   data class Results(
+    override val discriminant: TransactionResultCodeXdr,
     val value: List<OperationResultXdr>
-  ) : InnerTransactionResultResultXdr() {
-    override val discriminant: TransactionResultCodeXdr = TransactionResultCodeXdr.txSUCCESS
-  }
+  ) : InnerTransactionResultResultXdr()
 
   /** txFEE_BUMP_INNER_FAILED is not included */
   data class Void(
@@ -53,11 +52,11 @@ sealed class InnerTransactionResultResultXdr {
       return when (discriminant) {
         TransactionResultCodeXdr.txSUCCESS -> {
           val value = List(reader.readInt()) { OperationResultXdr.decode(reader) }
-          Results(value)
+          Results(discriminant, value)
         }
         TransactionResultCodeXdr.txFAILED -> {
           val value = List(reader.readInt()) { OperationResultXdr.decode(reader) }
-          Results(value)
+          Results(discriminant, value)
         }
         TransactionResultCodeXdr.txTOO_EARLY -> Void(discriminant)
         TransactionResultCodeXdr.txTOO_LATE -> Void(discriminant)

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/xdr/ManageOfferSuccessResultOfferXdr.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/xdr/ManageOfferSuccessResultOfferXdr.kt
@@ -18,10 +18,9 @@ sealed class ManageOfferSuccessResultOfferXdr {
   abstract val discriminant: ManageOfferEffectXdr
 
   data class Offer(
+    override val discriminant: ManageOfferEffectXdr,
     val value: OfferEntryXdr
-  ) : ManageOfferSuccessResultOfferXdr() {
-    override val discriminant: ManageOfferEffectXdr = ManageOfferEffectXdr.MANAGE_OFFER_CREATED
-  }
+  ) : ManageOfferSuccessResultOfferXdr()
 
   data object Void : ManageOfferSuccessResultOfferXdr() {
     override val discriminant: ManageOfferEffectXdr = ManageOfferEffectXdr.MANAGE_OFFER_DELETED
@@ -34,11 +33,11 @@ sealed class ManageOfferSuccessResultOfferXdr {
       return when (discriminant) {
         ManageOfferEffectXdr.MANAGE_OFFER_CREATED -> {
           val value = OfferEntryXdr.decode(reader)
-          Offer(value)
+          Offer(discriminant, value)
         }
         ManageOfferEffectXdr.MANAGE_OFFER_UPDATED -> {
           val value = OfferEntryXdr.decode(reader)
-          Offer(value)
+          Offer(discriminant, value)
         }
         ManageOfferEffectXdr.MANAGE_OFFER_DELETED -> Void
         else -> throw IllegalArgumentException("Unknown ManageOfferSuccessResultOfferXdr discriminant: $discriminant")

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/xdr/SCErrorXdr.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/xdr/SCErrorXdr.kt
@@ -31,10 +31,9 @@ sealed class SCErrorXdr {
   }
 
   data class Code(
+    override val discriminant: SCErrorTypeXdr,
     val value: SCErrorCodeXdr
-  ) : SCErrorXdr() {
-    override val discriminant: SCErrorTypeXdr = SCErrorTypeXdr.SCE_WASM_VM
-  }
+  ) : SCErrorXdr()
 
   companion object {
 
@@ -47,39 +46,39 @@ sealed class SCErrorXdr {
         }
         SCErrorTypeXdr.SCE_WASM_VM -> {
           val value = SCErrorCodeXdr.decode(reader)
-          Code(value)
+          Code(discriminant, value)
         }
         SCErrorTypeXdr.SCE_CONTEXT -> {
           val value = SCErrorCodeXdr.decode(reader)
-          Code(value)
+          Code(discriminant, value)
         }
         SCErrorTypeXdr.SCE_STORAGE -> {
           val value = SCErrorCodeXdr.decode(reader)
-          Code(value)
+          Code(discriminant, value)
         }
         SCErrorTypeXdr.SCE_OBJECT -> {
           val value = SCErrorCodeXdr.decode(reader)
-          Code(value)
+          Code(discriminant, value)
         }
         SCErrorTypeXdr.SCE_CRYPTO -> {
           val value = SCErrorCodeXdr.decode(reader)
-          Code(value)
+          Code(discriminant, value)
         }
         SCErrorTypeXdr.SCE_EVENTS -> {
           val value = SCErrorCodeXdr.decode(reader)
-          Code(value)
+          Code(discriminant, value)
         }
         SCErrorTypeXdr.SCE_BUDGET -> {
           val value = SCErrorCodeXdr.decode(reader)
-          Code(value)
+          Code(discriminant, value)
         }
         SCErrorTypeXdr.SCE_VALUE -> {
           val value = SCErrorCodeXdr.decode(reader)
-          Code(value)
+          Code(discriminant, value)
         }
         SCErrorTypeXdr.SCE_AUTH -> {
           val value = SCErrorCodeXdr.decode(reader)
-          Code(value)
+          Code(discriminant, value)
         }
         else -> throw IllegalArgumentException("Unknown SCErrorXdr discriminant: $discriminant")
       }

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/xdr/TransactionResultResultXdr.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/xdr/TransactionResultResultXdr.kt
@@ -37,16 +37,14 @@ sealed class TransactionResultResultXdr {
   abstract val discriminant: TransactionResultCodeXdr
 
   data class InnerResultPair(
+    override val discriminant: TransactionResultCodeXdr,
     val value: InnerTransactionResultPairXdr
-  ) : TransactionResultResultXdr() {
-    override val discriminant: TransactionResultCodeXdr = TransactionResultCodeXdr.txFEE_BUMP_INNER_SUCCESS
-  }
+  ) : TransactionResultResultXdr()
 
   data class Results(
+    override val discriminant: TransactionResultCodeXdr,
     val value: List<OperationResultXdr>
-  ) : TransactionResultResultXdr() {
-    override val discriminant: TransactionResultCodeXdr = TransactionResultCodeXdr.txSUCCESS
-  }
+  ) : TransactionResultResultXdr()
 
   /** case txFEE_BUMP_INNER_FAILED: handled above */
   data class Void(
@@ -60,19 +58,19 @@ sealed class TransactionResultResultXdr {
       return when (discriminant) {
         TransactionResultCodeXdr.txFEE_BUMP_INNER_SUCCESS -> {
           val value = InnerTransactionResultPairXdr.decode(reader)
-          InnerResultPair(value)
+          InnerResultPair(discriminant, value)
         }
         TransactionResultCodeXdr.txFEE_BUMP_INNER_FAILED -> {
           val value = InnerTransactionResultPairXdr.decode(reader)
-          InnerResultPair(value)
+          InnerResultPair(discriminant, value)
         }
         TransactionResultCodeXdr.txSUCCESS -> {
           val value = List(reader.readInt()) { OperationResultXdr.decode(reader) }
-          Results(value)
+          Results(discriminant, value)
         }
         TransactionResultCodeXdr.txFAILED -> {
           val value = List(reader.readInt()) { OperationResultXdr.decode(reader) }
-          Results(value)
+          Results(discriminant, value)
         }
         TransactionResultCodeXdr.txTOO_EARLY -> Void(discriminant)
         TransactionResultCodeXdr.txTOO_LATE -> Void(discriminant)

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/contract/ContractSpecTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/contract/ContractSpecTest.kt
@@ -1408,7 +1408,7 @@ class ContractSpecTest {
         assertEquals(42u, (result as SCErrorXdr.ContractCode).value.value)
 
         // Test with WasmVm error
-        val wasmError = SCErrorXdr.Code(SCErrorCodeXdr.SCEC_ARITH_DOMAIN)
+        val wasmError = SCErrorXdr.Code(SCErrorTypeXdr.SCE_WASM_VM, SCErrorCodeXdr.SCEC_ARITH_DOMAIN)
         val scValCodeError = SCValXdr.Error(wasmError)
         val codeResult = spec.scValToNative(scValCodeError, null)
 

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrBucketEntryTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrBucketEntryTest.kt
@@ -95,7 +95,7 @@ class XdrBucketEntryTest {
 
     @Test
     fun testBucketEntryLiveEntry() {
-        val entry = BucketEntryXdr.LiveEntry(simpleLedgerEntry())
+        val entry = BucketEntryXdr.LiveEntry(BucketEntryTypeXdr.LIVEENTRY, simpleLedgerEntry())
         assertXdrRoundTrip(entry, { v, w -> v.encode(w) }, { r -> BucketEntryXdr.decode(r) })
     }
 

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrDiscriminantPreservationTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrDiscriminantPreservationTest.kt
@@ -85,6 +85,19 @@ class XdrDiscriminantPreservationTest {
         assertTrue(decoded is TransactionResultResultXdr.InnerResultPair)
     }
 
+    @Test
+    fun txResultResult_feeBumpInnerSuccess_preservesDiscriminant() {
+        // stellar-xdr encode --type TransactionResultResult \
+        //   '{"tx_fee_bump_inner_success":{"transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000","result":{"fee_charged":"100","result":{"tx_success":[{"op_inner":{"payment":"success"}}]},"ext":"v0"}}}'
+        val decoded = assertRoundTripBytes(
+            base64 = "AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+            decode = { TransactionResultResultXdr.decode(it) },
+            encode = { v, w -> v.encode(w) }
+        )
+        assertEquals(TransactionResultCodeXdr.txFEE_BUMP_INNER_SUCCESS, decoded.discriminant)
+        assertTrue(decoded is TransactionResultResultXdr.InnerResultPair)
+    }
+
     // ===== InnerTransactionResultResult =====
 
     @Test
@@ -155,5 +168,40 @@ class XdrDiscriminantPreservationTest {
         assertEquals(SCErrorTypeXdr.SCE_OBJECT, decoded.discriminant)
         assertTrue(decoded is SCErrorXdr.Code)
         assertEquals(SCErrorCodeXdr.SCEC_UNEXPECTED_TYPE, decoded.value)
+    }
+
+    // ===== BucketEntry =====
+    // The pre-fix `LiveEntry` data class collapsed LIVEENTRY and INITENTRY
+    // (both carrying LedgerEntry) into one hardcoded LIVEENTRY.
+
+    @Test
+    fun bucketEntry_initEntry_preservesDiscriminant() {
+        // stellar-xdr encode --type BucketEntry \
+        //   '{"initentry":{"last_modified_ledger_seq":1,"data":{"ttl":{"key_hash":"0000000000000000000000000000000000000000000000000000000000000000","live_until_ledger_seq":1000}},"ext":"v0"}}'
+        val decoded = assertRoundTripBytes(
+            base64 = "AAAAAgAAAAEAAAAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPoAAAAAA==",
+            decode = { BucketEntryXdr.decode(it) },
+            encode = { v, w -> v.encode(w) }
+        )
+        assertEquals(BucketEntryTypeXdr.INITENTRY, decoded.discriminant)
+        assertTrue(decoded is BucketEntryXdr.LiveEntry)
+    }
+
+    // ===== ManageOfferSuccessResultOffer =====
+    // The pre-fix `Offer` data class collapsed MANAGE_OFFER_CREATED and
+    // MANAGE_OFFER_UPDATED (both carrying OfferEntry) into one hardcoded
+    // MANAGE_OFFER_CREATED.
+
+    @Test
+    fun manageOfferSuccess_updated_preservesDiscriminant() {
+        // stellar-xdr encode --type ManageOfferSuccessResultOffer \
+        //   '{"updated":{"seller_id":"GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ","offer_id":"42","selling":"native","buying":{"credit_alphanum4":{"asset_code":"USD","issuer":"GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"}},"amount":"1000000000","price":{"n":1,"d":2},"flags":0,"ext":"v0"}}'
+        val decoded = assertRoundTripBytes(
+            base64 = "AAAAAQAAAAA/DDS/k60NmXHQTMyQ9wVRHIOKrZc0pKL7DXoD/H/omgAAAAAAAAAqAAAAAAAAAAFVU0QAAAAAAD8MNL+TrQ2ZcdBMzJD3BVEcg4qtlzSkovsNegP8f+iaAAAAADuaygAAAAABAAAAAgAAAAAAAAAA",
+            decode = { ManageOfferSuccessResultOfferXdr.decode(it) },
+            encode = { v, w -> v.encode(w) }
+        )
+        assertEquals(ManageOfferEffectXdr.MANAGE_OFFER_UPDATED, decoded.discriminant)
+        assertTrue(decoded is ManageOfferSuccessResultOfferXdr.Offer)
     }
 }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrDiscriminantPreservationTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrDiscriminantPreservationTest.kt
@@ -1,0 +1,159 @@
+package com.soneso.stellar.sdk.unitTests.xdr
+
+import com.soneso.stellar.sdk.xdr.*
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that XDR unions where multiple discriminant cases share the same payload
+ * type preserve the original discriminant across decode and encode. A payload
+ * received as e.g. `txFAILED` must not silently re-encode as `txSUCCESS`.
+ *
+ * Each fixture is a base64-encoded XDR payload produced by the Stellar reference
+ * Rust XDR codec (github.com/stellar/stellar-xdr), exercising the second (or later)
+ * discriminant case of a shared arm. The JSON shown above each fixture is the
+ * verbatim input passed to the Rust encoder, so any maintainer can regenerate the
+ * bytes via the stellar-xdr CLI:
+ *
+ *     stellar-xdr encode --type <Type> '<json>'
+ *
+ * The test decodes, asserts the discriminant matches what the wire carries, and
+ * re-encodes to assert the bytes round-trip exactly.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+class XdrDiscriminantPreservationTest {
+
+    private fun decodeBytes(base64: String): ByteArray = Base64.decode(base64)
+
+    private inline fun <reified T> assertRoundTripBytes(
+        base64: String,
+        decode: (XdrReader) -> T,
+        encode: (T, XdrWriter) -> Unit
+    ): T {
+        val bytes = decodeBytes(base64)
+        val decoded = decode(XdrReader(bytes))
+        val writer = XdrWriter()
+        encode(decoded, writer)
+        assertTrue(
+            bytes.contentEquals(writer.toByteArray()),
+            "Re-encoded bytes differ from input — discriminant likely lost on decode/encode"
+        )
+        return decoded
+    }
+
+    // ===== TransactionResultResult =====
+
+    @Test
+    fun txResultResult_txFailed_preservesDiscriminant() {
+        // stellar-xdr encode --type TransactionResultResult '{"tx_failed":[{"op_inner":{"payment":"underfunded"}}]}'
+        val decoded = assertRoundTripBytes(
+            base64 = "/////wAAAAEAAAAAAAAAAf////4=",
+            decode = { TransactionResultResultXdr.decode(it) },
+            encode = { v, w -> v.encode(w) }
+        )
+        assertEquals(TransactionResultCodeXdr.txFAILED, decoded.discriminant)
+        assertTrue(decoded is TransactionResultResultXdr.Results)
+        assertEquals(1, decoded.value.size)
+    }
+
+    @Test
+    fun txResultResult_txSuccess_preservesDiscriminant() {
+        // stellar-xdr encode --type TransactionResultResult '{"tx_success":[{"op_inner":{"payment":"success"}}]}'
+        val decoded = assertRoundTripBytes(
+            base64 = "AAAAAAAAAAEAAAAAAAAAAQAAAAA=",
+            decode = { TransactionResultResultXdr.decode(it) },
+            encode = { v, w -> v.encode(w) }
+        )
+        assertEquals(TransactionResultCodeXdr.txSUCCESS, decoded.discriminant)
+        assertTrue(decoded is TransactionResultResultXdr.Results)
+        assertEquals(1, decoded.value.size)
+    }
+
+    @Test
+    fun txResultResult_feeBumpInnerFailed_preservesDiscriminant() {
+        // stellar-xdr encode --type TransactionResultResult \
+        //   '{"tx_fee_bump_inner_failed":{"transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000","result":{"fee_charged":"100","result":{"tx_failed":[{"op_inner":{"payment":"underfunded"}}]},"ext":"v0"}}}'
+        val decoded = assertRoundTripBytes(
+            base64 = "////8wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGT/////AAAAAQAAAAAAAAAB/////gAAAAA=",
+            decode = { TransactionResultResultXdr.decode(it) },
+            encode = { v, w -> v.encode(w) }
+        )
+        assertEquals(TransactionResultCodeXdr.txFEE_BUMP_INNER_FAILED, decoded.discriminant)
+        assertTrue(decoded is TransactionResultResultXdr.InnerResultPair)
+    }
+
+    // ===== InnerTransactionResultResult =====
+
+    @Test
+    fun innerTxResultResult_txFailed_preservesDiscriminant() {
+        // stellar-xdr encode --type InnerTransactionResultResult '{"tx_failed":[{"op_inner":{"change_trust":"malformed"}}]}'
+        val decoded = assertRoundTripBytes(
+            base64 = "/////wAAAAEAAAAAAAAABv////8=",
+            decode = { InnerTransactionResultResultXdr.decode(it) },
+            encode = { v, w -> v.encode(w) }
+        )
+        assertEquals(TransactionResultCodeXdr.txFAILED, decoded.discriminant)
+        assertTrue(decoded is InnerTransactionResultResultXdr.Results)
+        assertEquals(1, decoded.value.size)
+    }
+
+    @Test
+    fun innerTxResultResult_txSuccess_emptyOps_preservesDiscriminant() {
+        // stellar-xdr encode --type InnerTransactionResultResult '{"tx_success":[]}'
+        val decoded = assertRoundTripBytes(
+            base64 = "AAAAAAAAAAA=",
+            decode = { InnerTransactionResultResultXdr.decode(it) },
+            encode = { v, w -> v.encode(w) }
+        )
+        assertEquals(TransactionResultCodeXdr.txSUCCESS, decoded.discriminant)
+        assertTrue(decoded is InnerTransactionResultResultXdr.Results)
+        assertEquals(0, decoded.value.size)
+    }
+
+    // ===== SCError =====
+    // The pre-fix `Code` data class collapsed nine SCErrorType discriminants
+    // (SCE_WASM_VM through SCE_AUTH) into one hardcoded SCE_WASM_VM. Three
+    // representative fixtures are sufficient to lock the contract.
+
+    @Test
+    fun scError_context_preservesDiscriminant() {
+        // stellar-xdr encode --type ScError '{"context":"arith_domain"}'
+        val decoded = assertRoundTripBytes(
+            base64 = "AAAAAgAAAAA=",
+            decode = { SCErrorXdr.decode(it) },
+            encode = { v, w -> v.encode(w) }
+        )
+        assertEquals(SCErrorTypeXdr.SCE_CONTEXT, decoded.discriminant)
+        assertTrue(decoded is SCErrorXdr.Code)
+        assertEquals(SCErrorCodeXdr.SCEC_ARITH_DOMAIN, decoded.value)
+    }
+
+    @Test
+    fun scError_storage_preservesDiscriminant() {
+        // stellar-xdr encode --type ScError '{"storage":"missing_value"}'
+        val decoded = assertRoundTripBytes(
+            base64 = "AAAAAwAAAAM=",
+            decode = { SCErrorXdr.decode(it) },
+            encode = { v, w -> v.encode(w) }
+        )
+        assertEquals(SCErrorTypeXdr.SCE_STORAGE, decoded.discriminant)
+        assertTrue(decoded is SCErrorXdr.Code)
+        assertEquals(SCErrorCodeXdr.SCEC_MISSING_VALUE, decoded.value)
+    }
+
+    @Test
+    fun scError_object_preservesDiscriminant() {
+        // stellar-xdr encode --type ScError '{"object":"unexpected_type"}'
+        val decoded = assertRoundTripBytes(
+            base64 = "AAAABAAAAAg=",
+            decode = { SCErrorXdr.decode(it) },
+            encode = { v, w -> v.encode(w) }
+        )
+        assertEquals(SCErrorTypeXdr.SCE_OBJECT, decoded.discriminant)
+        assertTrue(decoded is SCErrorXdr.Code)
+        assertEquals(SCErrorCodeXdr.SCEC_UNEXPECTED_TYPE, decoded.value)
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrOperationResultGapsTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrOperationResultGapsTest.kt
@@ -276,17 +276,29 @@ class XdrOperationResultGapsTest {
 
     // ========== SCError - all variants ==========
     @Test fun testSCErrorContract() { rtSCE(SCErrorXdr.ContractCode(uint32(1u))) }
-    @Test fun testSCErrorWasm() { rtSCE(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_ARITH_DOMAIN)) }
-    @Test fun testSCErrorContext() { rtSCE(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_INTERNAL_ERROR)) }
-    @Test fun testSCErrorStorage() { rtSCE(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_EXCEEDED_LIMIT)) }
-    @Test fun testSCErrorObject() { rtSCE(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_INVALID_ACTION)) }
-    @Test fun testSCErrorCrypto() { rtSCE(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_MISSING_VALUE)) }
-    @Test fun testSCErrorEvents() { rtSCE(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_UNEXPECTED_TYPE)) }
-    @Test fun testSCErrorBudget() { rtSCE(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_UNEXPECTED_SIZE)) }
-    @Test fun testSCErrorValue() { rtSCE(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_INVALID_INPUT)) }
-    @Test fun testSCErrorAuth() { rtSCE(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_EXISTING_VALUE)) }
+    @Test fun testSCErrorWasm() { rtSCE(SCErrorXdr.Code(SCErrorTypeXdr.SCE_WASM_VM, SCErrorCodeXdr.SCEC_ARITH_DOMAIN)) }
+    @Test fun testSCErrorContext() { rtSCE(SCErrorXdr.Code(SCErrorTypeXdr.SCE_CONTEXT, SCErrorCodeXdr.SCEC_INTERNAL_ERROR)) }
+    @Test fun testSCErrorStorage() { rtSCE(SCErrorXdr.Code(SCErrorTypeXdr.SCE_STORAGE, SCErrorCodeXdr.SCEC_EXCEEDED_LIMIT)) }
+    @Test fun testSCErrorObject() { rtSCE(SCErrorXdr.Code(SCErrorTypeXdr.SCE_OBJECT, SCErrorCodeXdr.SCEC_INVALID_ACTION)) }
+    @Test fun testSCErrorCrypto() { rtSCE(SCErrorXdr.Code(SCErrorTypeXdr.SCE_CRYPTO, SCErrorCodeXdr.SCEC_MISSING_VALUE)) }
+    @Test fun testSCErrorEvents() { rtSCE(SCErrorXdr.Code(SCErrorTypeXdr.SCE_EVENTS, SCErrorCodeXdr.SCEC_UNEXPECTED_TYPE)) }
+    @Test fun testSCErrorBudget() { rtSCE(SCErrorXdr.Code(SCErrorTypeXdr.SCE_BUDGET, SCErrorCodeXdr.SCEC_UNEXPECTED_SIZE)) }
+    @Test fun testSCErrorValue() { rtSCE(SCErrorXdr.Code(SCErrorTypeXdr.SCE_VALUE, SCErrorCodeXdr.SCEC_INVALID_INPUT)) }
+    @Test fun testSCErrorAuth() { rtSCE(SCErrorXdr.Code(SCErrorTypeXdr.SCE_AUTH, SCErrorCodeXdr.SCEC_EXISTING_VALUE)) }
 
-    private fun rtSCE(v: SCErrorXdr) = assertXdrRoundTrip(v, { v2, w -> v2.encode(w) }, { r -> SCErrorXdr.decode(r) })
+    private fun rtSCE(v: SCErrorXdr) {
+        // Round-trip via bytes and assert the discriminant survives decode.
+        // Guards against regressions where multiple SCErrorType discriminants
+        // sharing the SCErrorXdr.Code payload collapse to a single hardcoded type.
+        val writer = XdrWriter()
+        v.encode(writer)
+        val bytes = writer.toByteArray()
+        val decoded = SCErrorXdr.decode(XdrReader(bytes))
+        kotlin.test.assertEquals(v.discriminant, decoded.discriminant, "discriminant lost on decode")
+        val writer2 = XdrWriter()
+        decoded.encode(writer2)
+        kotlin.test.assertTrue(bytes.contentEquals(writer2.toByteArray()), "XDR round-trip bytes differ")
+    }
 
     // ========== ChangeTrustAsset ==========
     @Test fun testChangeTrustAssetNative() {

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrSCValAllTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrSCValAllTest.kt
@@ -15,7 +15,7 @@ class XdrSCValAllTest {
     @Test fun testVoidLedgerKeyContractInstance() = rt(SCValXdr.Void(SCValTypeXdr.SCV_LEDGER_KEY_CONTRACT_INSTANCE))
 
     @Test fun testErrorContractCode() = rt(SCValXdr.Error(SCErrorXdr.ContractCode(Uint32Xdr(42u))))
-    @Test fun testErrorWasmVM() = rt(SCValXdr.Error(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_INTERNAL_ERROR)))
+    @Test fun testErrorWasmVM() = rt(SCValXdr.Error(SCErrorXdr.Code(SCErrorTypeXdr.SCE_WASM_VM, SCErrorCodeXdr.SCEC_INTERNAL_ERROR)))
 
     @Test fun testU32() = rt(SCValXdr.U32(Uint32Xdr(123456u)))
     @Test fun testU32Zero() = rt(SCValXdr.U32(Uint32Xdr(0u)))
@@ -94,9 +94,9 @@ class XdrSCValAllTest {
         ))))
     }
 
-    @Test fun testErrorContextType() = rt(SCValXdr.Error(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_ARITH_DOMAIN)))
-    @Test fun testErrorStorageType() = rt(SCValXdr.Error(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_MISSING_VALUE)))
-    @Test fun testErrorBudgetType() = rt(SCValXdr.Error(SCErrorXdr.Code(SCErrorCodeXdr.SCEC_EXCEEDED_LIMIT)))
+    @Test fun testErrorContextType() = rt(SCValXdr.Error(SCErrorXdr.Code(SCErrorTypeXdr.SCE_CONTEXT, SCErrorCodeXdr.SCEC_ARITH_DOMAIN)))
+    @Test fun testErrorStorageType() = rt(SCValXdr.Error(SCErrorXdr.Code(SCErrorTypeXdr.SCE_STORAGE, SCErrorCodeXdr.SCEC_MISSING_VALUE)))
+    @Test fun testErrorBudgetType() = rt(SCValXdr.Error(SCErrorXdr.Code(SCErrorTypeXdr.SCE_BUDGET, SCErrorCodeXdr.SCEC_EXCEEDED_LIMIT)))
 
     @Test fun testAddressLiquidityPool() = rt(SCValXdr.Address(SCAddressXdr.LiquidityPoolId(XdrTestHelpers.poolId())))
     @Test fun testAddressClaimableBalance() = rt(SCValXdr.Address(

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrSorobanDataTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrSorobanDataTest.kt
@@ -154,7 +154,7 @@ class XdrSorobanDataTest {
     @Test
     fun testSCErrorCodeArithDomain() {
         XdrTestHelpers.assertXdrRoundTrip(
-            SCErrorXdr.Code(SCErrorCodeXdr.SCEC_ARITH_DOMAIN),
+            SCErrorXdr.Code(SCErrorTypeXdr.SCE_WASM_VM, SCErrorCodeXdr.SCEC_ARITH_DOMAIN),
             { v, w -> v.encode(w) }, { r -> SCErrorXdr.decode(r) })
     }
 
@@ -207,7 +207,7 @@ class XdrSorobanDataTest {
             flags = XdrTestHelpers.uint32(0u), ext = OfferEntryExtXdr.Void
         )
         XdrTestHelpers.assertXdrRoundTrip(
-            ManageOfferSuccessResultXdr(offersClaimed = emptyList(), offer = ManageOfferSuccessResultOfferXdr.Offer(offerEntry)),
+            ManageOfferSuccessResultXdr(offersClaimed = emptyList(), offer = ManageOfferSuccessResultOfferXdr.Offer(ManageOfferEffectXdr.MANAGE_OFFER_CREATED, offerEntry)),
             { v, w -> v.encode(w) }, { r -> ManageOfferSuccessResultXdr.decode(r) })
     }
 }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrTransactionEnvelopeTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrTransactionEnvelopeTest.kt
@@ -417,7 +417,7 @@ class XdrTransactionEnvelopeTest {
         )
         val result = InnerTransactionResultXdr(
             feeCharged = int64(100L),
-            result = InnerTransactionResultResultXdr.Results(listOf(opResult)),
+            result = InnerTransactionResultResultXdr.Results(TransactionResultCodeXdr.txSUCCESS, listOf(opResult)),
             ext = InnerTransactionResultExtXdr.Void
         )
         assertXdrRoundTrip(result, { v, w -> v.encode(w) }, { r -> InnerTransactionResultXdr.decode(r) })

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrTransactionResultTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/XdrTransactionResultTest.kt
@@ -29,13 +29,13 @@ class XdrTransactionResultTest {
     @Test fun testResultSorobanInvalid() = rtResult(TransactionResultResultXdr.Void(TransactionResultCodeXdr.txSOROBAN_INVALID))
     @Test fun testResultFrozenKeyAccessed() = rtResult(TransactionResultResultXdr.Void(TransactionResultCodeXdr.txFROZEN_KEY_ACCESSED))
 
-    @Test fun testResultSuccessEmptyOps() = rtResult(TransactionResultResultXdr.Results(emptyList()))
+    @Test fun testResultSuccessEmptyOps() = rtResult(TransactionResultResultXdr.Results(TransactionResultCodeXdr.txSUCCESS, emptyList()))
 
     @Test fun testResultSuccessWithOps() {
         val opResult = OperationResultXdr.Tr(
             OperationResultTrXdr.PaymentResult(PaymentResultXdr.Void(PaymentResultCodeXdr.PAYMENT_SUCCESS))
         )
-        rtResult(TransactionResultResultXdr.Results(listOf(opResult)))
+        rtResult(TransactionResultResultXdr.Results(TransactionResultCodeXdr.txSUCCESS, listOf(opResult)))
     }
 
     @Test fun testResultSuccessMultipleOps() {
@@ -44,12 +44,12 @@ class XdrTransactionResultTest {
         val op2 = OperationResultXdr.Tr(OperationResultTrXdr.PaymentResult(
             PaymentResultXdr.Void(PaymentResultCodeXdr.PAYMENT_SUCCESS)))
         val op3 = OperationResultXdr.Void(OperationResultCodeXdr.opBAD_AUTH)
-        rtResult(TransactionResultResultXdr.Results(listOf(op1, op2, op3)))
+        rtResult(TransactionResultResultXdr.Results(TransactionResultCodeXdr.txSUCCESS, listOf(op1, op2, op3)))
     }
 
     @Test fun testFullTransactionResultSuccess() = rtTxResult(TransactionResultXdr(
         feeCharged = Int64Xdr(100L),
-        result = TransactionResultResultXdr.Results(emptyList()),
+        result = TransactionResultResultXdr.Results(TransactionResultCodeXdr.txSUCCESS, emptyList()),
         ext = TransactionResultExtXdr.Void
     ))
 
@@ -58,7 +58,7 @@ class XdrTransactionResultTest {
             ChangeTrustResultXdr.Void(ChangeTrustResultCodeXdr.CHANGE_TRUST_MALFORMED)))
         rtTxResult(TransactionResultXdr(
             feeCharged = Int64Xdr(200L),
-            result = TransactionResultResultXdr.Results(listOf(opResult)),
+            result = TransactionResultResultXdr.Results(TransactionResultCodeXdr.txFAILED, listOf(opResult)),
             ext = TransactionResultExtXdr.Void
         ))
     }
@@ -81,7 +81,7 @@ class XdrTransactionResultTest {
             InvokeHostFunctionResultXdr.Success(XdrTestHelpers.hashXdr())))
         rtTxResult(TransactionResultXdr(
             feeCharged = Int64Xdr(1000L),
-            result = TransactionResultResultXdr.Results(listOf(opResult)),
+            result = TransactionResultResultXdr.Results(TransactionResultCodeXdr.txSUCCESS, listOf(opResult)),
             ext = TransactionResultExtXdr.Void
         ))
     }

--- a/tools/xdrgen-kt/lib/xdrgen/generators/kotlin.rb
+++ b/tools/xdrgen-kt/lib/xdrgen/generators/kotlin.rb
@@ -249,8 +249,11 @@ module Xdrgen
             arm_type = kotlin_type_for(arm.declaration)
             is_default = arm.is_a?(AST::Definitions::UnionDefaultArm)
 
-            if is_default
-              # Default arm needs discriminant as constructor parameter
+            if is_default || arm.cases.length > 1
+              # Default arms and multi-case arms both need discriminant as a
+              # constructor parameter so the wire-read value survives a
+              # decode/encode round trip. Hardcoding here would lose the
+              # discriminant for any case beyond the first.
               out.puts "data class #{arm_class_name}("
               out.indent do
                 out.puts "override val discriminant: #{discriminant_type},"
@@ -288,15 +291,10 @@ module Xdrgen
 
             is_default = arms.first.is_a?(AST::Definitions::UnionDefaultArm)
 
-            if is_default
-              # Default arm needs discriminant as constructor parameter
-              out.puts "data class #{arm_class_name}("
-              out.indent do
-                out.puts "override val discriminant: #{discriminant_type}"
-              end
-              out.puts ") : #{union_name}()"
-            elsif total_discriminants > 1
-              # Multiple discriminant values - need a data class with discriminant parameter
+            if is_default || total_discriminants > 1
+              # Default arms and multi-case void arms both need discriminant
+              # as a constructor parameter — the wire-read value must survive
+              # decode/encode.
               out.puts "data class #{arm_class_name}("
               out.indent do
                 out.puts "override val discriminant: #{discriminant_type}"
@@ -323,7 +321,13 @@ module Xdrgen
               out.puts "val discriminant = #{decode_expression(union.discriminant, 'reader')}"
               out.puts "return when (discriminant) {"
               out.indent do
-                # Build a map to detect void arms with multiple discriminants
+                # Build a map to detect void arms with multiple discriminants.
+                # `union.normal_arms` excludes the default arm — that case is
+                # rendered separately below in the `union.default_arm.present?`
+                # block. The class-definition predicate at the top of this method
+                # uses `is_default || ...`; the predicate here intentionally does
+                # not need the `is_default` check because the default arm never
+                # reaches this loop.
                 void_arms_by_class = {}
                 union.normal_arms.select(&:void?).each do |arm|
                   class_name = arm.name.camelize
@@ -359,7 +363,11 @@ module Xdrgen
                       out.puts "#{discriminant_value} -> {"
                       out.indent do
                         out.puts "val value = #{decode_expression(arm.declaration, 'reader')}"
-                        out.puts "#{arm_class_name}(value)"
+                        if arm.cases.length > 1
+                          out.puts "#{arm_class_name}(discriminant, value)"
+                        else
+                          out.puts "#{arm_class_name}(value)"
+                        end
                       end
                       out.puts "}"
                     end

--- a/tools/xdrgen-kt/test/snapshots/MultiCaseUnionXdr.kt
+++ b/tools/xdrgen-kt/test/snapshots/MultiCaseUnionXdr.kt
@@ -26,10 +26,9 @@ sealed class MultiCaseUnionXdr {
   }
 
   data class TextValue(
+    override val discriminant: Int,
     val value: String
-  ) : MultiCaseUnionXdr() {
-    override val discriminant: Int = 1
-  }
+  ) : MultiCaseUnionXdr()
 
   data class RawValue(
     override val discriminant: Int,
@@ -47,11 +46,11 @@ sealed class MultiCaseUnionXdr {
         }
         1 -> {
           val value = reader.readString()
-          TextValue(value)
+          TextValue(discriminant, value)
         }
         2 -> {
           val value = reader.readString()
-          TextValue(value)
+          TextValue(discriminant, value)
         }
         else -> {
           val value = reader.readVariableOpaque()


### PR DESCRIPTION
XDR unions where multiple discriminant cases shared one non-void payload were generated with the discriminant hardcoded to the first case. As a result, `txFAILED` round-tripped as `txSUCCESS` and all `SCError` types collapsed to `SCE_WASM_VM`. The generator now emits the discriminant as a constructor parameter for these arms.

## Impact

The SDK's high-level transaction success/failure paths (Horizon `successful`, RPC `status`, `AssembledTransaction`, `ContractClient`) flow through JSON, not XDR discriminants, and were not affected.

The bug surfaced for code that:
- decoded `TransactionResultResultXdr` and inspected `.discriminant` (e.g. to distinguish `txFAILED` from `txSUCCESS`), or
- read Soroban contract errors via `Scv.fromError()` or `ContractSpec.scValToNative()` — the error *type* (e.g. `SCE_STORAGE`, `SCE_CONTEXT`) was always reported as `SCE_WASM_VM`, though the error *code* was correct.

## Migration

Users of the high-level helpers need no changes. Code that constructs the affected XDR types directly now passes
`discriminant` as the first constructor argument (e.g. `SCErrorXdr.Code(SCErrorTypeXdr.SCE_CONTEXT, code)`).