### PR TITLE
Fix demo build and SCVal rendering

### DIFF
--- a/demo/CLAUDE.md
+++ b/demo/CLAUDE.md
@@ -460,17 +460,14 @@ Button(onClick = {
 
 ```kotlin
 // Good: Shows developers the actual SDK pattern
+val asset = Asset.createNonNativeAsset(assetCode, assetIssuer)
+
 val transaction = TransactionBuilder(sourceAccount, Network.TESTNET)
-    .addOperation(
-        ChangeTrustOperation.Builder(
-            ChangeTrustAsset.create(assetCode, issuer),
-            limit
-        ).build()
-    )
+    .addOperation(ChangeTrustOperation(asset, limit))
     .build()
 
 transaction.sign(keypair)
-server.submitTransaction(transaction)
+server.submitTransaction(transaction.toEnvelopeXdrBase64())
 ```
 
 ### 5. Educational Comments

--- a/demo/macosApp/StellarDemo/Views/FetchTransactionView.swift
+++ b/demo/macosApp/StellarDemo/Views/FetchTransactionView.swift
@@ -1149,7 +1149,7 @@ func formatSCVal(_ scVal: SCValXdr, indentLevel: Int = 0) -> String {
     }
 
     if let symVal = scVal as? SCValXdr.Sym {
-        return "Symbol: \(symVal.value)\""
+        return "Symbol: \(symVal.value)"
     }
 
     if let vecVal = scVal as? SCValXdr.Vec {
@@ -1195,6 +1195,10 @@ func formatSCVal(_ scVal: SCValXdr, indentLevel: Int = 0) -> String {
 
     if let nonceVal = scVal as? SCValXdr.NonceKey {
         return "LedgerKeyNonce: \(nonceVal.value.nonce)"
+    }
+
+    if let executableTagVal = scVal as? SCValXdr.ExecutableTag {
+        return "ExecutableTag: \"\(executableTagVal.value)\""
     }
 
     return description

--- a/demo/shared/src/commonMain/kotlin/com/soneso/demo/ui/screens/FetchTransactionScreen.kt
+++ b/demo/shared/src/commonMain/kotlin/com/soneso/demo/ui/screens/FetchTransactionScreen.kt
@@ -1569,6 +1569,7 @@ private fun formatSCVal(scVal: SCValXdr, indentLevel: Int = 0): String {
         is SCValXdr.Address -> "Address: ${formatAddress(scVal.value)}"
         is SCValXdr.Instance -> "ContractInstance"
         is SCValXdr.NonceKey -> "LedgerKeyNonce: ${scVal.value.nonce.value}"
+        is SCValXdr.ExecutableTag -> "ExecutableTag: \"${scVal.value.value}\""
     }
 }
 


### PR DESCRIPTION
The demo app stopped compiling when the CAP-0083/0085 XDR update added SCValXdr.ExecutableTag: the when expression in the shared transaction-detail formatter was no longer exhaustive, failing every demo target. This adds the missing branch to the shared Kotlin formatter and to the macOS app's own Swift formatter, removes a stray quote from the Swift Symbol rendering, and corrects the trust-asset example in demo/CLAUDE.md to match the real API.

Verified locally: all demo targets compile (Android, desktop JVM, JS, iOS, macOS, framework links). The stellar-sdk module is untouched.