### PR TITLE
Fix: `AccountResponse.lastModifiedTime` must be nullable

### DIFF
--- a/demo/shared/src/commonMain/kotlin/com/soneso/demo/ui/screens/AccountDetailsScreen.kt
+++ b/demo/shared/src/commonMain/kotlin/com/soneso/demo/ui/screens/AccountDetailsScreen.kt
@@ -257,7 +257,7 @@ private fun AccountDetailsCard(account: AccountResponse) {
         DetailRow("Subentry Count", account.subentryCount.toString())
         account.homeDomain?.let { DetailRow("Home Domain", it) }
         DetailRow("Last Modified Ledger", account.lastModifiedLedger.toString())
-        DetailRow("Last Modified Time", account.lastModifiedTime)
+        account.lastModifiedTime?.let { DetailRow("Last Modified Time", it) }
     }
 
     // Balances - Individual collapsible entries with Native XLM first

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/responses/AccountResponse.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/responses/AccountResponse.kt
@@ -38,7 +38,7 @@ data class AccountResponse(
     val lastModifiedLedger: Int,
 
     @SerialName("last_modified_time")
-    val lastModifiedTime: String,
+    val lastModifiedTime: String? = null,
 
     @SerialName("thresholds")
     val thresholds: Thresholds,


### PR DESCRIPTION
# Problem

Fetching an account via server.accounts().account(id) throws a SerializationException for any account that hasn't been modified within Horizon's history-retention window. Horizon returns a valid HTTP 200, but with "last_modified_time": null.


# Cause

AccountResponse declares the field as non-null:
```kotlin
@SerialName("last_modified_time")
val lastModifiedTime: String,   // ← rejects JSON null
```

But `last_modified_time` is optional by design in Horizon. It's derived from the close-time of the account's `last_modified_ledger`, and is null whenever that ledger is no longer in Horizon's history database:

## Sources
1. The field is an optional pointer — stellar/go-stellar-sdk:
→ https://github.com/stellar/go-stellar-sdk/blob/main/protocols/horizon/main.go#L62-L63
```go
LastModifiedLedger   uint32            `json:"last_modified_ledger"`
LastModifiedTime     *time.Time        `json:"last_modified_time"`   // pointer → JSON null when unset
```


2. The server only sets it when the ledger is found — stellar/stellar-horizon:
→ https://github.com/stellar/stellar-horizon/blob/main/internal/resourceadapter/account_entry.go#L38-L39
```go
if ledger != nil {
      dest.LastModifiedTime = &ledger.ClosedAt
}
```


3. The ledger is nil when purged from history — stellar/stellar-horizon:
→ https://github.com/stellar/stellar-horizon/blob/main/internal/actions/account.go#L292
```go
func getLedgerBySequence(ctx context.Context, hq *history.Q, sequence int32) (*history.Ledger, error) {
      ...
      case hq.NoRows(err):   // ledger reaped by retention → returns nil ledger
```


This is increasingly common because horizon.stellar.org retains only 1 year of history (rolling) since Aug 1 2024, so any account untouched longer than the window returns null for this field.
- SDF 1-year retention policy: https://stellar.org/blog/foundation-news/sdf-s-horizon-limiting-data-to-1-year


---

## Additional Notes
- This pattern is aligned with other `lastModifiedTime` usages in this repository which are nullable.