### PR TITLE
Improve smart-account connect cascade order and fix indexer JSON parsing

### DIFF
--- a/docs/smart-accounts/README.md
+++ b/docs/smart-accounts/README.md
@@ -168,19 +168,37 @@ val config = OZSmartAccountConfig(
 val kit = OZSmartAccountKit.create(config)
 
 // Phase 1: Silent restore at app launch (no biometric prompt)
-val result = kit.walletOperations.connectWallet()
-if (result != null) {
-    println("Reconnected to ${result.contractId}")
-} else {
-    // No saved session -- show a "Connect" button in the UI
+when (val result = kit.walletOperations.connectWallet()) {
+    null -> {
+        // No saved session -- show a "Connect" button in the UI
+    }
+    is ConnectWalletResult.Connected -> {
+        println("Reconnected to ${result.contractId}")
+    }
+    is ConnectWalletResult.Ambiguous -> {
+        // Unreachable for the silent restore path
+    }
 }
 
 // Phase 2: User taps "Connect" -- triggers WebAuthn if no session
-val connected = kit.walletOperations.connectWallet(
+val result = kit.walletOperations.connectWallet(
     OZWalletOperations.ConnectWalletOptions(prompt = true)
 )
-if (connected != null) {
-    println("Connected to ${connected.contractId}")
+when (result) {
+    null -> { /* unreachable when prompt = true */ }
+    is ConnectWalletResult.Connected -> println("Connected to ${result.contractId}")
+    is ConnectWalletResult.Ambiguous -> {
+        // Indexer reported multiple contracts for this passkey. Show a picker
+        // and reconnect with the chosen contract address (no second WebAuthn
+        // ceremony required because we re-use result.credentialId).
+        val chosen = showContractPicker(result.candidates)
+        kit.walletOperations.connectWallet(
+            OZWalletOperations.ConnectWalletOptions(
+                credentialId = result.credentialId,
+                contractId = chosen
+            )
+        )
+    }
 }
 ```
 
@@ -192,7 +210,7 @@ val connection = kit.walletOperations.connectWallet(
 )
 ```
 
-Connect directly with known credentials (skips WebAuthn and session check, always returns non-null):
+Connect directly with known credentials (skips WebAuthn and session check; the cascade is bypassed so the result is always `Connected` on success):
 
 ```kotlin
 val connection = kit.walletOperations.connectWallet(

--- a/docs/smart-accounts/api-reference.md
+++ b/docs/smart-accounts/api-reference.md
@@ -456,52 +456,92 @@ data class ConnectWalletOptions(
     val fresh: Boolean = false,
     val prompt: Boolean = false
 )
+
+sealed class ConnectWalletResult {
+    abstract val credentialId: String
+
+    data class Connected(
+        override val credentialId: String,
+        val contractId: String,
+        val restoredFromSession: Boolean
+    ) : ConnectWalletResult()
+
+    data class Ambiguous(
+        override val credentialId: String,
+        val candidates: List<String>
+    ) : ConnectWalletResult()
+}
 ```
 
 Connects to an existing smart account wallet. Returns `null` when no session exists and no WebAuthn prompt is requested, enabling a two-phase connect pattern.
+
+The non-null result is one of two arms:
+- `Connected`: a single contract was resolved; kit state is set and a session is saved.
+- `Ambiguous`: the indexer reported multiple contracts where the passkey is registered as a signer. The kit state is NOT set; the caller must let the user pick a contract from `candidates` and reconnect with the chosen `contractId` (and the `credentialId` from the result, to skip a second WebAuthn ceremony).
+
+`Ambiguous` is by-construction unreachable when `contractId` is supplied (the cascade is bypassed).
 
 **Options Decision Matrix**:
 
 | Options | Behavior |
 |---------|----------|
 | (default) | Session restore; return `null` if no session |
-| `credentialId` and/or `contractId` | Direct connect, skip session check; always returns non-null |
+| `credentialId` and/or `contractId` | Direct connect, skip session check |
 | `fresh = true` | Skip session, always trigger WebAuthn |
 | `prompt = true` | Session restore; trigger WebAuthn if no session |
 | `fresh = true, prompt = true` | `fresh` takes priority, always trigger WebAuthn |
 
-**Returns**: `ConnectWalletResult?` -- non-null on successful connection, `null` when no session exists and `prompt` is `false`
+**Contract lookup order** (when `credentialId` is provided or WebAuthn was triggered, and `contractId` is not supplied): storage → derivation → indexer.
 
-When `credentialId` and/or `contractId` are provided, the direct connect path always returns non-null.
+1. Storage hit: `FAILED` deployment status throws with a recovery hint pointing to `deployPendingCredential()`. `PENDING` entries are trusted.
+2. Derivation: derive the deterministic address under the configured deployer and verify on-chain. If no contract exists, fall through to the indexer.
+3. Indexer: 0 results → `WalletException.NotFound`. 1 result → verify on-chain and return `Connected`. N > 1 → return `Ambiguous(candidates)`.
 
 **Throws**:
 - `WebAuthnException`: Authentication failed (only when WebAuthn is triggered)
-- `WalletException.NotFound`: Wallet not found for credential
-- `ValidationException`: Invalid options
+- `WalletException.NotFound`: Contract not found at any cascade stage (no on-chain contract at the derived address and either no indexer or zero/missing indexer results), or `FAILED` storage entry detected
+- `ValidationException`: Invalid options, or malformed deployer config (from `deriveContractAddress`)
+- `TransactionException`: Internal XDR encoding failure (from `deriveContractAddress`)
 
 **Example**:
 
 ```kotlin
 // Phase 1: Silent restore at app launch (returns null if no session)
-val result = walletOps.connectWallet()
-if (result != null) {
-    println("Silently reconnected to ${result.contractId}")
-} else {
-    // Show a "Connect" button in the UI
+when (val result = walletOps.connectWallet()) {
+    null -> {
+        // No saved session — show a "Connect" button in the UI
+    }
+    is ConnectWalletResult.Connected -> {
+        println("Silently reconnected to ${result.contractId}")
+    }
+    is ConnectWalletResult.Ambiguous -> {
+        // Unreachable for the silent restore path
+    }
 }
 
-// Phase 2: User taps "Connect" -- triggers WebAuthn if no session
-val connected = walletOps.connectWallet(
-    ConnectWalletOptions(prompt = true)
-)
+// Phase 2: User taps "Connect" — triggers WebAuthn if no session
+val result = walletOps.connectWallet(ConnectWalletOptions(prompt = true))
+when (result) {
+    null -> { /* unreachable when prompt = true */ }
+    is ConnectWalletResult.Connected -> println("Connected: ${result.contractId}")
+    is ConnectWalletResult.Ambiguous -> {
+        // Let the user pick, then re-connect with credentialId + chosen contractId
+        // (no second WebAuthn ceremony required).
+        val chosen = userPicker(result.candidates)
+        walletOps.connectWallet(
+            ConnectWalletOptions(
+                credentialId = result.credentialId,
+                contractId = chosen
+            )
+        )
+    }
+}
 
 // Force fresh authentication
-val fresh = walletOps.connectWallet(
-    ConnectWalletOptions(fresh = true)
-)
+walletOps.connectWallet(ConnectWalletOptions(fresh = true))
 
-// Direct connection (always returns non-null)
-val direct = walletOps.connectWallet(
+// Direct connection (Ambiguous is by-construction unreachable)
+walletOps.connectWallet(
     ConnectWalletOptions(
         credentialId = "abc123...",
         contractId = "CBCD..."
@@ -616,17 +656,30 @@ data class CreateWalletResult(
 
 #### ConnectWalletResult
 ```kotlin
-data class ConnectWalletResult(
-    val credentialId: String,
-    val contractId: String,
-    val restoredFromSession: Boolean
-)
+sealed class ConnectWalletResult {
+    abstract val credentialId: String
+
+    data class Connected(
+        override val credentialId: String,
+        val contractId: String,
+        val restoredFromSession: Boolean
+    ) : ConnectWalletResult()
+
+    data class Ambiguous(
+        override val credentialId: String,
+        val candidates: List<String>
+    ) : ConnectWalletResult()
+}
 ```
 
-**Fields**:
+**Connected fields**:
 - `credentialId`: Base64URL-encoded credential ID
 - `contractId`: Smart account contract address
 - `restoredFromSession`: True if reconnected from saved session, false if new authentication
+
+**Ambiguous fields**:
+- `credentialId`: Base64URL-encoded credential ID; reuse this for the disambiguation reconnect to skip a second WebAuthn ceremony
+- `candidates`: Contract addresses (C-addresses) where the passkey is registered as a signer. The caller should let the user pick one and reconnect with `OZWalletOperations.ConnectWalletOptions(credentialId, contractId = chosen)`.
 
 #### DeployPendingResult
 ```kotlin

--- a/docs/smart-accounts/onboarding.md
+++ b/docs/smart-accounts/onboarding.md
@@ -267,7 +267,7 @@ An indexer is an optional service that maps credential IDs to contract addresses
 
 Without an indexer, the SDK derives the contract address from the credential ID and the deployer's public key. This works when the deployer keypair is known (including the default deployer). But if a custom deployer was used and the client does not have the deployer keypair, it cannot derive the address.
 
-With an indexer, `connectWallet()` queries the indexer to find the contract address for any credential, regardless of which deployer was used.
+With an indexer, `connectWallet()` falls back to it when derivation under the configured deployer doesn't find an on-chain contract — typically because the passkey was added as a signer to an existing wallet rather than deploying its own. If the indexer reports the passkey on more than one contract, `connectWallet()` returns `ConnectWalletResult.Ambiguous(candidates)` so the app can let the user pick.
 
 SDK configuration:
 ```kotlin
@@ -333,9 +333,9 @@ App builds tx --> SDK simulates --> Passkey signs auth entry --> SDK assembles t
 ### Reconnecting
 
 1. On app relaunch, the app calls `connectWallet()` with default options. The SDK checks for a saved session in the `StorageAdapter` (a platform-specific interface for persisting credentials and session data, covered in the [SDK guide](README.md)).
-2. If a valid (non-expired) session exists, the wallet is silently reconnected. No biometric prompt is shown. The SDK loads the credential ID and contract ID from the session and returns a non-null `ConnectWalletResult`. Sessions last 7 days by default, configurable via `sessionExpiryMs` in `OZSmartAccountConfig`.
+2. If a valid (non-expired) session exists, the wallet is silently reconnected. No biometric prompt is shown. The SDK loads the credential ID and contract ID from the session and returns `ConnectWalletResult.Connected`. Sessions last 7 days by default, configurable via `sessionExpiryMs` in `OZSmartAccountConfig`.
 3. If no session exists or it has expired, `connectWallet()` returns `null`. The app can then show a "Connect" button and call `connectWallet(ConnectWalletOptions(prompt = true))` when the user taps it, which triggers a WebAuthn biometric prompt.
-4. After authentication, the SDK derives or looks up the contract address (via derivation or indexer) and verifies it exists on-chain by querying Soroban RPC.
+4. After authentication, the SDK runs a storage → derivation → indexer cascade to resolve the contract address and verifies it exists on-chain. If the indexer reports the passkey on multiple contracts, the SDK returns `ConnectWalletResult.Ambiguous(candidates)` so the app can let the user pick (see the [SDK guide](README.md#connecting-to-an-existing-wallet) for the picker pattern).
 
 ---
 

--- a/skills/kmp-stellar-sdk/references/api_reference.md
+++ b/skills/kmp-stellar-sdk/references/api_reference.md
@@ -929,11 +929,19 @@ constructor(message: String, cause: Throwable? = null)
 ## ConfigurationException.MissingConfig
 constructor(message: String, cause: Throwable? = null)
 
-## data ConnectWalletResult
+## sealed ConnectWalletResult
+abstract val credentialId: String
+
+## data ConnectWalletResult.Connected : ConnectWalletResult
 constructor(val credentialId: String, val contractId: String, val restoredFromSession: Boolean)
 val credentialId: String
 val contractId: String
 val restoredFromSession: Boolean
+
+## data ConnectWalletResult.Ambiguous : ConnectWalletResult
+constructor(val credentialId: String, val candidates: List<String>)
+val credentialId: String
+val candidates: List<String>
 
 ## data ConnectedWallet
 constructor(val address: String, val walletId: String, val walletName: String)

--- a/skills/kmp-stellar-sdk/references/smart_accounts.md
+++ b/skills/kmp-stellar-sdk/references/smart_accounts.md
@@ -413,35 +413,69 @@ On a successful direct connect, `connectWithCredentials` **removes** the matchin
 
 ### ConnectWalletResult
 
+A sealed type with two arms. `Connected` means a single contract was resolved (the kit's connected state has been set, a session has been saved). `Ambiguous` means the indexer reported multiple contracts where the passkey is registered as a signer; the connected state has NOT been set, and the caller must let the user pick a contract and reconnect with the chosen `contractId`.
+
 ```kotlin
-data class ConnectWalletResult(
-    val credentialId: String,
-    val contractId: String,
-    val restoredFromSession: Boolean
-)
+sealed class ConnectWalletResult {
+    abstract val credentialId: String
+
+    data class Connected(
+        override val credentialId: String,
+        val contractId: String,
+        val restoredFromSession: Boolean
+    ) : ConnectWalletResult()
+
+    data class Ambiguous(
+        override val credentialId: String,
+        val candidates: List<String>   // contract addresses
+    ) : ConnectWalletResult()
+}
 ```
+
+`Ambiguous` is by-construction unreachable when `contractId` is supplied to `ConnectWalletOptions` — the cascade is bypassed in that case and the result is always `Connected`.
 
 ### Phase 1: silent restore at app launch
 
 ```kotlin
 val kit = OZSmartAccountKit.create(config)
 
-val restored: ConnectWalletResult? = kit.walletOperations.connectWallet()
-if (restored != null) {
-    println("Reconnected to ${restored.contractId}")
-} else {
-    // No session — show Connect button in UI
+when (val restored = kit.walletOperations.connectWallet()) {
+    null -> {
+        // No saved session — show Connect button in UI.
+    }
+    is ConnectWalletResult.Connected -> {
+        println("Reconnected to ${restored.contractId}")
+    }
+    is ConnectWalletResult.Ambiguous -> {
+        // Unreachable for the silent restore path: the saved session
+        // supplies an explicit contractId, which bypasses the cascade.
+    }
 }
 ```
 
 ### Phase 2: user taps Connect
 
 ```kotlin
-val connected = kit.walletOperations.connectWallet(
+val result = kit.walletOperations.connectWallet(
     OZWalletOperations.ConnectWalletOptions(prompt = true)
 )
-if (connected != null) {
-    println("Connected: ${connected.contractId}")
+when (result) {
+    null -> { /* unreachable when prompt = true */ }
+    is ConnectWalletResult.Connected -> {
+        println("Connected: ${result.contractId}")
+    }
+    is ConnectWalletResult.Ambiguous -> {
+        // Show a picker to the user, then call connectWallet again with
+        // both credentialId (= result.credentialId) and the chosen contractId.
+        showPicker(result.candidates) { chosen ->
+            kit.walletOperations.connectWallet(
+                OZWalletOperations.ConnectWalletOptions(
+                    credentialId = result.credentialId,
+                    contractId = chosen
+                )
+            )
+        }
+    }
 }
 ```
 
@@ -466,7 +500,9 @@ val direct = kit.walletOperations.connectWallet(
         contractId   = "CABC..."
     )
 )
-// Always returns non-null on success; throws on contract-not-found.
+// Always returns Connected on success (Ambiguous is by-construction unreachable
+// when contractId is supplied); throws WalletException.NotFound if the
+// contract does not exist on-chain.
 ```
 
 ```kotlin
@@ -478,11 +514,26 @@ val direct = kit.walletOperations.connectWallet(
 
 When `credentialId` is provided (or after WebAuthn), the SDK resolves the contract address in this order:
 
-1. Local storage (matching credential)
-2. Indexer (if configured)
-3. Deterministic address derivation from the deployer
+1. **Local storage**. A storage hit means deployment is `PENDING` or `FAILED`
+   (successful deploy deletes the credential). `FAILED` entries throw
+   `WalletException.NotFound` with a message pointing to
+   `deployPendingCredential()` for retry. `PENDING` entries are trusted —
+   the stored `contractId` is used directly.
+2. **Deterministic address derivation** from the configured deployer. The
+   derived address is verified on-chain via `getContractData`. If no
+   contract exists at the derived address, the cascade falls through to
+   the indexer (the passkey was added as a signer to an existing wallet
+   rather than deploying its own under our deployer). RPC / network errors
+   during verification propagate as their original types.
+3. **Indexer fallback** (if configured). Looks up contracts where the
+   passkey is registered as a signer (sourced from on-chain
+   `signer_registered` events, emitted both at deploy time and on
+   `add_signer`).
+   - 0 contracts → throw `WalletException.NotFound`.
+   - 1 contract → verify on-chain and return `Connected`.
+   - N > 1 contracts → return `ConnectWalletResult.Ambiguous(credentialId, candidates)`. Connection state is NOT set; the caller must let the user pick.
 
-If derivation is used, the SDK verifies the contract instance exists on-chain via `getContractData`. If not found, throws `WalletException.NotFound`.
+When the explicit `contractId` is supplied (direct connect or session restore), the cascade is bypassed and only the on-chain verification runs.
 
 ---
 

--- a/skills/kmp-stellar-sdk/references/smart_accounts_webauthn.md
+++ b/skills/kmp-stellar-sdk/references/smart_accounts_webauthn.md
@@ -861,9 +861,14 @@ fun bootstrap() {
     val kit = OZSmartAccountKit.create(config)
 
     scope.launch {
-        val restored = kit.walletOperations.connectWallet()
-        if (restored != null) {
-            console.log("Reconnected: ${restored.contractId}")
+        when (val restored = kit.walletOperations.connectWallet()) {
+            null -> { /* no saved session */ }
+            is ConnectWalletResult.Connected -> {
+                console.log("Reconnected: ${restored.contractId}")
+            }
+            is ConnectWalletResult.Ambiguous -> {
+                // Unreachable for the silent restore path
+            }
         }
     }
 }

--- a/smart-account-demo/macosApp/StellarSmartDemo/Views/WalletConnectionScreen.swift
+++ b/smart-account-demo/macosApp/StellarSmartDemo/Views/WalletConnectionScreen.swift
@@ -21,6 +21,14 @@ private enum ConnectionSection {
     case pending(String)
 }
 
+/// Captures the data needed to finalize an ambiguous-result connect: the
+/// credential ID from the authentication that produced the Ambiguous result,
+/// and the candidate contracts the user must pick from.
+private struct AmbiguousState {
+    let credentialId: String
+    let candidates: [String]
+}
+
 // MARK: - WalletConnectionScreen
 
 /// Screen that provides four paths for connecting a smart account wallet.
@@ -67,6 +75,13 @@ struct WalletConnectionScreen: View {
     /// Locally stored credentials with a pending deployment status.
     @State private var pendingCredentials: [StoredCredential] = []
 
+    /// State surfaced when a connect flow returns an `Ambiguous` bridge
+    /// result. While non-nil, the picker sheet is shown. The user's
+    /// selection is routed through `performFinalizeConnect`, which uses
+    /// `credentialId` from the original authentication so a second WebAuthn
+    /// prompt is not required.
+    @State private var ambiguousState: AmbiguousState? = nil
+
     // All sections are always expanded (no collapse/expand toggle).
 
     // MARK: - Derived state
@@ -100,6 +115,25 @@ struct WalletConnectionScreen: View {
         .navigationToolbar(title: "Connect Wallet")
         .task {
             await loadPending()
+        }
+        .sheet(isPresented: Binding(
+            get: { ambiguousState != nil },
+            set: { if !$0 { ambiguousState = nil } }
+        )) {
+            ContractPickerSheet(
+                candidates: ambiguousState?.candidates ?? [],
+                onCancel: { ambiguousState = nil },
+                onSelected: { chosen in
+                    let credentialId = ambiguousState?.credentialId
+                    ambiguousState = nil
+                    if let credentialId = credentialId {
+                        performFinalizeConnect(
+                            credentialId: credentialId,
+                            contractAddress: chosen
+                        )
+                    }
+                }
+            )
         }
     }
 
@@ -223,7 +257,7 @@ struct WalletConnectionScreen: View {
             Spacer().frame(height: 4)
 
             LoadingButton(
-                action: performAddressConnect,
+                action: { performAddressConnect() },
                 isLoading: isAddressLoading,
                 isEnabled: isIdle && isAddressValid,
                 text: "Connect",
@@ -366,13 +400,11 @@ struct WalletConnectionScreen: View {
                 let result = try await bridgeWrapper.bridge.quickConnect()
                 await MainActor.run {
                     activeSection = nil
-                    if result != nil {
-                        appState.sync(from: bridgeWrapper.bridge)
-                        toastManager.show("Connected successfully")
-                        dismiss()
-                    } else {
-                        autoConnectError = "No wallet found for this passkey."
-                    }
+                    handleBridgeResult(
+                        result,
+                        nullErrorSetter: { autoConnectError = $0 },
+                        nullErrorMessage: "No wallet found for this passkey."
+                    )
                 }
             } catch {
                 await MainActor.run {
@@ -396,13 +428,11 @@ struct WalletConnectionScreen: View {
                 let result = try await bridgeWrapper.bridge.manualConnect()
                 await MainActor.run {
                     activeSection = nil
-                    if result != nil {
-                        appState.sync(from: bridgeWrapper.bridge)
-                        toastManager.show("Connected successfully")
-                        dismiss()
-                    } else {
-                        indexerError = "No contract found for this credential."
-                    }
+                    handleBridgeResult(
+                        result,
+                        nullErrorSetter: { indexerError = $0 },
+                        nullErrorMessage: "No contract found for this credential."
+                    )
                 }
             } catch {
                 await MainActor.run {
@@ -418,22 +448,26 @@ struct WalletConnectionScreen: View {
         }
     }
 
-    private func performAddressConnect() {
+    /// Attempts to connect to a known contract address.
+    ///
+    /// - Parameter prefilledAddress: When provided, used directly instead of
+    ///   reading the user-entered field. The picker flow uses this to finalize
+    ///   an Ambiguous result without requiring the user to retype an address.
+    private func performAddressConnect(prefilledAddress: String? = nil) {
         clearAllErrors()
-        let address = contractAddressInput.trimmingCharacters(in: .whitespaces)
+        let address = prefilledAddress
+            ?? contractAddressInput.trimmingCharacters(in: .whitespaces)
         activeSection = .address
         Task {
             do {
                 let result = try await bridgeWrapper.bridge.connectWithAddress(contractAddress: address)
                 await MainActor.run {
                     activeSection = nil
-                    if result != nil {
-                        appState.sync(from: bridgeWrapper.bridge)
-                        toastManager.show("Connected successfully")
-                        dismiss()
-                    } else {
-                        addressError = "Could not connect to the provided contract address."
-                    }
+                    handleBridgeResult(
+                        result,
+                        nullErrorSetter: { addressError = $0 },
+                        nullErrorMessage: "Could not connect to the provided contract address."
+                    )
                 }
             } catch {
                 await MainActor.run {
@@ -444,6 +478,70 @@ struct WalletConnectionScreen: View {
                     } else {
                         addressError = msg
                     }
+                }
+            }
+        }
+    }
+
+    /// Handles a bridge connect result by routing to the right state update.
+    ///
+    /// - `nil`: invokes `nullErrorSetter` with `nullErrorMessage`.
+    /// - `result.connected != nil`: syncs app state, shows a toast, dismisses.
+    /// - `result.ambiguous != nil`: sets `ambiguousCandidates`, which triggers
+    ///   the picker sheet. Does NOT dismiss the screen.
+    private func handleBridgeResult(
+        _ result: WalletConnectionBridgeResult?,
+        nullErrorSetter: (String) -> Void,
+        nullErrorMessage: String
+    ) {
+        guard let result = result else {
+            nullErrorSetter(nullErrorMessage)
+            return
+        }
+        if result.connected != nil {
+            appState.sync(from: bridgeWrapper.bridge)
+            toastManager.show("Connected successfully")
+            dismiss()
+        } else if let ambiguous = result.ambiguous {
+            // Surface the candidates; the .sheet binding renders the picker.
+            // The credentialId is captured so the picker callback can finalize
+            // without a second WebAuthn prompt.
+            ambiguousState = AmbiguousState(
+                credentialId: ambiguous.credentialId,
+                candidates: ambiguous.candidates
+            )
+        } else {
+            // Bridge returned a non-null result with neither arm populated.
+            // This violates the bridge invariant; surface as a generic error.
+            nullErrorSetter(nullErrorMessage)
+        }
+    }
+
+    /// Finalizes a connect after the user picks a contract from the
+    /// ambiguous-result picker. Reuses the credential ID from the
+    /// authentication that produced the Ambiguous result, skipping a second
+    /// WebAuthn prompt.
+    private func performFinalizeConnect(credentialId: String, contractAddress: String) {
+        clearAllErrors()
+        activeSection = .address
+        Task {
+            do {
+                let result = try await bridgeWrapper.bridge.finalizeConnect(
+                    credentialId: credentialId,
+                    contractAddress: contractAddress
+                )
+                await MainActor.run {
+                    activeSection = nil
+                    handleBridgeResult(
+                        result,
+                        nullErrorSetter: { addressError = $0 },
+                        nullErrorMessage: "Could not connect to the selected wallet."
+                    )
+                }
+            } catch {
+                await MainActor.run {
+                    activeSection = nil
+                    addressError = error.localizedDescription
                 }
             }
         }
@@ -497,5 +595,122 @@ struct WalletConnectionScreen: View {
         } catch {
             // Non-fatal — the section simply stays hidden
         }
+    }
+}
+
+// MARK: - Contract picker sheet
+
+/// Sheet shown when a connect flow returns an `Ambiguous` bridge result.
+///
+/// The user picks one contract from the candidate list; the parent
+/// `WalletConnectionScreen` then re-runs the connect via
+/// `performAddressConnect(prefilledAddress:)` with the chosen address.
+private struct ContractPickerSheet: View {
+    let candidates: [String]
+    let onCancel: () -> Void
+    let onSelected: (String) -> Void
+
+    @State private var selected: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Select Wallet")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(Material3Colors.onSurface)
+
+            Text(
+                "This passkey is a signer on more than one wallet. " +
+                "Pick the one to connect."
+            )
+            .font(.system(size: 13))
+            .foregroundColor(Material3Colors.onSurfaceVariant)
+
+            if candidates.isEmpty {
+                Text("No candidates available.")
+                    .font(.system(size: 13))
+                    .foregroundColor(Material3Colors.onSurfaceVariant)
+                    .padding(.vertical, 24)
+            } else {
+                ScrollView {
+                    VStack(spacing: 8) {
+                        ForEach(candidates, id: \.self) { address in
+                            ContractCandidateRow(
+                                address: address,
+                                isSelected: selected == address,
+                                onTap: { selected = address }
+                            )
+                        }
+                    }
+                }
+                .frame(maxHeight: 280)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button("Connect") {
+                    if let selected = selected {
+                        onSelected(selected)
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(selected == nil)
+            }
+        }
+        .padding(20)
+        .frame(width: 460)
+        .onAppear {
+            if selected == nil {
+                selected = candidates.first
+            }
+        }
+    }
+}
+
+private struct ContractCandidateRow: View {
+    let address: String
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: isSelected
+                ? "largecircle.fill.circle"
+                : "circle"
+            )
+            .foregroundColor(isSelected
+                ? Material3Colors.primary
+                : Material3Colors.onSurfaceVariant
+            )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Smart Account")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(Material3Colors.onSurface)
+                Text(truncate(address, prefixCount: 8, suffixCount: 8))
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(Material3Colors.onSurfaceVariant)
+            }
+
+            Spacer()
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isSelected
+                    ? Material3Colors.primaryContainer.opacity(0.5)
+                    : Material3Colors.surfaceVariant.opacity(0.5)
+                )
+        )
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
+    }
+
+    private func truncate(_ value: String, prefixCount: Int, suffixCount: Int) -> String {
+        guard value.count > prefixCount + suffixCount else { return value }
+        let prefix = value.prefix(prefixCount)
+        let suffix = value.suffix(suffixCount)
+        return "\(prefix)...\(suffix)"
     }
 }

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/flows/WalletConnectionFlow.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/flows/WalletConnectionFlow.kt
@@ -27,23 +27,10 @@ import com.soneso.smartdemo.util.fetchXlmBalance
 import com.soneso.smartdemo.util.formatStroopsAsXlm
 import com.soneso.smartdemo.util.isUserCancellation
 import com.soneso.smartdemo.util.refreshAllBalances
+import com.soneso.stellar.sdk.smartaccount.oz.ConnectWalletResult
 import com.soneso.stellar.sdk.smartaccount.oz.DeployPendingResult
 import com.soneso.stellar.sdk.smartaccount.oz.OZWalletOperations
 import com.soneso.stellar.sdk.smartaccount.oz.StoredCredential
-
-/**
- * Result of a successful wallet connection.
- *
- * @property contractId The C-address of the connected smart account contract.
- * @property credentialId The Base64URL-encoded passkey credential ID.
- * @property restoredFromSession True if the connection was restored from a saved session
- *   without requiring a new WebAuthn authentication ceremony.
- */
-data class WalletConnectionResult(
-    val contractId: String,
-    val credentialId: String,
-    val restoredFromSession: Boolean
-)
 
 /**
  * Result of deploying a pending credential and provisioning it with tokens.
@@ -91,7 +78,7 @@ private suspend fun isContractDeployed(): Boolean {
  * @throws Exception if the WebAuthn ceremony fails or the network is unreachable.
  *   Check [isUserCancellation] to distinguish user cancellations from hard errors.
  */
-suspend fun quickConnect(): WalletConnectionResult? {
+suspend fun quickConnect(): ConnectWalletResult? {
     val kit = DemoState.kit
         ?: throw IllegalStateException("SDK not initialized")
 
@@ -108,33 +95,38 @@ suspend fun quickConnect(): WalletConnectionResult? {
         return null
     }
 
-    if (result.restoredFromSession) {
-        ActivityLogState.success("Restored from saved session")
-    } else {
-        ActivityLogState.success("Connected via passkey authentication")
+    when (result) {
+        is ConnectWalletResult.Connected -> {
+            if (result.restoredFromSession) {
+                ActivityLogState.success("Restored from saved session")
+            } else {
+                ActivityLogState.success("Connected via passkey authentication")
+            }
+
+            // Update DemoState with the connected wallet's contract and credential.
+            DemoState.setConnected(true, result.contractId, result.credentialId)
+
+            // Verify the contract is actually deployed on-chain. Session restore does not
+            // guarantee on-chain existence (e.g., createWallet with autoSubmit=false).
+            val deployed = isContractDeployed()
+            DemoState.updateDeployed(deployed)
+
+            if (deployed) {
+                refreshAllBalances(result.contractId)
+            } else {
+                ActivityLogState.info("Wallet contract not yet deployed on-chain")
+            }
+        }
+        is ConnectWalletResult.Ambiguous -> {
+            // Indexer returned multiple contracts. Surface to the UI so the
+            // user can pick. Connection state has not been set; the picker's
+            // result will route through connectWithAddress.
+            ActivityLogState.info(
+                "Multiple wallets found for this passkey. Please pick one."
+            )
+        }
     }
-
-    // Update DemoState with the connected wallet's contract and credential.
-    DemoState.setConnected(true, result.contractId, result.credentialId)
-
-    // Verify the contract is actually deployed on-chain. Session restore does not
-    // guarantee on-chain existence (e.g., createWallet with autoSubmit=false).
-    val deployed = isContractDeployed()
-    DemoState.updateDeployed(deployed)
-
-    if (deployed) {
-        // Fetch both XLM and DEMO balances after connection so the main screen shows
-        // up-to-date values without requiring a manual refresh.
-        refreshAllBalances(result.contractId)
-    } else {
-        ActivityLogState.info("Wallet contract not yet deployed on-chain")
-    }
-
-    return WalletConnectionResult(
-        contractId = result.contractId,
-        credentialId = result.credentialId,
-        restoredFromSession = result.restoredFromSession
-    )
+    return result
 }
 
 /**
@@ -155,7 +147,7 @@ suspend fun quickConnect(): WalletConnectionResult? {
  * @throws Exception if the WebAuthn ceremony fails or the indexer lookup fails.
  *   Check [isUserCancellation] to distinguish user cancellations from hard errors.
  */
-suspend fun manualConnect(): WalletConnectionResult? {
+suspend fun manualConnect(): ConnectWalletResult? {
     val kit = DemoState.kit
         ?: throw IllegalStateException("SDK not initialized")
 
@@ -164,9 +156,9 @@ suspend fun manualConnect(): WalletConnectionResult? {
     val authResult = kit.walletOperations.authenticatePasskey()
     ActivityLogState.success("Authenticated with credential: ${authResult.credentialId.take(16)}...")
 
-    // Step 2: Connect using the credential ID. The SDK queries the indexer to map the
-    // credential to its deployed smart account contract address.
-    // Throws WalletException.NotFound if no contract is indexed for this credential.
+    // Step 2: Connect using the credential ID. The SDK runs the
+    // storage -> derivation -> indexer cascade. May return Ambiguous if the
+    // indexer reports multiple contracts for this credential.
     ActivityLogState.info("Looking up contract for credential...")
     val result = kit.walletOperations.connectWallet(
         OZWalletOperations.ConnectWalletOptions(credentialId = authResult.credentialId)
@@ -177,17 +169,22 @@ suspend fun manualConnect(): WalletConnectionResult? {
         return null
     }
 
-    ActivityLogState.success("Connected to contract: ${result.contractId}")
-    DemoState.setConnected(true, result.contractId, result.credentialId)
-    // A successful indexer-based connection means the contract exists on-chain.
-    DemoState.updateDeployed(true)
-    refreshAllBalances(result.contractId)
-
-    return WalletConnectionResult(
-        contractId = result.contractId,
-        credentialId = result.credentialId,
-        restoredFromSession = result.restoredFromSession
-    )
+    when (result) {
+        is ConnectWalletResult.Connected -> {
+            ActivityLogState.success("Connected to contract: ${result.contractId}")
+            DemoState.setConnected(true, result.contractId, result.credentialId)
+            // A successful resolution implies the contract exists on-chain
+            // (the SDK's verifyContractExists has run).
+            DemoState.updateDeployed(true)
+            refreshAllBalances(result.contractId)
+        }
+        is ConnectWalletResult.Ambiguous -> {
+            ActivityLogState.info(
+                "Multiple wallets found for this passkey. Please pick one."
+            )
+        }
+    }
+    return result
 }
 
 /**
@@ -202,7 +199,7 @@ suspend fun manualConnect(): WalletConnectionResult? {
  * @param contractAddress The C-address of the smart account contract.
  * @return [WalletConnectionResult] on success, or null if connection failed.
  */
-suspend fun connectWithAddress(contractAddress: String): WalletConnectionResult? {
+suspend fun connectWithAddress(contractAddress: String): ConnectWalletResult.Connected? {
     val kit = DemoState.kit
         ?: throw IllegalStateException("SDK not initialized")
 
@@ -211,10 +208,39 @@ suspend fun connectWithAddress(contractAddress: String): WalletConnectionResult?
     ActivityLogState.success("Authenticated with credential: ${authResult.credentialId.take(16)}...")
 
     // Step 2: Connect using both the credential ID and the provided contract address.
+    return finalizeConnect(
+        credentialId = authResult.credentialId,
+        contractAddress = contractAddress
+    )
+}
+
+/**
+ * Finalizes a connect when both the credential ID and the contract address
+ * are already known, skipping the WebAuthn ceremony.
+ *
+ * Used by the picker flow that handles `ConnectWalletResult.Ambiguous`: the
+ * user has already authenticated with a passkey to produce the ambiguous
+ * result, so we re-use that same `credentialId` rather than prompting again.
+ *
+ * @param credentialId The Base64URL-encoded credential ID from the
+ *   authentication that produced the Ambiguous result.
+ * @param contractAddress The C-address chosen by the user from the picker.
+ * @return [ConnectWalletResult.Connected] on success, or null if the connect
+ *   failed.
+ */
+suspend fun finalizeConnect(
+    credentialId: String,
+    contractAddress: String
+): ConnectWalletResult.Connected? {
+    val kit = DemoState.kit
+        ?: throw IllegalStateException("SDK not initialized")
+
+    // Supplying contractId bypasses the cascade in the SDK, so the result is
+    // always Connected (Ambiguous is by-construction unreachable on this path).
     ActivityLogState.info("Connecting to contract: ${contractAddress.take(8)}...")
     val result = kit.walletOperations.connectWallet(
         OZWalletOperations.ConnectWalletOptions(
-            credentialId = authResult.credentialId,
+            credentialId = credentialId,
             contractId = contractAddress
         )
     )
@@ -224,17 +250,19 @@ suspend fun connectWithAddress(contractAddress: String): WalletConnectionResult?
         return null
     }
 
-    ActivityLogState.success("Connected to contract: ${result.contractId}")
-    DemoState.setConnected(true, result.contractId, result.credentialId)
-    // A successful address-based connection means the contract exists on-chain.
-    DemoState.updateDeployed(true)
-    refreshAllBalances(result.contractId)
+    val connected = when (result) {
+        is ConnectWalletResult.Connected -> result
+        is ConnectWalletResult.Ambiguous -> error(
+            "Unreachable: connectWallet with explicit contractId never returns Ambiguous"
+        )
+    }
 
-    return WalletConnectionResult(
-        contractId = result.contractId,
-        credentialId = result.credentialId,
-        restoredFromSession = result.restoredFromSession
-    )
+    ActivityLogState.success("Connected to contract: ${connected.contractId}")
+    DemoState.setConnected(true, connected.contractId, connected.credentialId)
+    DemoState.updateDeployed(true)
+    refreshAllBalances(connected.contractId)
+
+    return connected
 }
 
 /**
@@ -261,7 +289,7 @@ suspend fun connectWithAddress(contractAddress: String): WalletConnectionResult?
  */
 suspend fun retryPendingDeploy(
     credentialId: String,
-): WalletConnectionResult {
+): ConnectWalletResult.Connected {
     val kit = DemoState.kit
         ?: throw IllegalStateException("SDK not initialized")
 
@@ -282,9 +310,9 @@ suspend fun retryPendingDeploy(
     DemoState.updateDeployed(true)
     refreshAllBalances(result.contractId)
 
-    return WalletConnectionResult(
-        contractId = result.contractId,
+    return ConnectWalletResult.Connected(
         credentialId = credentialId,
+        contractId = result.contractId,
         restoredFromSession = false
     )
 }
@@ -316,7 +344,7 @@ suspend fun deployPendingAndProvision(
     // Step 1: Deploy the pending credential. This handles the on-chain deployment,
     // sets DemoState.isDeployed=true, and refreshes XLM + DEMO balances via
     // refreshAllBalances. On failure, the exception propagates to the caller.
-    val connectionResult: WalletConnectionResult
+    val connectionResult: ConnectWalletResult.Connected
     try {
         onProgress("Deploying contract...")
         connectionResult = retryPendingDeploy(credentialId)

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/ui/components/ContractPickerDialog.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/ui/components/ContractPickerDialog.kt
@@ -1,0 +1,221 @@
+package com.soneso.smartdemo.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.soneso.smartdemo.util.truncateAddress
+
+/**
+ * Dialog for choosing one contract from a list of candidates.
+ *
+ * Shown when `connectWallet` returns `ConnectWalletResult.Ambiguous` -- the
+ * indexer reported the passkey as a signer on more than one contract and the
+ * SDK declined to pick automatically. The user selects which contract to
+ * connect to and the caller re-runs the connect flow with the chosen address.
+ *
+ * @param isOpen Whether the dialog is visible
+ * @param candidates Contract addresses (C-addresses) to choose from
+ * @param onDismiss Called when the dialog is dismissed without selecting
+ * @param onSelected Called with the chosen contract address when the user confirms
+ * @param title Dialog title
+ * @param description Explanatory text shown below the title
+ */
+@Composable
+fun ContractPickerDialog(
+    isOpen: Boolean,
+    candidates: List<String>,
+    onDismiss: () -> Unit,
+    onSelected: (String) -> Unit,
+    title: String = "Select Wallet",
+    description: String = "This passkey is a signer on more than one wallet. Pick the one to connect."
+) {
+    if (!isOpen) return
+
+    var selectedAddress by remember(candidates) { mutableStateOf(candidates.firstOrNull()) }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true
+        )
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 32.dp)
+                .heightIn(max = 600.dp),
+            shape = MaterialTheme.shapes.large,
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            )
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                // Header
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 8.dp, top = 8.dp, bottom = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Close",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+
+                // Scrollable content
+                Column(
+                    modifier = Modifier
+                        .weight(1f, fill = false)
+                        .verticalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp)
+                ) {
+                    Text(
+                        text = description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = 12.dp)
+                    )
+
+                    if (candidates.isEmpty()) {
+                        Text(
+                            text = "No candidates available.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(vertical = 24.dp)
+                        )
+                    } else {
+                        candidates.forEach { address ->
+                            val isSelected = selectedAddress == address
+                            ContractCandidateRow(
+                                address = address,
+                                isSelected = isSelected,
+                                onClick = { selectedAddress = address }
+                            )
+                        }
+                    }
+                }
+
+                // Footer
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text("Cancel")
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(
+                        onClick = {
+                            val chosen = selectedAddress
+                            if (chosen != null) {
+                                onSelected(chosen)
+                            }
+                        },
+                        enabled = selectedAddress != null
+                    ) {
+                        Text("Connect")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContractCandidateRow(
+    address: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 8.dp)
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isSelected) {
+                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+            }
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            RadioButton(
+                selected = isSelected,
+                onClick = onClick
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Smart Account",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = truncateAddress(address, 8),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/ui/screens/WalletConnectionScreen.kt
+++ b/smart-account-demo/shared/src/commonMain/kotlin/com/soneso/smartdemo/ui/screens/WalletConnectionScreen.kt
@@ -52,8 +52,8 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import com.soneso.smartdemo.flows.WalletConnectionResult
 import com.soneso.smartdemo.flows.deletePendingCredential
+import com.soneso.smartdemo.flows.finalizeConnect
 import com.soneso.smartdemo.flows.loadPendingCredentials
 import com.soneso.smartdemo.flows.connectWithAddress
 import com.soneso.smartdemo.flows.manualConnect
@@ -61,8 +61,10 @@ import com.soneso.smartdemo.flows.quickConnect
 import com.soneso.smartdemo.flows.retryPendingDeploy
 import com.soneso.smartdemo.state.ActivityLogState
 import com.soneso.smartdemo.state.DemoState
+import com.soneso.smartdemo.ui.components.ContractPickerDialog
 import com.soneso.smartdemo.util.isUserCancellation
 import com.soneso.smartdemo.util.isValidContractAddress
+import com.soneso.stellar.sdk.smartaccount.oz.ConnectWalletResult
 import com.soneso.stellar.sdk.smartaccount.oz.StoredCredential
 import kotlinx.coroutines.launch
 
@@ -114,6 +116,13 @@ class WalletConnectionScreen : Screen {
         var indexerConnectError by remember { mutableStateOf<String?>(null) }
         var addressConnectError by remember { mutableStateOf<String?>(null) }
 
+        // Ambiguous-result picker state. Set when a connect flow returns
+        // ConnectWalletResult.Ambiguous (the indexer reports the passkey as
+        // a signer on more than one contract). The dialog is rendered as long
+        // as this is non-null. The user's selection routes through
+        // connectWithAddress to finalize the connect with the chosen contract.
+        var ambiguousResult by remember { mutableStateOf<ConnectWalletResult.Ambiguous?>(null) }
+
         // All sections are always expanded (no collapse/expand toggle).
 
         // Recovery connect input
@@ -139,17 +148,21 @@ class WalletConnectionScreen : Screen {
             section: ConnectionSection,
             setError: (String) -> Unit,
             nullResultMessage: String,
-            connect: suspend () -> WalletConnectionResult?
+            connect: suspend () -> ConnectWalletResult?
         ) {
             clearAllErrors()
             scope.launch {
                 activeConnection = section
                 try {
-                    val result = connect()
-                    if (result != null) {
-                        navigator.pop()
-                    } else {
-                        setError(nullResultMessage)
+                    when (val result = connect()) {
+                        null -> setError(nullResultMessage)
+                        is ConnectWalletResult.Connected -> navigator.pop()
+                        is ConnectWalletResult.Ambiguous -> {
+                            // Show the picker; do not pop yet. The picker's
+                            // onSelected callback will re-launch the connect
+                            // flow with the chosen contract address.
+                            ambiguousResult = result
+                        }
                     }
                 } catch (e: Throwable) {
                     val message = e.message ?: "Unknown error"
@@ -492,6 +505,32 @@ class WalletConnectionScreen : Screen {
                 }
             }
         }
+
+        // Picker dialog rendered when a connect flow returned Ambiguous.
+        // The user selects a contract; we then call finalizeConnect with the
+        // credentialId from the original authentication, skipping a second
+        // WebAuthn prompt. (We do not reuse connectWithAddress here because
+        // it always re-authenticates -- which would (a) prompt the user
+        // twice and (b) let them pick a different passkey on the second
+        // prompt, which would be on a different signer set than the chosen
+        // contract expects.)
+        ContractPickerDialog(
+            isOpen = ambiguousResult != null,
+            candidates = ambiguousResult?.candidates ?: emptyList(),
+            onDismiss = { ambiguousResult = null },
+            onSelected = { chosen ->
+                val authedCredentialId = ambiguousResult?.credentialId
+                ambiguousResult = null
+                if (authedCredentialId != null) {
+                    launchConnection(
+                        section = ConnectionSection.ADDRESS,
+                        setError = { addressConnectError = it },
+                        nullResultMessage = "Could not connect to the selected wallet",
+                        connect = { finalizeConnect(authedCredentialId, chosen) }
+                    )
+                }
+            }
+        )
     }
 }
 

--- a/smart-account-demo/shared/src/macosMain/kotlin/com/soneso/smartdemo/MacOSBridge.kt
+++ b/smart-account-demo/shared/src/macosMain/kotlin/com/soneso/smartdemo/MacOSBridge.kt
@@ -14,8 +14,8 @@ import com.soneso.smartdemo.flows.ContextRuleResult
 import com.soneso.smartdemo.flows.FlowPolicyEntry
 import com.soneso.smartdemo.flows.SignerEntry
 import com.soneso.smartdemo.flows.TransferResult
-import com.soneso.smartdemo.flows.WalletConnectionResult
 import com.soneso.smartdemo.flows.WalletCreationResult
+import com.soneso.stellar.sdk.smartaccount.oz.ConnectWalletResult
 import com.soneso.smartdemo.flows.addContextRule
 import com.soneso.smartdemo.flows.buildDelegatedSigner
 import com.soneso.smartdemo.flows.buildEd25519Signer
@@ -23,6 +23,7 @@ import com.soneso.smartdemo.flows.buildSelectedSigners
 import com.soneso.smartdemo.flows.connectWithAddress
 import com.soneso.smartdemo.flows.deletePendingCredential
 import com.soneso.smartdemo.flows.disconnect
+import com.soneso.smartdemo.flows.finalizeConnect
 import com.soneso.smartdemo.flows.initializeKit
 import com.soneso.smartdemo.flows.loadAccountSigners
 import com.soneso.smartdemo.flows.loadAvailablePasskeySigners
@@ -82,6 +83,75 @@ import platform.AuthenticationServices.ASPresentationAnchor
 import platform.darwin.NSObject
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
+
+/**
+ * Bridge-friendly result for the connect-wallet flows.
+ *
+ * Kotlin sealed classes do not map cleanly to Swift, so the bridge exposes a
+ * flat shape with two mutually-exclusive arms. **Exactly one** of [connected]
+ * and [ambiguous] is non-null when the bridge returns a non-null result;
+ * Swift callers switch on which is non-nil and use the corresponding fields.
+ *
+ * The bridge methods return `WalletConnectionBridgeResult?` overall; `null`
+ * preserves the existing "no result -- show generic error" behavior.
+ */
+data class WalletConnectionBridgeResult(
+    val connected: ConnectedResult? = null,
+    val ambiguous: AmbiguousResult? = null
+) {
+    init {
+        // Enforce the "exactly one of connected / ambiguous is non-null"
+        // invariant at construction time. Without this, a future bridge
+        // entry point could accidentally produce a result with both arms
+        // null or both arms set, which Swift consumers would mishandle.
+        require((connected == null) != (ambiguous == null)) {
+            "WalletConnectionBridgeResult must have exactly one of connected / ambiguous set"
+        }
+    }
+
+    /**
+     * Single-contract connect result. Mirrors [ConnectWalletResult.Connected].
+     */
+    data class ConnectedResult(
+        val contractId: String,
+        val credentialId: String,
+        val restoredFromSession: Boolean
+    )
+
+    /**
+     * Multi-candidate result. Mirrors [ConnectWalletResult.Ambiguous].
+     *
+     * Swift should display [candidates] as a picker, then call
+     * `finalizeConnect(credentialId, chosen)` on the bridge with the
+     * `credentialId` from this result and the chosen contract address.
+     * Reusing the credentialId avoids a second WebAuthn ceremony.
+     */
+    data class AmbiguousResult(
+        val credentialId: String,
+        val candidates: List<String>
+    )
+}
+
+/**
+ * Translates the SDK's [ConnectWalletResult] sealed type into the
+ * bridge-friendly flat shape used by Swift consumers.
+ */
+private fun ConnectWalletResult.toBridgeResult(): WalletConnectionBridgeResult =
+    when (this) {
+        is ConnectWalletResult.Connected -> WalletConnectionBridgeResult(
+            connected = WalletConnectionBridgeResult.ConnectedResult(
+                contractId = contractId,
+                credentialId = credentialId,
+                restoredFromSession = restoredFromSession
+            )
+        )
+        is ConnectWalletResult.Ambiguous -> WalletConnectionBridgeResult(
+            ambiguous = WalletConnectionBridgeResult.AmbiguousResult(
+                credentialId = credentialId,
+                candidates = candidates
+            )
+        )
+    }
 
 /**
  * Bridge between native macOS SwiftUI and the Kotlin Smart Account Kit.
@@ -188,49 +258,81 @@ class MacOSBridge {
     /**
      * Attempts to restore the last session or trigger a passkey authentication prompt.
      *
-     * @return [WalletConnectionResult] on success, null if no wallet was found or restored.
+     * @return Bridge result. When non-null, exactly one of `connected` and
+     *   `ambiguous` is set. `ambiguous` indicates the indexer reported the
+     *   passkey on more than one contract; Swift should show a picker and
+     *   then call [connectWithAddress] with the chosen contract. Null means
+     *   no wallet was found or restored.
      * @throws Exception if the WebAuthn ceremony or network call fails.
      */
     @Throws(Exception::class)
-    suspend fun quickConnect(): WalletConnectionResult? =
-        com.soneso.smartdemo.flows.quickConnect()
+    suspend fun quickConnect(): WalletConnectionBridgeResult? =
+        com.soneso.smartdemo.flows.quickConnect()?.toBridgeResult()
 
     /**
      * Two-step connect: authenticates a passkey first, then resolves the contract via the indexer.
      *
-     * @return [WalletConnectionResult] on success, null if the contract cannot be resolved.
+     * @return Bridge result. See [quickConnect] for the connected/ambiguous shape.
      * @throws Exception if the WebAuthn ceremony or indexer lookup fails.
      */
     @Throws(Exception::class)
-    suspend fun manualConnect(): WalletConnectionResult? =
-        com.soneso.smartdemo.flows.manualConnect()
+    suspend fun manualConnect(): WalletConnectionBridgeResult? =
+        com.soneso.smartdemo.flows.manualConnect()?.toBridgeResult()
 
     /**
      * Connects to a known contract address using any registered passkey.
      *
+     * Supplying an explicit contractId bypasses the SDK's discovery cascade,
+     * so the result is always the connected arm (or null on failure). This
+     * is the path Swift uses to finalize an ambiguous result after the user
+     * picks from the candidates surfaced by [quickConnect] or [manualConnect].
+     *
      * @param contractAddress C-address of the smart account contract.
-     * @return [WalletConnectionResult] on success, null if connection fails.
+     * @return Bridge result with the connected arm populated, or null if the
+     *   connect failed.
      * @throws Exception if the WebAuthn ceremony or network call fails.
      */
     @Throws(Exception::class)
-    suspend fun connectWithAddress(contractAddress: String): WalletConnectionResult? =
-        com.soneso.smartdemo.flows.connectWithAddress(contractAddress)
+    suspend fun connectWithAddress(contractAddress: String): WalletConnectionBridgeResult? =
+        com.soneso.smartdemo.flows.connectWithAddress(contractAddress)?.toBridgeResult()
+
+    /**
+     * Finalizes a connect after the user picks a contract from the
+     * ambiguous-result picker. Reuses the credential ID from the
+     * authentication that produced the Ambiguous result, skipping a second
+     * WebAuthn prompt.
+     *
+     * @param credentialId Base64URL-encoded credential ID from the original
+     *   authentication.
+     * @param contractAddress The C-address chosen by the user.
+     * @return Bridge result with the connected arm populated, or null if the
+     *   connect failed.
+     * @throws Exception if the network call fails.
+     */
+    @Throws(Exception::class)
+    suspend fun finalizeConnect(
+        credentialId: String,
+        contractAddress: String
+    ): WalletConnectionBridgeResult? =
+        com.soneso.smartdemo.flows.finalizeConnect(credentialId, contractAddress)?.toBridgeResult()
 
     /**
      * Retries a pending wallet deployment for a previously registered passkey.
      *
      * The SDK looks up the contract ID and public key from stored credential data.
+     * This path always produces a single connected contract; the bridge result
+     * always has `connected` populated and `ambiguous` null.
      *
      * @param credentialId Base64URL-encoded credential ID of the pending deployment.
-     * @return [WalletConnectionResult] on success.
+     * @return Bridge result with the connected arm populated.
      * @throws Exception if the credential is not found, missing required fields, or the
      *   deploy transaction fails.
      */
     @Throws(Exception::class)
     suspend fun retryPendingDeploy(
         credentialId: String,
-    ): WalletConnectionResult =
-        com.soneso.smartdemo.flows.retryPendingDeploy(credentialId)
+    ): WalletConnectionBridgeResult =
+        com.soneso.smartdemo.flows.retryPendingDeploy(credentialId).toBridgeResult()
 
     /**
      * Deploys a pending wallet and provisions it with XLM and DEMO tokens.

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZIndexerClient.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZIndexerClient.kt
@@ -32,7 +32,8 @@ import kotlinx.serialization.json.*
  */
 @Serializable
 data class CredentialLookupResponse(
-    @SerialName("credential_id")
+    // Indexer's JSON uses the JS variable name (camelCase) at the top level,
+    // even though the inner contracts use snake_case column names.
     val credentialId: String,
     val contracts: List<IndexedContractSummary>,
     val count: Int
@@ -46,7 +47,7 @@ data class CredentialLookupResponse(
  */
 @Serializable
 data class AddressLookupResponse(
-    @SerialName("signer_address")
+    // Same camelCase top-level convention as CredentialLookupResponse.
     val signerAddress: String,
     val contracts: List<IndexedContractSummary>,
     val count: Int
@@ -59,10 +60,10 @@ data class AddressLookupResponse(
  */
 @Serializable
 data class ContractDetailsResponse(
-    @SerialName("contract_id")
+    // Indexer returns the top-level keys in camelCase (JS variable names);
+    // only the inner fields use snake_case (SQL column names).
     val contractId: String,
     val summary: IndexedContractSummary,
-    @SerialName("context_rules")
     val contextRules: List<IndexedContextRule>
 )
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZWalletOperations.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/smartaccount/oz/OZWalletOperations.kt
@@ -105,18 +105,57 @@ data class DeployPendingResult(
 /**
  * Result of a wallet connection operation.
  *
- * Contains the credential ID, contract address, and whether the connection was
- * restored from a saved session.
+ * `connectWallet` and `connectWithCredentials` return one of two arms:
  *
- * @property credentialId The credential ID (Base64URL-encoded, no padding)
- * @property contractId The smart account contract address (C-address)
- * @property restoredFromSession Whether the connection was restored from a saved session
+ * - [Connected]: a single contract was resolved for the credential. The
+ *   connection state has been set on the kit and the session has been saved.
+ * - [Ambiguous]: the indexer reported multiple contracts for the credential
+ *   (the passkey is registered as a signer on more than one contract). The
+ *   connection state has NOT been set; the caller must let the user pick a
+ *   contract and re-call `connectWallet` (or `connectWithAddress` in the demo)
+ *   with the chosen contractId.
+ *
+ * `Ambiguous` is by-construction unreachable when an explicit `contractId` is
+ * supplied (the cascade is bypassed). The session-restore path inside
+ * `connectWallet` therefore always sees `Connected`.
  */
-data class ConnectWalletResult(
-    val credentialId: String,
-    val contractId: String,
-    val restoredFromSession: Boolean
-)
+sealed class ConnectWalletResult {
+
+    /**
+     * The credential ID (Base64URL-encoded, no padding).
+     */
+    abstract val credentialId: String
+
+    /**
+     * A single contract was resolved for the credential.
+     *
+     * The kit's connection state is set and the session has been saved.
+     *
+     * @property credentialId The credential ID (Base64URL-encoded, no padding)
+     * @property contractId The smart account contract address (C-address)
+     * @property restoredFromSession Whether the connection was restored from a saved session
+     */
+    data class Connected(
+        override val credentialId: String,
+        val contractId: String,
+        val restoredFromSession: Boolean
+    ) : ConnectWalletResult()
+
+    /**
+     * The indexer returned more than one contract for the credential.
+     *
+     * The kit's connection state is NOT set. The caller is expected to let
+     * the user select a contract from [candidates] and re-connect with the
+     * chosen `contractId`.
+     *
+     * @property credentialId The credential ID (Base64URL-encoded, no padding)
+     * @property candidates Contract addresses (C-addresses) returned by the indexer
+     */
+    data class Ambiguous(
+        override val credentialId: String,
+        val candidates: List<String>
+    ) : ConnectWalletResult()
+}
 
 /**
  * Result of standalone passkey authentication.
@@ -542,25 +581,44 @@ class OZWalletOperations internal constructor(
      * session exists and neither [ConnectWalletOptions.prompt] nor
      * [ConnectWalletOptions.fresh] is set.
      *
+     * The non-null result is one of two sealed arms:
+     * - [ConnectWalletResult.Connected]: a single contract was resolved, the
+     *   kit's connected state has been set, and a session has been saved.
+     * - [ConnectWalletResult.Ambiguous]: the indexer reported multiple
+     *   contracts where the passkey is registered as a signer. The connected
+     *   state has NOT been set; the caller must let the user pick a contract
+     *   and re-call `connectWallet(ConnectWalletOptions(credentialId,
+     *   contractId = chosen))` to finalize.
+     *
      * Connection flow:
-     * 1. If credentialId/contractId provided: direct connect (always returns non-null)
-     * 2. If fresh = true: skip session, trigger WebAuthn authentication
-     * 3. Otherwise, check storage for a valid (non-expired) session
-     * 4. If valid session found: verify contract on-chain and reconnect (clears stale sessions)
-     * 5. If no valid session and prompt = false: return null
-     * 6. If no valid session and prompt = true: trigger WebAuthn authentication
-     * 7. Look up contract address via storage, indexer, or on-chain derivation
-     * 8. Save session, set kit connected state, return result
+     * 1. If credentialId/contractId provided: direct connect via [connectWithCredentials].
+     * 2. If fresh = true: skip session, trigger WebAuthn authentication.
+     * 3. Otherwise, check storage for a valid (non-expired) session. If a
+     *    valid session is found, verify the contract on-chain and reconnect.
+     *    If verification returns NotFound (contract is not on-chain), clear
+     *    the stale session and continue. Other exceptions during session
+     *    verification propagate (the saved session is preserved so the user
+     *    can retry once their network is healthy).
+     * 4. If no valid session and prompt = false: return null.
+     * 5. If no valid session and prompt = true: trigger WebAuthn authentication.
+     * 6. Resolve the contract via the cascade: storage → derivation → indexer.
+     *    Storage with FAILED deployment status throws with a recovery hint.
+     *    Derivation under the configured deployer is checked on-chain; if
+     *    the address has no contract, falls through to the indexer. Indexer
+     *    returns 0 / 1 / N>1 contracts mapping to NotFound / Connected /
+     *    Ambiguous respectively.
+     * 7. On Connected: save session, set kit connected state, return.
+     *    On Ambiguous: return early without saving a session.
      *
      * ## Connection Options
      *
      * **Silent Session Check (default)**
      * ```kotlin
      * val result = walletOps.connectWallet()
-     * if (result != null) {
-     *     println("Connected: ${result.contractId}")
-     * } else {
-     *     println("No active session - show login UI")
+     * when (result) {
+     *     null -> println("No active session - show login UI")
+     *     is ConnectWalletResult.Connected -> println("Connected: ${result.contractId}")
+     *     is ConnectWalletResult.Ambiguous -> { /* unreachable for the silent path */ }
      * }
      * ```
      *
@@ -569,7 +627,11 @@ class OZWalletOperations internal constructor(
      * val result = walletOps.connectWallet(
      *     ConnectWalletOptions(prompt = true)
      * )
-     * // Restores session if valid, prompts WebAuthn if not
+     * when (result) {
+     *     null -> { /* unreachable when prompt = true */ }
+     *     is ConnectWalletResult.Connected -> println("Connected: ${result.contractId}")
+     *     is ConnectWalletResult.Ambiguous -> showPicker(result.candidates)
+     * }
      * ```
      *
      * **Direct Connection**
@@ -580,7 +642,8 @@ class OZWalletOperations internal constructor(
      *         contractId = "CABC..."
      *     )
      * )
-     * // Connects directly without WebAuthn or session check
+     * // Explicit contractId bypasses the cascade. The non-null result is
+     * // always Connected; Ambiguous is by-construction unreachable.
      * ```
      *
      * **Force Fresh Authentication**
@@ -588,19 +651,35 @@ class OZWalletOperations internal constructor(
      * val result = walletOps.connectWallet(
      *     ConnectWalletOptions(fresh = true)
      * )
-     * // Always prompts WebAuthn, ignoring any saved session
+     * // Always prompts WebAuthn, ignoring any saved session.
      * ```
      *
      * IMPORTANT: Requires a WebAuthnProvider to be configured in the kit config
      * when WebAuthn authentication is needed (prompt = true or fresh = true).
      *
-     * @param options Connection options controlling the flow behavior
-     * @return ConnectWalletResult on success, or null if no session and prompt is false
-     * @throws WebAuthnException if authentication fails or no provider configured
-     * @throws WalletException if wallet not found
-     * @throws ValidationException if options are invalid (e.g., contractId without credentialId)
+     * @param options Connection options controlling the flow behavior.
+     * @return [ConnectWalletResult] on success, or null if no session and
+     *   prompt is false.
+     * @throws WebAuthnException if WebAuthn authentication fails or no
+     *   provider is configured.
+     * @throws WalletException.NotFound if no contract can be resolved for
+     *   the credential (e.g. a FAILED storage entry, no on-chain contract
+     *   at the derived address, or the indexer reports zero contracts).
+     * @throws ValidationException if options are invalid (e.g. contractId
+     *   without credentialId), or if the configured deployer's public key
+     *   is malformed.
+     * @throws TransactionException if XDR encoding of the contract-id
+     *   preimage fails (an internal SDK bug).
+     * @throws com.soneso.stellar.sdk.rpc.SorobanRpcException if a Soroban
+     *   RPC call (e.g. the on-chain `verifyContractExists` check) fails
+     *   for transport / server reasons. RPC errors propagate as their
+     *   original type rather than being laundered to NotFound, so callers
+     *   can distinguish "contract is not on-chain" from "lookup was
+     *   inconclusive."
+     * @throws com.soneso.stellar.sdk.smartaccount.core.IndexerException
+     *   if the indexer call fails for transport / server reasons.
      *
-     * @see ConnectWalletOptions for detailed option descriptions and the decision matrix
+     * @see ConnectWalletOptions for detailed option descriptions and the decision matrix.
      */
     suspend fun connectWallet(
         options: ConnectWalletOptions = ConnectWalletOptions()
@@ -628,9 +707,27 @@ class OZWalletOperations internal constructor(
                         credentialId = session.credentialId,
                         contractId = session.contractId
                     )
-                    return result.copy(restoredFromSession = true)
+                    // The session-restore path supplies an explicit contractId,
+                    // which bypasses the cascade in connectWithCredentials. The
+                    // result is therefore always Connected; Ambiguous is by
+                    // construction unreachable here.
+                    return when (result) {
+                        is ConnectWalletResult.Connected -> result.copy(restoredFromSession = true)
+                        is ConnectWalletResult.Ambiguous -> error(
+                            "Unreachable: connectWithCredentials with explicit contractId never returns Ambiguous"
+                        )
+                    }
                 } catch (_: WalletException.NotFound) {
-                    // Contract no longer exists on-chain (expired TTL) - clear stale session
+                    // The stored contract is not on-chain (it was never
+                    // deployed, or the saved contractId is malformed). Clear
+                    // the stale session and fall through. Archived contracts
+                    // do not trigger this branch -- the RPC's
+                    // getLedgerEntries returns archived entries as real
+                    // entries, so verifyContractExists passes for them.
+                    //
+                    // Other exceptions (network/RPC errors) propagate to the
+                    // caller; the saved session is preserved so the user can
+                    // retry once their network is healthy.
                     try {
                         kit.getStorage().clearSession()
                     } catch (_: Exception) {
@@ -687,59 +784,126 @@ class OZWalletOperations internal constructor(
         // STEP 5: Base64URL-encode credential ID
         val credentialIdBase64url = Util.base64urlEncode(authenticationResult.credentialId)
 
-        // STEP 6: Look up contract ID
+        // STEP 6: Look up contract ID via cascade: storage -> derivation -> indexer.
+        //
+        // Storage hit means deployment is PENDING or FAILED (successful deploys
+        // delete the credential). FAILED entries throw with a recovery hint;
+        // PENDING entries are trusted without an on-chain re-verify here.
+        //
+        // Derivation finds "the contract this passkey deployed under our
+        // configured deployer." Exceptions from deriveContractAddress
+        // (ValidationException.InvalidAddress for a malformed deployer
+        // config, TransactionException.SigningFailed for an internal
+        // encoding bug) propagate as their original types so the developer
+        // sees the actual cause rather than a misleading "not found."
+        //
+        // If derivation succeeds and the address has no on-chain contract,
+        // the WalletException.NotFound thrown by verifyContractExists is
+        // caught and we fall through to the indexer. Other RPC / network
+        // errors during verification propagate as their original types so
+        // the caller knows the lookup was inconclusive.
+        //
+        // Indexer fallback: returns contracts where the passkey is registered
+        // as a signer, sourced from on-chain signer_registered events
+        // (emitted both at deploy time and on add_signer). It is reached
+        // when derivation produces no on-chain contract -- typically because
+        // the passkey was added as a signer to an existing wallet, or the
+        // wallet was originally deployed under a different deployer than the
+        // one configured here. N=0 means not found; N=1 is verified on-chain
+        // for symmetry with the derivation arm; N>1 returns
+        // ConnectWalletResult.Ambiguous so the caller can let the user pick.
         var contractId: String? = null
 
-        // 6a. Check local storage
-        try {
-            val storedCredential = credentialManager.getCredential(credentialId = credentialIdBase64url)
-            if (storedCredential != null) {
-                contractId = storedCredential.contractId
-            }
+        // 6a. Storage
+        val storedCredential = try {
+            credentialManager.getCredential(credentialId = credentialIdBase64url)
         } catch (_: Exception) {
-            // Storage lookup failed - continue to indexer
+            null
+        }
+        if (storedCredential != null) {
+            if (storedCredential.deploymentStatus == CredentialDeploymentStatus.FAILED) {
+                throw WalletException.notFound(
+                    "Smart account deployment previously failed for credential $credentialIdBase64url. " +
+                    "Call deployPendingCredential() to retry, or deleteCredential() to start over."
+                )
+            }
+            contractId = storedCredential.contractId
         }
 
-        // 6b. If not found and indexer configured: call indexer
+        // 6b. Derivation: derive the deterministic address and check it on-chain.
+        if (contractId == null) {
+            val deployer = kit.getDeployer()
+            val derivedContractId = SmartAccountUtils.deriveContractAddress(
+                credentialId = authenticationResult.credentialId,
+                deployerPublicKey = deployer.getAccountId(),
+                networkPassphrase = kit.config.networkPassphrase
+            )
+
+            try {
+                verifyContractExists(derivedContractId)
+                contractId = derivedContractId
+            } catch (_: WalletException.NotFound) {
+                // Address is well-formed but no contract is deployed there.
+                // Typically this means the passkey was added as a signer to
+                // an existing wallet (rather than deploying its own under our
+                // configured deployer). Fall through to the indexer for
+                // discovery.
+            }
+            // Any other exception from verifyContractExists (network/RPC) propagates.
+        }
+
+        // 6c. Indexer fallback: discover contracts where the passkey is registered.
         if (contractId == null) {
             val indexer = kit.indexerClient
-            if (indexer != null) {
-                try {
-                    val lookupResponse = indexer.lookupByCredentialId(credentialIdBase64url)
-                    if (lookupResponse.contracts.isNotEmpty()) {
-                        contractId = lookupResponse.contracts.first().contractId
-                    }
-                } catch (_: Exception) {
-                    // Indexer lookup failed - continue to derivation
+                ?: throw WalletException.notFound(
+                    "Could not resolve contract for credential $credentialIdBase64url. " +
+                    "No contract was found at the derived address and no indexer is configured."
+                )
+
+            val candidates = indexer.lookupByCredentialId(credentialIdBase64url).contracts
+            when (candidates.size) {
+                0 -> throw WalletException.notFound(
+                    "No contract found for credential $credentialIdBase64url."
+                )
+                1 -> {
+                    val candidate = candidates.first().contractId
+                    verifyContractExists(candidate)
+                    contractId = candidate
+                }
+                else -> {
+                    // Multiple contracts list this passkey as a signer. We do
+                    // not pick one for the user -- return Ambiguous and let
+                    // the caller render a picker. Connection state is NOT set.
+                    return ConnectWalletResult.Ambiguous(
+                        credentialId = credentialIdBase64url,
+                        candidates = candidates.map { it.contractId }
+                    )
                 }
             }
         }
 
-        // 6c. If still not found: derive contract address and verify on-chain
-        if (contractId == null) {
-            val deployer = kit.getDeployer()
-            val derivedContractId = try {
-                SmartAccountUtils.deriveContractAddress(
-                    credentialId = authenticationResult.credentialId,
-                    deployerPublicKey = deployer.getAccountId(),
-                    networkPassphrase = kit.config.networkPassphrase
-                )
-            } catch (e: Exception) {
-                throw WalletException.notFound(
-                    "Failed to derive contract address: ${e.message}"
-                )
-            }
+        // The cascade above either set contractId to a non-null value or
+        // exited via throw / early return; the compiler smart-casts contractId
+        // to String here.
+        val finalContractId: String = contractId
 
-            // Verify contract exists by checking for its instance ledger entry
-            verifyContractExists(derivedContractId)
+        // End-of-cascade on-chain verify. For the Stage B derivation arm and
+        // the Stage C N=1 arm this is a redundant repeat of the per-stage
+        // verify. For the Stage A storage-hit arm (PENDING credential) it is
+        // the only verification, and catches the "credential is in storage
+        // but the deploy never landed on-chain" case (otherwise the user
+        // would silently connect to a non-existent contract and the next
+        // operation would fail confusingly). Mirrors connectWithCredentials.
+        verifyContractExists(finalContractId)
 
-            contractId = derivedContractId
+        // Delete transitional credential from storage after on-chain
+        // verification. No-ops cleanly when storage didn't have an entry
+        // (Stage B / Stage C paths).
+        try {
+            credentialManager.deleteCredential(credentialId = credentialIdBase64url)
+        } catch (_: Exception) {
+            // Non-critical - credential is transitional
         }
-
-        val finalContractId = contractId
-            ?: throw WalletException.notFound(
-                "Failed to resolve contract address for credential ID: $credentialIdBase64url"
-            )
 
         // Set connected state
         kit.setConnectedState(
@@ -756,7 +920,7 @@ class OZWalletOperations internal constructor(
 
         saveSession(credentialId = credentialIdBase64url, contractId = finalContractId)
 
-        return ConnectWalletResult(
+        return ConnectWalletResult.Connected(
             credentialId = credentialIdBase64url,
             contractId = finalContractId,
             restoredFromSession = false
@@ -914,26 +1078,64 @@ class OZWalletOperations internal constructor(
 
 
     /**
-     * Connects to a wallet using explicit credential ID and contract ID.
+     * Connects to a wallet using an explicit credential ID and / or contract ID.
      *
-     * This is a helper function used by connectWallet when credentialId
-     * or contractId options are provided. It skips session restoration
-     * and WebAuthn authentication, directly connecting to the specified
-     * credential/contract.
+     * Helper used by [connectWallet] when [ConnectWalletOptions.credentialId]
+     * or [ConnectWalletOptions.contractId] is provided, and by the
+     * session-restore path inside [connectWallet] STEP 2. Skips WebAuthn
+     * authentication and session restore (those are the caller's
+     * responsibility).
      *
-     * Flow:
-     * 1. If credentialId provided, look up contract ID from storage or derive it
-     * 2. If contractId provided without credentialId, throw validation error
-     * 3. Verify contract exists on-chain
-     * 4. Save new session
-     * 5. Set kit connected state
-     * 6. Return result
+     * Behavior depends on which arguments are non-null:
+     * - **Both provided** (`credentialId` and `contractId`): the cascade is
+     *   bypassed entirely. The supplied `contractId` is used directly. The
+     *   on-chain verification at the end of the function catches the case
+     *   where the explicit contract address does not exist on-chain. The
+     *   result is always [ConnectWalletResult.Connected];
+     *   [ConnectWalletResult.Ambiguous] is by construction unreachable.
+     * - **`credentialId` only** (no `contractId`): runs the
+     *   storage → derivation → indexer cascade.
+     *   - Stage A (storage): a credential with PENDING status is trusted;
+     *     FAILED throws with a recovery hint pointing at
+     *     [deployPendingCredential] or [deleteCredential].
+     *   - Stage B (derivation): derives the deterministic address under the
+     *     configured deployer and verifies it on-chain. NotFound from
+     *     verification falls through to the indexer; other RPC errors
+     *     propagate.
+     *   - Stage C (indexer): looks up contracts where the passkey is
+     *     registered. Returns [ConnectWalletResult.Connected] for N=1 (with
+     *     on-chain verify) and [ConnectWalletResult.Ambiguous] for N>1.
      *
-     * @param credentialId The credential ID (Base64URL-encoded), optional
-     * @param contractId The contract ID (C-address), optional
-     * @return ConnectWalletResult with restoredFromSession = false
-     * @throws ValidationException if contractId provided without credentialId
-     * @throws WalletException if wallet not found or contract doesn't exist
+     * After a successful resolution, the function:
+     * 1. Verifies the contract on-chain (catches the explicit-contractId case
+     *    where the caller passed an address that does not exist on-chain).
+     * 2. Deletes any transitional credential from storage (PENDING entries
+     *    are removed once the contract is confirmed live).
+     * 3. Sets the kit's connected state and saves a session.
+     *
+     * @param credentialId The credential ID (Base64URL-encoded), optional.
+     * @param contractId The contract ID (C-address), optional. Must be
+     *   accompanied by `credentialId` if provided.
+     * @return [ConnectWalletResult.Connected] when a single contract is
+     *   resolved, or [ConnectWalletResult.Ambiguous] when the indexer
+     *   reports multiple contracts (cascade path only).
+     * @throws ValidationException if `contractId` is provided without
+     *   `credentialId`, or if the configured deployer's public key is
+     *   malformed (the latter is from `deriveContractAddress`).
+     * @throws WalletException.NotFound if the contract can't be resolved
+     *   (FAILED storage entry, no on-chain contract at the derived address,
+     *   indexer returns zero results, or the explicit `contractId` is not
+     *   on-chain).
+     * @throws TransactionException if XDR encoding of the contract-id
+     *   preimage fails (an internal SDK bug).
+     * @throws com.soneso.stellar.sdk.rpc.SorobanRpcException if a Soroban
+     *   RPC call (e.g. the on-chain `verifyContractExists` check) fails
+     *   for transport / server reasons. RPC errors propagate as their
+     *   original type rather than being laundered to NotFound, so callers
+     *   can distinguish "contract is not on-chain" from "lookup was
+     *   inconclusive."
+     * @throws com.soneso.stellar.sdk.smartaccount.core.IndexerException
+     *   if the indexer call fails for transport / server reasons.
      */
     private suspend fun connectWithCredentials(
         credentialId: String?,
@@ -947,45 +1149,52 @@ class OZWalletOperations internal constructor(
             )
         }
 
-        val finalCredentialId = credentialId
+        // contractId is reassigned during the cascade so it needs a local var;
+        // credentialId is read-only and used as the function parameter directly.
         var finalContractId = contractId
 
-        // If credentialId provided, look up contract ID if not provided
-        if (finalCredentialId != null) {
-            // Look up in storage first
-            if (finalContractId == null) {
-                try {
-                    val storedCredential = credentialManager.getCredential(credentialId = finalCredentialId)
-                    if (storedCredential != null) {
-                        finalContractId = storedCredential.contractId
-                    }
-                } catch (_: Exception) {
-                    // Storage lookup failed - continue to indexer
+        // When credentialId is provided without contractId, run the cascade:
+        // storage -> derivation -> indexer. When contractId is provided, the
+        // cascade is bypassed entirely (caller-supplied contractId wins) and
+        // Ambiguous is by-construction unreachable.
+        if (credentialId != null && finalContractId == null) {
+
+            // Stage A: Storage. A storage hit means deployment is PENDING or
+            // FAILED (successful deploy deletes the credential). FAILED entries
+            // throw with a recovery hint; PENDING entries are trusted without
+            // an on-chain re-verify here.
+            val storedCredential = try {
+                credentialManager.getCredential(credentialId = credentialId)
+            } catch (_: Exception) {
+                null
+            }
+            if (storedCredential != null) {
+                if (storedCredential.deploymentStatus == CredentialDeploymentStatus.FAILED) {
+                    throw WalletException.notFound(
+                        "Smart account deployment previously failed for credential $credentialId. " +
+                        "Call deployPendingCredential() to retry, or deleteCredential() to start over."
+                    )
                 }
+                finalContractId = storedCredential.contractId
             }
 
-            // If not found, try indexer
-            if (finalContractId == null) {
-                val indexer = kit.indexerClient
-                if (indexer != null) {
-                    try {
-                        val lookupResponse = indexer.lookupByCredentialId(finalCredentialId)
-                        if (lookupResponse.contracts.isNotEmpty()) {
-                            finalContractId = lookupResponse.contracts.first().contractId
-                        }
-                    } catch (_: Exception) {
-                        // Indexer lookup failed - continue to derivation
-                    }
-                }
-            }
-
-            // If still not found, derive contract address
+            // Stage B: Derivation. Derive the deterministic address and check
+            // it on-chain. Exceptions from deriveContractAddress
+            // (ValidationException.InvalidAddress for a malformed deployer
+            // config, TransactionException.SigningFailed for an internal
+            // encoding bug) propagate as their original types.
+            //
+            // NotFound from verifyContractExists falls through to the indexer
+            // (the passkey was added as a signer to an existing wallet rather
+            // than deploying its own under our configured deployer). Other
+            // RPC errors during verification propagate as their original types
+            // so the caller knows the lookup was inconclusive.
             if (finalContractId == null) {
                 val deployer = kit.getDeployer()
 
                 // Decode Base64URL credential ID to raw bytes
                 val credentialIdBytes = try {
-                    Util.base64urlDecode(finalCredentialId)
+                    Util.base64urlDecode(credentialId)
                 } catch (_: IllegalArgumentException) {
                     throw ValidationException.invalidInput(
                         "credentialId",
@@ -993,54 +1202,94 @@ class OZWalletOperations internal constructor(
                     )
                 }
 
-                finalContractId = try {
-                    SmartAccountUtils.deriveContractAddress(
-                        credentialId = credentialIdBytes,
-                        deployerPublicKey = deployer.getAccountId(),
-                        networkPassphrase = kit.config.networkPassphrase
+                val derivedContractId = SmartAccountUtils.deriveContractAddress(
+                    credentialId = credentialIdBytes,
+                    deployerPublicKey = deployer.getAccountId(),
+                    networkPassphrase = kit.config.networkPassphrase
+                )
+
+                try {
+                    verifyContractExists(derivedContractId)
+                    finalContractId = derivedContractId
+                } catch (_: WalletException.NotFound) {
+                    // Address is well-formed but no contract is deployed there.
+                    // Typically the passkey was added as a signer to an
+                    // existing wallet rather than deploying its own under our
+                    // configured deployer. Fall through to the indexer.
+                }
+                // Any other exception from verifyContractExists propagates.
+            }
+
+            // Stage C: Indexer fallback.
+            if (finalContractId == null) {
+                val indexer = kit.indexerClient
+                    ?: throw WalletException.notFound(
+                        "Could not resolve contract for credential $credentialId. " +
+                        "No contract was found at the derived address and no indexer is configured."
                     )
-                } catch (e: Exception) {
-                    throw WalletException.notFound(
-                        "Failed to derive contract address: ${e.message}"
+
+                val candidates = indexer.lookupByCredentialId(credentialId).contracts
+                when (candidates.size) {
+                    0 -> throw WalletException.notFound(
+                        "No contract found for credential $credentialId."
                     )
+                    1 -> {
+                        val candidate = candidates.first().contractId
+                        verifyContractExists(candidate)
+                        finalContractId = candidate
+                    }
+                    else -> {
+                        // Multiple contracts list this passkey as a signer.
+                        // Return Ambiguous; do NOT set connected state, do
+                        // NOT delete the transitional credential.
+                        return ConnectWalletResult.Ambiguous(
+                            credentialId = credentialId,
+                            candidates = candidates.map { it.contractId }
+                        )
+                    }
                 }
             }
         }
 
         // At this point, we must have both credentialId and contractId
-        if (finalCredentialId == null || finalContractId == null) {
+        if (credentialId == null || finalContractId == null) {
             throw WalletException.notFound(
                 "Could not determine credential ID or contract ID"
             )
         }
 
-        // Verify contract exists on-chain by checking for its instance ledger entry
+        // Verify contract exists on-chain by checking for its instance ledger entry.
+        // For the storage-hit and explicit-contractId paths this is the only
+        // verification; for the derivation and indexer-N=1 paths it is a no-op
+        // repeat (already verified during the cascade) but kept for symmetry
+        // and to catch the explicit-contractId case where the caller passes a
+        // contract address that does not exist on-chain.
         verifyContractExists(finalContractId)
 
         // Delete transitional credential from storage after on-chain verification
         try {
-            credentialManager.deleteCredential(credentialId = finalCredentialId)
+            credentialManager.deleteCredential(credentialId = credentialId)
         } catch (_: Exception) {
             // Non-critical - credential is transitional
         }
 
         // Set connected state
         kit.setConnectedState(
-            credentialId = finalCredentialId,
+            credentialId = credentialId,
             contractId = finalContractId
         )
 
         kit.events.emit(
             SmartAccountEvent.WalletConnected(
                 contractId = finalContractId,
-                credentialId = finalCredentialId
+                credentialId = credentialId
             )
         )
 
-        saveSession(credentialId = finalCredentialId, contractId = finalContractId)
+        saveSession(credentialId = credentialId, contractId = finalContractId)
 
-        return ConnectWalletResult(
-            credentialId = finalCredentialId,
+        return ConnectWalletResult.Connected(
+            credentialId = credentialId,
             contractId = finalContractId,
             restoredFromSession = false
         )
@@ -1051,10 +1300,23 @@ class OZWalletOperations internal constructor(
     /**
      * Verifies a smart account contract exists on-chain by checking its instance ledger entry.
      *
-     * Uses `getContractData` with the contract instance key.
+     * Distinguishes three outcomes so callers can react correctly:
+     * - **Entry returned (live or archived)**: returns normally. The Soroban
+     *   RPC's `getLedgerEntries` returns archived entries as real entries
+     *   (with a TTL marker indicating archived state); a state-archived
+     *   contract therefore passes this check. The next operation against the
+     *   contract auto-restores the entry on Protocol 23+.
+     * - **Malformed address** (`IllegalArgumentException` from `Address(contractId)`)
+     *   or **no entry on-chain** (`getContractData` returns `null` because
+     *   the RPC reports the key as `NotFound`): throws [WalletException.NotFound].
+     *   Both mean "no contract exists at this address" -- a malformed
+     *   address by definition cannot have one.
+     * - **Lookup failed** (network / RPC exception from `SorobanServer.getContractData`):
+     *   the original exception propagates as its original type. The caller
+     *   knows the lookup was inconclusive rather than authoritatively "not found."
      *
      * @param contractId The contract address to verify
-     * @throws WalletException.NotFound if the contract does not exist
+     * @throws WalletException.NotFound if the contract does not exist on-chain
      */
     private suspend fun verifyContractExists(contractId: String) {
         val instanceEntry = try {
@@ -1063,9 +1325,10 @@ class OZWalletOperations internal constructor(
                 key = Scv.toLedgerKeyContractInstance(),
                 durability = SorobanServer.Durability.PERSISTENT
             )
-        } catch (e: Exception) {
+        } catch (e: IllegalArgumentException) {
+            // Malformed C-address. By definition no contract exists at it.
             throw WalletException.notFound(
-                "Contract not found at address: $contractId (${e.message})"
+                "Invalid contract address: $contractId (${e.message})"
             )
         }
 

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/smartaccount/SmartAccountKitTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/smartaccount/SmartAccountKitTest.kt
@@ -34,6 +34,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlin.time.Clock
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -647,9 +648,13 @@ class SmartAccountKitTest {
 
     @Test
     fun testWalletOperations_connectWallet_withValidSession_noNetwork() = runTest {
-        // Session restore verifies the contract on-chain.
-        // Without network access, verification fails and the stale session is cleared.
-        // With prompt=false (default), connectWallet returns null.
+        // Session restore verifies the stored contractId on-chain. The session
+        // contractId here is malformed (it would also fail address parsing on
+        // the way to the RPC), and there is no real network in this test
+        // environment. The session-restore catch only handles
+        // WalletException.NotFound (genuine "contract is not on-chain"); other
+        // failures propagate so the calling app can show a real error and the
+        // saved session is preserved for retry once the network is healthy.
         val config = createTestConfig()
         val storage = InMemoryStorageAdapter()
         val kit = OZSmartAccountKit.create(config.copy(storage = storage))
@@ -662,11 +667,13 @@ class SmartAccountKitTest {
         )
         storage.saveSession(session)
 
-        // On-chain verification fails -> session cleared -> returns null (prompt=false)
+        // The malformed-address case actually does throw WalletException.NotFound
+        // (verifyContractExists wraps IllegalArgumentException). It is therefore
+        // caught and clears the session. For a transient RPC error path we'd
+        // expect propagation; that path requires a fake RPC and is covered
+        // separately by future test infrastructure.
         val result = kit.walletOperations.connectWallet()
         assertNull(result)
-
-        // Session should have been cleared
         assertNull(storage.getSession())
     }
 
@@ -693,7 +700,12 @@ class SmartAccountKitTest {
 
     @Test
     fun testWalletOperations_connectWallet_expiredSessionWithPrompt_triggersWebAuthn() = runTest {
-        // prompt=true with expired session -> triggers WebAuthn, fails on lookup
+        // prompt=true with expired session -> triggers WebAuthn, then runs the
+        // discovery cascade against the mock credential. Under no real network /
+        // no usable indexer the cascade surfaces an exception (either
+        // WalletException.NotFound or a transport-level error from the
+        // indexer/RPC). The connect must not return a Connected result and
+        // must not silently succeed.
         val mockProvider = MockWebAuthnProvider()
         val config = createTestConfig(webauthnProvider = mockProvider)
         val storage = InMemoryStorageAdapter()
@@ -708,8 +720,13 @@ class SmartAccountKitTest {
         )
         storage.saveSession(session)
 
-        // Should trigger WebAuthn authentication, then fail on contract lookup
-        assertFailsWith<WalletException.NotFound> {
+        // Should trigger WebAuthn authentication, then fail on contract lookup.
+        // We use the broad assertFails (rather than assertFailsWith<NotFound>)
+        // because the exact exception depends on the test runner's network
+        // state -- WalletException.NotFound when the testnet RPC reaches a
+        // verdict, SorobanRpcException / IndexerException when transport
+        // fails. The cascade must always fail; the type is environmental.
+        assertFails {
             kit.walletOperations.connectWallet(
                 options = OZWalletOperations.ConnectWalletOptions(prompt = true)
             )
@@ -2152,6 +2169,10 @@ class SmartAccountKitTest {
 
     @Test
     fun testConnectWallet_freshOptionSkipsSession() = runTest {
+        // fresh=true bypasses the saved session and triggers WebAuthn. The
+        // resulting cascade (storage / derivation / indexer) cannot resolve a
+        // contract for the mock credential and must surface an exception
+        // (either WalletException.NotFound or an RPC/indexer transport error).
         val mockProvider = MockWebAuthnProvider()
         val config = createTestConfig(webauthnProvider = mockProvider)
         val storage = InMemoryStorageAdapter()
@@ -2165,7 +2186,7 @@ class SmartAccountKitTest {
         )
         storage.saveSession(session)
 
-        assertFailsWith<WalletException.NotFound> {
+        assertFails {
             kit.walletOperations.connectWallet(
                 options = OZWalletOperations.ConnectWalletOptions(fresh = true)
             )
@@ -2186,13 +2207,17 @@ class SmartAccountKitTest {
 
     @Test
     fun testConnectWallet_noSessionWithPrompt_triggersWebAuthn() = runTest {
-        // No session, prompt=true -> triggers WebAuthn, fails on contract lookup
+        // No session, prompt=true -> triggers WebAuthn. The cascade then runs
+        // and cannot resolve a contract for the mock credential; an exception
+        // is surfaced (either WalletException.NotFound or an RPC/indexer
+        // transport error). The test's purpose is to verify the cascade is
+        // entered, not the specific error type.
         val mockProvider = MockWebAuthnProvider()
         val config = createTestConfig(webauthnProvider = mockProvider)
         val storage = InMemoryStorageAdapter()
         val kit = OZSmartAccountKit.create(config.copy(storage = storage))
 
-        assertFailsWith<WalletException.NotFound> {
+        assertFails {
             kit.walletOperations.connectWallet(
                 options = OZWalletOperations.ConnectWalletOptions(prompt = true)
             )
@@ -2201,7 +2226,9 @@ class SmartAccountKitTest {
 
     @Test
     fun testConnectWallet_freshTakesPriorityOverPrompt() = runTest {
-        // fresh=true, prompt=true -> fresh takes priority, skips session, triggers WebAuthn
+        // fresh=true, prompt=true -> fresh takes priority, skips the saved
+        // session, triggers WebAuthn. The cascade fails to resolve the
+        // mock credential and surfaces an exception.
         val mockProvider = MockWebAuthnProvider()
         val config = createTestConfig(webauthnProvider = mockProvider)
         val storage = InMemoryStorageAdapter()
@@ -2216,8 +2243,7 @@ class SmartAccountKitTest {
         )
         storage.saveSession(session)
 
-        // fresh=true skips session even though it's valid, triggers WebAuthn, fails on lookup
-        assertFailsWith<WalletException.NotFound> {
+        assertFails {
             kit.walletOperations.connectWallet(
                 options = OZWalletOperations.ConnectWalletOptions(fresh = true, prompt = true)
             )

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/IndexerClientTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/IndexerClientTest.kt
@@ -225,7 +225,7 @@ class IndexerClientTest {
     fun testLookupByCredentialId_success() = runTest {
         val responseJson = """
             {
-                "credential_id": "aabbccdd",
+                "credentialId": "aabbccdd",
                 "contracts": [$contractSummaryJson],
                 "count": 1
             }
@@ -257,7 +257,7 @@ class IndexerClientTest {
     fun testLookupByCredentialId_verifiesUrlPath() = runTest {
         val responseJson = """
             {
-                "credential_id": "aabbccdd",
+                "credentialId": "aabbccdd",
                 "contracts": [],
                 "count": 0
             }
@@ -386,7 +386,7 @@ class IndexerClientTest {
     fun testLookupByAddress_successWithGAddress() = runTest {
         val responseJson = """
             {
-                "signer_address": "$testAccountId",
+                "signerAddress": "$testAccountId",
                 "contracts": [$contractSummaryJson],
                 "count": 1
             }
@@ -415,7 +415,7 @@ class IndexerClientTest {
     fun testLookupByAddress_successWithCAddress() = runTest {
         val responseJson = """
             {
-                "signer_address": "$testContractId",
+                "signerAddress": "$testContractId",
                 "contracts": [$contractSummaryJson],
                 "count": 1
             }
@@ -443,7 +443,7 @@ class IndexerClientTest {
     fun testLookupByAddress_verifiesUrlPath() = runTest {
         val responseJson = """
             {
-                "signer_address": "$testAccountId",
+                "signerAddress": "$testAccountId",
                 "contracts": [],
                 "count": 0
             }
@@ -525,9 +525,9 @@ class IndexerClientTest {
     fun testGetContract_success() = runTest {
         val responseJson = """
             {
-                "contract_id": "$testContractId",
+                "contractId": "$testContractId",
                 "summary": $contractSummaryJson,
-                "context_rules": [
+                "contextRules": [
                     {
                         "context_rule_id": 0,
                         "signers": [
@@ -607,9 +607,9 @@ class IndexerClientTest {
     fun testGetContract_verifiesUrlPath() = runTest {
         val responseJson = """
             {
-                "contract_id": "$testContractId",
+                "contractId": "$testContractId",
                 "summary": $contractSummaryJson,
-                "context_rules": []
+                "contextRules": []
             }
         """.trimIndent()
 

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/WalletOperationsValidationTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/WalletOperationsValidationTest.kt
@@ -409,12 +409,12 @@ class WalletOperationsValidationTest {
     }
 
     // ========================================================================
-    // ConnectWalletResult Data Class
+    // ConnectWalletResult Sealed Type
     // ========================================================================
 
     @Test
-    fun testConnectWalletResult_construction() {
-        val result = ConnectWalletResult(
+    fun testConnectWalletResult_connected_construction() {
+        val result = ConnectWalletResult.Connected(
             credentialId = "cred-abc",
             contractId = validContractAddress,
             restoredFromSession = false
@@ -425,8 +425,8 @@ class WalletOperationsValidationTest {
     }
 
     @Test
-    fun testConnectWalletResult_restoredFromSession() {
-        val result = ConnectWalletResult(
+    fun testConnectWalletResult_connected_restoredFromSession() {
+        val result = ConnectWalletResult.Connected(
             credentialId = "cred-abc",
             contractId = validContractAddress,
             restoredFromSession = true
@@ -435,21 +435,55 @@ class WalletOperationsValidationTest {
     }
 
     @Test
-    fun testConnectWalletResult_equality() {
-        val a = ConnectWalletResult("c", validContractAddress, false)
-        val b = ConnectWalletResult("c", validContractAddress, false)
-        val c = ConnectWalletResult("c", validContractAddress, true)
+    fun testConnectWalletResult_connected_equality() {
+        val a = ConnectWalletResult.Connected("c", validContractAddress, false)
+        val b = ConnectWalletResult.Connected("c", validContractAddress, false)
+        val c = ConnectWalletResult.Connected("c", validContractAddress, true)
         assertEquals(a, b)
         assertEquals(a.hashCode(), b.hashCode())
         assertNotEquals(a, c)
     }
 
     @Test
-    fun testConnectWalletResult_copy() {
-        val original = ConnectWalletResult("c", validContractAddress, false)
+    fun testConnectWalletResult_connected_copy() {
+        val original = ConnectWalletResult.Connected("c", validContractAddress, false)
         val copied = original.copy(restoredFromSession = true)
         assertTrue(copied.restoredFromSession)
         assertEquals("c", copied.credentialId)
+    }
+
+    @Test
+    fun testConnectWalletResult_ambiguous_construction() {
+        val candidates = listOf(
+            "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+            "CCMK6CYUEFEWKCPP6JL4EYYWTQGVPLG4F2KHE2H6DQOMXKBTHSDIH3JB"
+        )
+        val result = ConnectWalletResult.Ambiguous(
+            credentialId = "cred-abc",
+            candidates = candidates
+        )
+        assertEquals("cred-abc", result.credentialId)
+        assertEquals(candidates, result.candidates)
+        assertEquals(2, result.candidates.size)
+    }
+
+    @Test
+    fun testConnectWalletResult_sealed_when_exhaustive() {
+        // Compile-time exhaustiveness check: when on the sealed type must
+        // cover both arms. If a future change adds a new arm, this test
+        // fails to compile until the arm is handled here, surfacing the
+        // need to update every consumer.
+        val results: List<ConnectWalletResult> = listOf(
+            ConnectWalletResult.Connected("c", validContractAddress, false),
+            ConnectWalletResult.Ambiguous("c", listOf(validContractAddress))
+        )
+        for (r in results) {
+            val handled: String = when (r) {
+                is ConnectWalletResult.Connected -> "connected:${r.contractId}"
+                is ConnectWalletResult.Ambiguous -> "ambiguous:${r.candidates.size}"
+            }
+            assertTrue(handled.isNotEmpty())
+        }
     }
 
     // ========================================================================


### PR DESCRIPTION
# Improve smart-account connect cascade order and fix indexer JSON parsing

When a passkey signs for multiple smart accounts, `connectWallet` picked the indexer's first result (contracts ordered lexicographically by address), giving the caller no signal that the choice was ambiguous. The cascade now runs **storage → derivation → indexer** (was storage → indexer → derivation), and a multi-result indexer response surfaces as the new `ConnectWalletResult.Ambiguous` arm so the caller can let the user pick a contract.

The indexer-vs-derivation reorder also revealed a pre-existing JSON parsing bug in `OZIndexerClient`: the indexer's top-level response fields are camelCase, but the SDK's data classes annotated them as snake_case. The old cascade silently swallowed the deserialization failure (`catch (_: Exception)`); the new cascade surfaces it. Fixed
in `CredentialLookupResponse`, `AddressLookupResponse`, and `ContractDetailsResponse`.

## Impact

High-level helpers (transfers, signer management, context-rule operations) are unaffected — they consume `kit.contractId` / `kit.credentialId` rather than `ConnectWalletResult` directly.

Direct consumers of `connectWallet` / `connectWithCredentials` need to migrate from the old data-class shape to the new sealed type.

## Migration

`ConnectWalletResult` is now a sealed type with two arms:

```kotlin
sealed class ConnectWalletResult {
    abstract val credentialId: String

    data class Connected(
        override val credentialId: String,
        val contractId: String,
        val restoredFromSession: Boolean
    ) : ConnectWalletResult()

    data class Ambiguous(
        override val credentialId: String,
        val candidates: List<String>
    ) : ConnectWalletResult()
}
```

Direct field access (`result.contractId`) becomes a `when` switch:

```kotlin
when (val result = walletOps.connectWallet(...)) {
    null -> { /* no session, prompt = false */ }
    is ConnectWalletResult.Connected -> println(result.contractId)
    is ConnectWalletResult.Ambiguous -> {
        // Show a picker; reconnect with the chosen contractId.
        // Reuse result.credentialId to skip a second WebAuthn ceremony.
        val chosen = userPicker(result.candidates)
        walletOps.connectWallet(
            ConnectWalletOptions(
                credentialId = result.credentialId,
                contractId = chosen
            )
        )
    }
}
```

`Ambiguous` is by-construction unreachable when the caller supplies an explicit `contractId` (the cascade is bypassed). The session-restore path inside `connectWallet` and direct-connect callers can rely on this.

Two other behavior changes worth noting:

- A credential whose deployment failed previously connected silently to a non-existent contract. It now throws with a message pointing the user at `deployPendingCredential()` for retry.
- RPC and indexer transport errors propagate as their original types instead of being laundered as "contract not found." Callers can now distinguish "contract is not on-chain" from "the lookup itself failed."
