### PR TITLE
Harden strkey and claimable balance id handling per SEP-23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,117 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `ClaimableBalanceId` reads a claimable balance id in whichever spelling it is
+  written: the `B...` strkey, the bare 32-byte hash as 64 hexadecimal characters,
+  and that hash behind a type discriminant carried either in the single byte the
+  strkey body leads with (66 characters) or in the four big-endian bytes the XDR
+  union writes (72 characters), the shape Horizon reports. Hexadecimal is read in
+  upper or lower case. It reports the balance as the canonical lower case hash
+  (`hashHex`), as the 72-character form Horizon takes (`toPaddedHex()`), as the
+  strkey (`toStrKey()`) and as the XDR union (`toXdr()`). Every byte of a
+  discriminant is checked, so an id that names another type is rejected rather
+  than having its high bytes dropped.
+- `StrKey.encodeClaimableBalance` accepts the 36-byte XDR wire form alongside the
+  32-byte hash and the 33-byte strkey body, so
+  `Address.fromClaimableBalance(ByteArray)` takes it as well.
+- `TransactionResponse.getCreatedClaimableBalanceId(operationIndex)` reports the
+  id of the claimable balance the operation at that position created, as a `B...`
+  strkey. It answers null when the transaction did not succeed, when the result
+  XDR is absent or unreadable, when no operation sits at the index, or when the
+  operation there creates no balance. Fee bump transactions are read through to
+  the inner transaction's results.
+
+### Changed
+- `ClaimClaimableBalanceOperation`, `ClawbackClaimableBalanceOperation` and
+  `Sponsorship.ClaimableBalance` take a balance id in any spelling
+  `ClaimableBalanceId` accepts, judge it when the operation is constructed, and
+  put the same bytes on the wire for equivalent spellings. The first two required
+  the 72-character form before. `Sponsorship.ClaimableBalance` validated nothing:
+  a 72-character id became a 36-byte hash that the ledger key rejected only once
+  the transaction was built. Reading an operation back from XDR reports the
+  72-character form throughout. `Sponsorship.ClaimableBalance` reported the bare
+  64-character hash before.
+- `ClaimableBalancesRequestBuilder.claimableBalance`,
+  `OperationsRequestBuilder.forClaimableBalance` and
+  `TransactionsRequestBuilder.forClaimableBalance` take a balance id in any of
+  those spellings and put the 72-character form Horizon serves in the route. An
+  id naming no balance raises `IllegalArgumentException` before a request is sent
+  rather than reaching Horizon as a 400. Streams build their URL from the same
+  path segments, so they carry the same id.
+- The Android unit test source set builds on the JVM one, so it resolves the JVM
+  `actual` declarations the common tests need. It did not compile before. The
+  variant runs on JUnit 5, as the JVM target does, and
+  `-PexcludeIntegrationTests` reaches it too.
+
+### Removed
+- `EffectsRequestBuilder.forClaimableBalance`. Horizon serves no
+  `/claimable_balances/{id}/effects` route, so every call this method made
+  answered with a route-not-found error. The effects of a claimable balance are
+  reachable through the operations that touched it.
+
+### Fixed
+- Strkey decoding requires canonical encoding. Input that at least one target
+  previously accepted now raises `IllegalArgumentException` on all of them: trailing
+  `=` padding, any content after a `=`, whitespace anywhere in the string
+  including mid-string, lowercase base32, and characters outside the ASCII range.
+  Padding also defeated the unused-trailing-bits check, so appending `===` to a
+  strkey whose last character carried non-zero leftover bits made it decode; the
+  padding drove the leftover bit count to zero and the check was skipped. A
+  non-ASCII character was narrowed to its low byte before decoding, so a `G...`
+  key with one character replaced by U+0141 decoded to the same key as the
+  canonical string. Two different strings named one account. Decoding now also
+  checks the encoded string length against the requested type before running the
+  codec, so an oversized input is rejected without it running at all. Consumers
+  that passed padded or whitespace-bearing strkeys, for example values pasted
+  from a user interface, will now see rejections and should trim input before
+  validating it.
+- Every target reaches the same verdict on the same strkey. JVM and Android
+  accepted whitespace and lowercase base32 where JavaScript and Native rejected
+  the identical string. The exception type is uniform as well: `"========"` raised
+  `ArrayIndexOutOfBoundsException` on JVM and Native but `IllegalArgumentException`
+  on JavaScript, and `IndexOutOfBoundsException` no longer escapes any decode
+  entry point on any platform.
+- Signed payload strkeys (`P...`) are checked against the framing the XDR wire
+  form defines: a declared payload length of 1 to 64, a data size that fits that
+  length exactly, and zero padding after the payload. `StrKey.isValidSignedPayload`
+  now reflects what `SignerKey` and the XDR decoders accept. The three SEP-0023
+  signed payload vectors with malformed framing all decoded before: two
+  round-tripped through `SignerKey` to a different strkey with the surplus bytes
+  silently dropped, and the third raised `IndexOutOfBoundsException` from
+  `SignerKey.fromEncodedSignerKey`, which its documentation says raises
+  `IllegalArgumentException`.
+- Claimable balance strkeys (`B...`) that carry a discriminant other than
+  `CLAIMABLE_BALANCE_ID_TYPE_V0` are rejected by `StrKey.isValidClaimableBalance`,
+  `StrKey.decodeClaimableBalance` and the `Address` constructor. Such a strkey
+  previously validated, decoded, produced an `Address` that reported
+  `AddressType.CLAIMABLE_BALANCE` and re-encoded to the same string; only
+  `toSCAddress()` refused it.
+- `StrKey.encodeSignedPayload` and `StrKey.encodeClaimableBalance` run the same
+  checks their decoders run, so neither emits a string the SDK will not read
+  back. `encodeSignedPayload` validated a 40 to 100 byte count only and now
+  validates the framing. `encodeClaimableBalance` requires a 33-byte input to
+  carry a zero discriminant; the 32-byte hash-only form is unchanged and still
+  prepends the discriminant itself. `Address.fromClaimableBalance(ByteArray)`
+  therefore rejects a non-V0 33-byte value at construction rather than at
+  `toSCAddress()`.
+- SEP-8 service construction fails on JVM and Android when a `stellar.toml`
+  `CURRENCIES` entry names an issuer that is not a canonical strkey, for example
+  one with whitespace inside the quotes, which the TOML parser preserves. It
+  already failed that way on JavaScript and Native: `Sep08Service.fromDomain`
+  builds a `RegulatedAsset` per regulated entry, and each one passes its issuer
+  to `Asset.createNonNativeAsset`.
+- SEP-10 challenge validation is unchanged in outcome. A non-canonical
+  `SIGNING_KEY` makes the challenge source-account guard skip on JVM and Android
+  as it already did elsewhere, and the signature check then rejects the
+  challenge.
+- SEP-12 callback signature verification fails closed when the configured signing
+  key is not a canonical strkey. Its verifier catches `Throwable`, so a key that
+  JVM and Android previously decoded now yields a `false` verification result
+  rather than an error.
+
 ## [1.11.0] - 2026-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,13 +86,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   round-tripped through `SignerKey` to a different strkey with the surplus bytes
   silently dropped, and the third raised `IndexOutOfBoundsException` from
   `SignerKey.fromEncodedSignerKey`, which its documentation says raises
-  `IllegalArgumentException`.
+  `IllegalArgumentException`. `SignerKey.fromEncodedSignerKey` names the rule a
+  malformed signed payload broke rather than answering with the generic
+  invalid-signer-key message.
 - Claimable balance strkeys (`B...`) that carry a discriminant other than
   `CLAIMABLE_BALANCE_ID_TYPE_V0` are rejected by `StrKey.isValidClaimableBalance`,
-  `StrKey.decodeClaimableBalance` and the `Address` constructor. Such a strkey
-  previously validated, decoded, produced an `Address` that reported
-  `AddressType.CLAIMABLE_BALANCE` and re-encoded to the same string; only
-  `toSCAddress()` refused it.
+  `StrKey.decodeClaimableBalance`, the `Address` constructor and XDR-JSON
+  decoding. Such a strkey previously validated, decoded, produced an `Address`
+  that reported `AddressType.CLAIMABLE_BALANCE` and re-encoded to the same
+  string; only `toSCAddress()` refused it.
 - `StrKey.encodeSignedPayload` and `StrKey.encodeClaimableBalance` run the same
   checks their decoders run, so neither emits a string the SDK will not read
   back. `encodeSignedPayload` validated a 40 to 100 byte count only and now
@@ -101,16 +103,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prepends the discriminant itself. `Address.fromClaimableBalance(ByteArray)`
   therefore rejects a non-V0 33-byte value at construction rather than at
   `toSCAddress()`.
+- Hexadecimal id and hash parsing holds input to the ASCII hex alphabet. The
+  per-pair radix parse accepted a leading sign and non-ASCII Unicode digits, so
+  a string of signed pairs such as `-1` repeated built a pool id, wasm hash,
+  memo hash or contract spec bytes argument of different bytes than its
+  characters spell, through the liquidity pool operations,
+  `InvokeHostFunctionOperation.createContract`, `MemoHash`, `MemoReturn`, the
+  contract spec and the OpenZeppelin credential storage, whose rejection is now
+  `IllegalArgumentException` with a message where it was `NumberFormatException`.
+  Contract spec hex arguments no longer have interior spaces removed; the `0x`
+  prefix is still accepted there.
+  `SorobanServer.loadContractCodeForWasmId` requires a 64-character wasm id
+  before building the ledger key it queries.
 - SEP-8 service construction fails on JVM and Android when a `stellar.toml`
   `CURRENCIES` entry names an issuer that is not a canonical strkey, for example
   one with whitespace inside the quotes, which the TOML parser preserves. It
   already failed that way on JavaScript and Native: `Sep08Service.fromDomain`
   builds a `RegulatedAsset` per regulated entry, and each one passes its issuer
   to `Asset.createNonNativeAsset`.
-- SEP-10 challenge validation is unchanged in outcome. A non-canonical
-  `SIGNING_KEY` makes the challenge source-account guard skip on JVM and Android
-  as it already did elsewhere, and the signature check then rejects the
-  challenge.
+- Mint, burn and clawback asset balance changes on invoke host function
+  operations deserialize. Horizon omits `from` on a mint and `to` on a burn or
+  clawback, and the response model required both, so an operations page carrying
+  one failed to parse as a whole. Both fields are now optional.
 - SEP-12 callback signature verification fails closed when the configured signing
   key is not a canonical strkey. Its verifier catches `Throwable`, so a key that
   JVM and Android previously decoded now yields a `false` verification result

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,9 @@ The SDK uses **production-ready, audited cryptographic libraries** - no custom/e
 
 #### Base32 Encoding (StrKey)
 - **JVM**: Apache Commons Codec (`commons-codec:commons-codec:1.16.1`)
-- **JS**: Pure Kotlin implementation (not security-critical)
-- **Native**: Pure Kotlin implementation (not security-critical)
+- **JS**: Pure Kotlin implementation
+- **Native**: Pure Kotlin implementation
+- **Strict alphabet**: All three accept only the 32 characters of the base32 alphabet. The pad character `=`, whitespace, lowercase letters and every other byte are rejected, so the same string gets the same verdict on JVM, Android, JS and Native. Alphabet membership is decided in the SDK rather than delegated to Commons Codec, which also maps lowercase and the pad character.
 
 ### Security Principles
 
@@ -585,6 +586,14 @@ The `demo` directory demonstrates **comprehensive SDK usage** with a Compose Mul
 - ✅ Version byte validation
 - ✅ Base32 encoding (platform-specific: Apache Commons on JVM, pure Kotlin on JS/Native)
 
+Decoding accepts canonical strkeys only, and rejects everything else with
+`IllegalArgumentException`:
+- The encoded length is checked against the requested type before any base32 decoding runs.
+- `=` padding, anything following a `=`, whitespace anywhere in the string, lowercase base32 and characters outside the ASCII range are all rejected. `IndexOutOfBoundsException` escapes no decode entry point.
+- Signed payload (P...) framing is validated on encode and decode: declared length 1..64, a data size that fits that length exactly, zero padding after the payload.
+- Claimable balance (B...) payloads must carry the `CLAIMABLE_BALANCE_ID_TYPE_V0` discriminant, on encode and decode, in the single byte the strkey body leads with and in the four big-endian bytes the XDR wire form carries. `Address` rejects any other value at construction rather than at `toSCAddress()`.
+- `StrKey.encodeClaimableBalance` takes three widths: the 32-byte hash, the 33-byte strkey body and the 36-byte XDR wire form. Nothing in between is padded or truncated to one of them.
+
 ### Transactions & Operations
 
 #### Transaction Building
@@ -613,6 +622,15 @@ The `demo` directory demonstrates **comprehensive SDK usage** with a Compose Mul
 
 **Claimable Balance Operations**:
 - ✅ CreateClaimableBalance, ClaimClaimableBalance, ClawbackClaimableBalance
+
+`ClaimableBalanceId` is the one resolver for a balance id. It reads the `B...` strkey, the bare
+hash as 64 hexadecimal characters, and that hash behind a discriminant of one byte (66
+characters) or four (72 characters). `ClaimClaimableBalanceOperation`,
+`ClawbackClaimableBalanceOperation`, `Sponsorship.ClaimableBalance` and the Horizon request
+builders all read an id through it, judge it where the id is given, and report the 72-character
+form back. `TransactionResponse.getCreatedClaimableBalanceId()` reports a created balance as a
+strkey. Horizon serves no `/claimable_balances/{id}/effects` route, so `EffectsRequestBuilder`
+has no claimable balance method.
 
 **Liquidity Pool Operations**:
 - ✅ LiquidityPoolDeposit, LiquidityPoolWithdraw

--- a/docs/documentation-strategy.md
+++ b/docs/documentation-strategy.md
@@ -16,6 +16,10 @@ All documentation is written for **Group 1: SDK Users** - developers who want to
 
 **Contributor documentation** (testing guides, architecture internals, build instructions) exists separately and is not part of the main learning path.
 
+## Release Policy for Docs
+
+Main's user-facing documentation and skill content describe the released SDK, because users read them on GitHub against the SDK they can install. Documentation and skill content for unreleased behavior goes to the `release-docs` branch, not to the feature branch that implements the behavior; `release-docs` is merged as the first step of release preparation. Feature branches carry only code, tests, the CHANGELOG's `[Unreleased]` section, CLAUDE.md updates, and version-independent process documents. Skill archives are rebuilt only during release preparation, never on feature branches.
+
 ## Core Principles
 
 ### 1. Progressive Learning
@@ -81,6 +85,25 @@ Platform guides show **one primary framework** to avoid decision paralysis:
 - **JVM Server**: Ktor
 
 **Rationale**: Multiple framework examples create confusion and maintenance burden. Choose the most common/recommended approach.
+
+### 8. No Changelog Residue
+
+Documentation states the current contract, never the story of how the code got there — and never the counterfactual of what the code would do without one of its checks. Sentences shaped like "X happens rather than Y" or "X instead of Y", where Y is a former defect or a hypothetical failure, leak the author's editing context into the reader's head: the reader never imagined Y, learns nothing about the API from it, and is left wondering why it is mentioned.
+
+Keep a "rather than"/"instead of" contrast only when both branches are real choices or plausible expectations for the reader ("returns null rather than throwing"). Delete it when the second branch exists only in the author's memory of the code.
+
+```
+DON'T: The checksum is verified, so a corrupted seed is rejected rather than
+       imported as the signing key of a different account.
+
+DO:    The checksum is verified, so a corrupted seed is rejected.
+```
+
+The justification for a check ("this guards against X") belongs in the commit message or release notes, not in user documentation.
+
+### 9. Error Handling in Examples
+
+Call the API directly when the input is fixed and known good (hardcoded literals, freshly generated values) — a failure there is a programming error. Wrap the call in `try`/`catch` where a value arrives at runtime (user input, network data). Never show runtime input handled without a catch. Explain the convention to readers once in the entry-level guide; other pages follow it without restating it.
 
 ## Content Guidelines
 
@@ -163,6 +186,7 @@ Before publishing or updating documentation, verify:
 
 ### Clarity
 - [ ] Comments explain WHY, not WHAT
+- [ ] No changelog residue: no "rather than"/"instead of" clause whose second branch is former behavior or a hypothetical defect
 - [ ] Real-world use cases shown
 - [ ] Platform compatibility noted
 - [ ] Links to related documentation

--- a/releases/RELEASE_INSTRUCTIONS.md
+++ b/releases/RELEASE_INSTRUCTIONS.md
@@ -34,6 +34,10 @@ Before starting a release, ensure you have:
 
 ### Phase 1: Prepare Release
 
+#### Step 0: Merge the pending docs branch
+
+If a `release-docs` branch exists, merge it into `main` before anything else. User-facing documentation and skill content that describes unreleased behavior is kept on that branch (not on the feature branches) so that main's docs always match the released SDK. A release that skips this step ships stale docs. Skill archives (`skills/*.zip`) are never rebuilt on feature branches; Step 2 rebuilds the archive after the skill metadata is updated. If the branch does not exist, continue.
+
 #### Step 1: Determine Version Number
 
 Follow [Semantic Versioning](https://semver.org/):
@@ -204,6 +208,9 @@ Always pass `-PexcludeIntegrationTests` during release verification. Integration
 
 # Run macOS native unit tests (if on macOS)
 ./gradlew :stellar-sdk:macosArm64Test -PexcludeIntegrationTests
+
+# Run Android unit tests (the JVM suite on the Android variant)
+./gradlew :stellar-sdk:testDebugUnitTest -PexcludeIntegrationTests
 ```
 
 **Note**: the integration tests run later, as the pre-publish gate in Phase 3 (Step 10).

--- a/stellar-sdk/build.gradle.kts
+++ b/stellar-sdk/build.gradle.kts
@@ -226,6 +226,13 @@ kotlin {
             }
         }
 
+        // Android unit tests compile against the JVM actual declarations, matching the
+        // dependsOn(jvmMain) above. Without it the Android unit test compilation sees the
+        // common expect declarations with no actuals and fails to resolve them.
+        val androidUnitTest by getting {
+            dependsOn(jvmTest)
+        }
+
         val jsMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-js:3.3.2")
@@ -306,6 +313,22 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    // The Android unit test variant compiles the JVM test source set, whose framework is
+    // JUnit 5. Selecting the same framework here keeps one kotlin-test implementation on the
+    // variant's classpath; the JUnit 4 runner AGP defaults to would bring a second one, and the
+    // two collide on the capability they share.
+    testOptions {
+        unitTests.all {
+            it.useJUnitPlatform()
+
+            // The variant runs the common test source set, so the property that keeps the
+            // network-bound tests out of the other targets has to reach it too.
+            if (project.hasProperty("excludeIntegrationTests")) {
+                it.exclude("**/integrationTests/**")
+            }
+        }
     }
 }
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Address.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Address.kt
@@ -113,9 +113,8 @@ class Address(address: String) {
                 SCAddressXdr.MuxedAccount(muxedAccount)
             }
             AddressType.CLAIMABLE_BALANCE -> {
-                require(key[0] == 0.toByte()) {
-                    "The claimable balance ID type is not supported, it must be `CLAIMABLE_BALANCE_ID_TYPE_V0`."
-                }
+                // The strkey decoder only admits the V0 type discriminant, so the bytes
+                // after it are the V0 hash.
                 val hashBytes = key.copyOfRange(1, key.size)
                 val hash = HashXdr(hashBytes)
                 val claimableBalanceId = ClaimableBalanceIDXdr.V0(hash)
@@ -207,8 +206,15 @@ class Address(address: String) {
         /**
          * Creates a new [Address] from a Stellar Claimable Balance ID.
          *
+         * Accepts the 33-byte strkey body (the type discriminant followed by the 32-byte
+         * hash), the 32-byte hash alone, or the 36-byte XDR wire form (the four-byte
+         * big-endian union discriminant followed by the hash).
+         *
          * @param claimableBalanceId the byte array of the Stellar Claimable Balance ID (B...)
          * @return a new [Address] object from the given Stellar Claimable Balance ID
+         * @throws IllegalArgumentException if [claimableBalanceId] has none of those widths,
+         * or if the discriminant in the 33- or 36-byte form is not the one the XDR union
+         * declares
          */
         fun fromClaimableBalance(claimableBalanceId: ByteArray): Address {
             return Address(StrKey.encodeClaimableBalance(claimableBalanceId))

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/ClaimableBalanceId.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/ClaimableBalanceId.kt
@@ -1,0 +1,154 @@
+package com.soneso.stellar.sdk
+
+import com.soneso.stellar.sdk.xdr.ClaimableBalanceIDXdr
+import com.soneso.stellar.sdk.xdr.HashXdr
+
+/**
+ * A claimable balance id, resolved from any of the spellings it is written in.
+ *
+ * The same balance reaches an application under four names: the `B...` strkey, the bare hash as
+ * hexadecimal, and that hash behind a type discriminant carried either in the single byte the
+ * strkey body leads with or in the four big-endian bytes the XDR union writes (the spelling
+ * Horizon reports). [forId] reads all of them and this type reports the one balance they name, so a
+ * caller may pass on whichever spelling it received.
+ *
+ * @property hashHex the 32-byte balance hash as 64 lower case hexadecimal characters, the
+ * canonical spelling of the balance this id names
+ */
+class ClaimableBalanceId private constructor(val hashHex: String) {
+
+    /**
+     * The id in the spelling Horizon reports: the hexadecimal of the XDR wire form, the type
+     * discriminant as four big-endian bytes ahead of the hash, in lower case.
+     */
+    fun toPaddedHex(): String = XDR_DISCRIMINANT_HEX + hashHex
+
+    /**
+     * The id as the `B...` strkey, 58 characters long.
+     */
+    fun toStrKey(): String = StrKey.encodeClaimableBalance(Util.hexToBytes(hashHex))
+
+    /**
+     * The id as the XDR union the wire form and the operations carry.
+     */
+    fun toXdr(): ClaimableBalanceIDXdr =
+        ClaimableBalanceIDXdr.V0(HashXdr(Util.hexToBytes(hashHex)))
+
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is ClaimableBalanceId && other.hashHex == hashHex)
+
+    override fun hashCode(): Int = hashHex.hashCode()
+
+    override fun toString(): String = "ClaimableBalanceId($hashHex)"
+
+    companion object {
+
+        /** The character a claimable balance strkey begins with. */
+        private const val STRKEY_PREFIX = "B"
+
+        /**
+         * The one type discriminant the XDR union declares, as the hexadecimal here is read:
+         * a value across as many bytes as the spelling carries, rather than the single byte
+         * the strkey body holds it in.
+         */
+        private val V0_DISCRIMINANT: Long = StrKey.CLAIMABLE_BALANCE_V0_DISCRIMINANT.toLong()
+
+        /** Characters a claimable balance strkey (B...) has. */
+        private val STRKEY_LENGTH: Int = StrKey.CLAIMABLE_BALANCE_STRKEY_LENGTH
+
+        /** Characters the bare balance hash has in hexadecimal. */
+        private val HASH_HEX_LENGTH: Int = StrKey.CLAIMABLE_BALANCE_HASH_SIZE * 2
+
+        /** Characters the type discriminant of the strkey body has in hexadecimal. */
+        private val STRKEY_DISCRIMINANT_HEX_LENGTH: Int =
+            StrKey.CLAIMABLE_BALANCE_DISCRIMINANT_SIZE * 2
+
+        /** Characters the type discriminant of the XDR wire form has in hexadecimal. */
+        private val XDR_DISCRIMINANT_HEX_LENGTH: Int = StrKey.XDR_UNION_DISCRIMINANT_SIZE * 2
+
+        /** Characters the strkey body has in hexadecimal: the discriminant and the hash. */
+        private val BODY_HEX_LENGTH: Int = StrKey.CLAIMABLE_BALANCE_BODY_SIZE * 2
+
+        /** Characters the XDR wire form has in hexadecimal: the discriminant and the hash. */
+        private val XDR_HEX_LENGTH: Int = StrKey.CLAIMABLE_BALANCE_XDR_SIZE * 2
+
+        /** The type discriminant of the XDR wire form, in the hexadecimal a padded id opens with. */
+        private val XDR_DISCRIMINANT_HEX: String = "0".repeat(XDR_DISCRIMINANT_HEX_LENGTH)
+
+        /**
+         * Reads [claimableBalanceId] in whichever spelling it holds and returns the balance it
+         * names.
+         *
+         * A string as long as a strkey is read as one: the base32 and the hexadecimal alphabets
+         * overlap, but no hexadecimal spelling has that length, so the strkey reading is the
+         * only one that can succeed. A hexadecimal spelling is read in either case, and every
+         * byte of a discriminant it carries is judged, so an id that names another type is
+         * rejected rather than having its high bytes dropped.
+         *
+         * @param claimableBalanceId the balance id as a `B...` strkey, as the bare hash in
+         * hexadecimal, or as the hash behind a type discriminant of either width in hexadecimal
+         * @return the balance the given spelling names
+         * @throws IllegalArgumentException if [claimableBalanceId] is as long as a strkey but
+         * does not begin with `B`, if it is not a strkey this codec accepts, if its length
+         * matches none of the accepted shapes, if it is not hexadecimal, or if it carries a
+         * discriminant naming no claimable balance id type
+         */
+        fun forId(claimableBalanceId: String): ClaimableBalanceId {
+            if (claimableBalanceId.length == STRKEY_LENGTH) {
+                require(claimableBalanceId.startsWith(STRKEY_PREFIX)) {
+                    "a $STRKEY_LENGTH character claimable balance id must be a strkey " +
+                        "beginning with \"$STRKEY_PREFIX\""
+                }
+                // The decode judges the checksum and the type discriminant and hands back the
+                // body: the discriminant followed by the hash.
+                val body = StrKey.decodeClaimableBalance(claimableBalanceId)
+                return ClaimableBalanceId(
+                    Util.bytesToHex(
+                        body.copyOfRange(StrKey.CLAIMABLE_BALANCE_DISCRIMINANT_SIZE, body.size)
+                    )
+                )
+            }
+
+            val discriminantLength = when (claimableBalanceId.length) {
+                HASH_HEX_LENGTH -> 0
+                BODY_HEX_LENGTH -> STRKEY_DISCRIMINANT_HEX_LENGTH
+                XDR_HEX_LENGTH -> XDR_DISCRIMINANT_HEX_LENGTH
+                else -> throw IllegalArgumentException(
+                    "claimable balance id must be a $STRKEY_LENGTH character strkey " +
+                        "($STRKEY_PREFIX...), or hex of the bare id ($HASH_HEX_LENGTH " +
+                        "characters), which a discriminant may prefix to $BODY_HEX_LENGTH or " +
+                        "$XDR_HEX_LENGTH characters; ${claimableBalanceId.length} characters given"
+                )
+            }
+
+            require(claimableBalanceId.all { it.isHexDigit() }) {
+                "claimable balance id \"$claimableBalanceId\" is not hexadecimal"
+            }
+
+            // Hexadecimal is case insensitive; lower case is the canonical spelling, so one
+            // balance is reported under one string whichever case it arrived in.
+            val value = claimableBalanceId.lowercase()
+            if (discriminantLength > 0) {
+                val carried = value.substring(0, discriminantLength).toLong(16)
+                require(carried == V0_DISCRIMINANT) {
+                    "claimable balance id carries the discriminant 0x${carried.toString(16)}, " +
+                        "which names no claimable balance id type"
+                }
+            }
+            return ClaimableBalanceId(value.substring(value.length - HASH_HEX_LENGTH))
+        }
+
+        /**
+         * Reads the balance id an XDR union carries.
+         *
+         * @param balanceId the balance id as the XDR union declares it
+         * @return the balance the union names
+         */
+        fun fromXdr(balanceId: ClaimableBalanceIDXdr): ClaimableBalanceId = when (balanceId) {
+            is ClaimableBalanceIDXdr.V0 -> ClaimableBalanceId(Util.bytesToHex(balanceId.value.value))
+        }
+
+        private fun Char.isHexDigit(): Boolean =
+            this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
+    }
+}

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/ClaimableBalanceId.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/ClaimableBalanceId.kt
@@ -82,8 +82,7 @@ class ClaimableBalanceId private constructor(val hashHex: String) {
          * A string as long as a strkey is read as one: the base32 and the hexadecimal alphabets
          * overlap, but no hexadecimal spelling has that length, so the strkey reading is the
          * only one that can succeed. A hexadecimal spelling is read in either case, and every
-         * byte of a discriminant it carries is judged, so an id that names another type is
-         * rejected rather than having its high bytes dropped.
+         * byte of a discriminant it carries is judged.
          *
          * @param claimableBalanceId the balance id as a `B...` strkey, as the bare hash in
          * hexadecimal, or as the hash behind a type discriminant of either width in hexadecimal

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Operation.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Operation.kt
@@ -1044,44 +1044,32 @@ data class CreateClaimableBalanceOperation(
 /**
  * Represents a [ClaimClaimableBalance](https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations#claim-claimable-balance) operation.
  *
- * @property balanceId The hex-encoded claimable balance ID to claim
+ * @property balanceId The claimable balance ID to claim, in any spelling
+ * [ClaimableBalanceId.forId] accepts: the `B...` strkey, the bare hash in hexadecimal, or that
+ * hash behind a type discriminant of either width in hexadecimal
  */
 data class ClaimClaimableBalanceOperation(
     val balanceId: String
 ) : Operation() {
 
-    init {
-        require(balanceId.length == 72) {
-            "Invalid balance ID length: expected 72 characters, got ${balanceId.length}"
-        }
-        // Validate hex string
-        try {
-            Util.hexToBytes(balanceId)
-        } catch (e: Exception) {
-            throw IllegalArgumentException("Balance ID must be valid hex string", e)
-        }
-    }
+    /**
+     * Resolving the id here holds every spelling to the same rules at construction, and
+     * equivalent spellings reach the wire as the same bytes.
+     */
+    private val claimableBalanceId: ClaimableBalanceId = ClaimableBalanceId.forId(balanceId)
 
     override fun toOperationBody(): OperationBodyXdr {
-        val balanceIdBytes = Util.hexToBytes(balanceId)
-        // Deserialize the full XDR bytes to get the ClaimableBalanceID
-        val reader = XdrReader(balanceIdBytes)
-        val claimableBalanceId = ClaimableBalanceIDXdr.decode(reader)
-
         val op = ClaimClaimableBalanceOpXdr(
-            balanceId = claimableBalanceId
+            balanceId = claimableBalanceId.toXdr()
         )
         return OperationBodyXdr.ClaimClaimableBalanceOp(op)
     }
 
     companion object {
         fun fromXdr(op: ClaimClaimableBalanceOpXdr): ClaimClaimableBalanceOperation {
-            // Serialize the entire ClaimableBalanceID XDR to bytes
-            val writer = XdrWriter()
-            op.balanceId.encode(writer)
-            val balanceIdBytes = writer.toByteArray()
-            val balanceId = Util.bytesToHex(balanceIdBytes).lowercase()
-            return ClaimClaimableBalanceOperation(balanceId)
+            return ClaimClaimableBalanceOperation(
+                ClaimableBalanceId.fromXdr(op.balanceId).toPaddedHex()
+            )
         }
     }
 }
@@ -1089,44 +1077,32 @@ data class ClaimClaimableBalanceOperation(
 /**
  * Represents a [ClawbackClaimableBalance](https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations#clawback-claimable-balance) operation.
  *
- * @property balanceId The hex-encoded claimable balance ID to claw back
+ * @property balanceId The claimable balance ID to claw back, in any spelling
+ * [ClaimableBalanceId.forId] accepts: the `B...` strkey, the bare hash in hexadecimal, or that
+ * hash behind a type discriminant of either width in hexadecimal
  */
 data class ClawbackClaimableBalanceOperation(
     val balanceId: String
 ) : Operation() {
 
-    init {
-        require(balanceId.length == 72) {
-            "Invalid balance ID length: expected 72 characters, got ${balanceId.length}"
-        }
-        // Validate hex string
-        try {
-            Util.hexToBytes(balanceId)
-        } catch (e: Exception) {
-            throw IllegalArgumentException("Balance ID must be valid hex string", e)
-        }
-    }
+    /**
+     * Resolving the id here holds every spelling to the same rules at construction, and
+     * equivalent spellings reach the wire as the same bytes.
+     */
+    private val claimableBalanceId: ClaimableBalanceId = ClaimableBalanceId.forId(balanceId)
 
     override fun toOperationBody(): OperationBodyXdr {
-        val balanceIdBytes = Util.hexToBytes(balanceId)
-        // Deserialize the full XDR bytes to get the ClaimableBalanceID
-        val reader = XdrReader(balanceIdBytes)
-        val claimableBalanceId = ClaimableBalanceIDXdr.decode(reader)
-
         val op = ClawbackClaimableBalanceOpXdr(
-            balanceId = claimableBalanceId
+            balanceId = claimableBalanceId.toXdr()
         )
         return OperationBodyXdr.ClawbackClaimableBalanceOp(op)
     }
 
     companion object {
         fun fromXdr(op: ClawbackClaimableBalanceOpXdr): ClawbackClaimableBalanceOperation {
-            // Serialize the entire ClaimableBalanceID XDR to bytes
-            val writer = XdrWriter()
-            op.balanceId.encode(writer)
-            val balanceIdBytes = writer.toByteArray()
-            val balanceId = Util.bytesToHex(balanceIdBytes).lowercase()
-            return ClawbackClaimableBalanceOperation(balanceId)
+            return ClawbackClaimableBalanceOperation(
+                ClaimableBalanceId.fromXdr(op.balanceId).toPaddedHex()
+            )
         }
     }
 }
@@ -1293,11 +1269,11 @@ data class RevokeSponsorshipOperation(
                 )
             }
             is Sponsorship.ClaimableBalance -> {
-                val balanceIdBytes = Util.hexToBytes(sponsorship.balanceId)
-                val claimableBalanceId = ClaimableBalanceIDXdr.V0(HashXdr(balanceIdBytes))
                 RevokeSponsorshipOpXdr.LedgerKey(
                     LedgerKeyXdr.ClaimableBalance(
-                        LedgerKeyClaimableBalanceXdr(balanceId = claimableBalanceId)
+                        LedgerKeyClaimableBalanceXdr(
+                            balanceId = sponsorship.claimableBalanceId.toXdr()
+                        )
                     )
                 )
             }
@@ -1350,10 +1326,9 @@ data class RevokeSponsorshipOperation(
                             Sponsorship.Data(accountId, ledgerKey.value.dataName.value)
                         }
                         is LedgerKeyXdr.ClaimableBalance -> {
-                            val balanceId = when (val id = ledgerKey.value.balanceId) {
-                                is ClaimableBalanceIDXdr.V0 -> Util.bytesToHex(id.value.value)
-                            }
-                            Sponsorship.ClaimableBalance(balanceId.lowercase())
+                            Sponsorship.ClaimableBalance(
+                                ClaimableBalanceId.fromXdr(ledgerKey.value.balanceId).toPaddedHex()
+                            )
                         }
                         else -> throw IllegalArgumentException("Unknown ledger key type for revoke sponsorship")
                     }
@@ -1405,9 +1380,17 @@ sealed class Sponsorship {
 
     /**
      * Revoke sponsorship of a claimable balance.
-     * @property balanceId The hex-encoded claimable balance ID
+     * @property balanceId The claimable balance ID, in any spelling
+     * [ClaimableBalanceId.forId] accepts: the `B...` strkey, the bare hash in hexadecimal, or
+     * that hash behind a type discriminant of either width in hexadecimal
      */
-    data class ClaimableBalance(val balanceId: String) : Sponsorship()
+    data class ClaimableBalance(val balanceId: String) : Sponsorship() {
+        /**
+         * Resolving the id here holds every spelling to the same rules at construction, and
+         * equivalent spellings reach the wire as the same bytes.
+         */
+        internal val claimableBalanceId: ClaimableBalanceId = ClaimableBalanceId.forId(balanceId)
+    }
 
     /**
      * Revoke sponsorship of a signer.

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Operation.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Operation.kt
@@ -1044,18 +1044,14 @@ data class CreateClaimableBalanceOperation(
 /**
  * Represents a [ClaimClaimableBalance](https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations#claim-claimable-balance) operation.
  *
- * @property balanceId The claimable balance ID to claim, in any spelling
- * [ClaimableBalanceId.forId] accepts: the `B...` strkey, the bare hash in hexadecimal, or that
- * hash behind a type discriminant of either width in hexadecimal
+ * @property balanceId The claimable balance ID, in any spelling [ClaimableBalanceId.forId]
+ * accepts. Equality and `toString` follow the spelling as given, while equivalent spellings
+ * encode to the same XDR.
  */
 data class ClaimClaimableBalanceOperation(
     val balanceId: String
 ) : Operation() {
 
-    /**
-     * Resolving the id here holds every spelling to the same rules at construction, and
-     * equivalent spellings reach the wire as the same bytes.
-     */
     private val claimableBalanceId: ClaimableBalanceId = ClaimableBalanceId.forId(balanceId)
 
     override fun toOperationBody(): OperationBodyXdr {
@@ -1077,18 +1073,14 @@ data class ClaimClaimableBalanceOperation(
 /**
  * Represents a [ClawbackClaimableBalance](https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations#clawback-claimable-balance) operation.
  *
- * @property balanceId The claimable balance ID to claw back, in any spelling
- * [ClaimableBalanceId.forId] accepts: the `B...` strkey, the bare hash in hexadecimal, or that
- * hash behind a type discriminant of either width in hexadecimal
+ * @property balanceId The claimable balance ID, in any spelling [ClaimableBalanceId.forId]
+ * accepts. Equality and `toString` follow the spelling as given, while equivalent spellings
+ * encode to the same XDR.
  */
 data class ClawbackClaimableBalanceOperation(
     val balanceId: String
 ) : Operation() {
 
-    /**
-     * Resolving the id here holds every spelling to the same rules at construction, and
-     * equivalent spellings reach the wire as the same bytes.
-     */
     private val claimableBalanceId: ClaimableBalanceId = ClaimableBalanceId.forId(balanceId)
 
     override fun toOperationBody(): OperationBodyXdr {
@@ -1380,15 +1372,11 @@ sealed class Sponsorship {
 
     /**
      * Revoke sponsorship of a claimable balance.
-     * @property balanceId The claimable balance ID, in any spelling
-     * [ClaimableBalanceId.forId] accepts: the `B...` strkey, the bare hash in hexadecimal, or
-     * that hash behind a type discriminant of either width in hexadecimal
+     * @property balanceId The claimable balance ID, in any spelling [ClaimableBalanceId.forId]
+     * accepts. Equality and `toString` follow the spelling as given, while equivalent spellings
+     * encode to the same XDR.
      */
     data class ClaimableBalance(val balanceId: String) : Sponsorship() {
-        /**
-         * Resolving the id here holds every spelling to the same rules at construction, and
-         * equivalent spellings reach the wire as the same bytes.
-         */
         internal val claimableBalanceId: ClaimableBalanceId = ClaimableBalanceId.forId(balanceId)
     }
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/SignerKey.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/SignerKey.kt
@@ -1,7 +1,6 @@
 package com.soneso.stellar.sdk
 
 import com.soneso.stellar.sdk.xdr.SignerKeyEd25519SignedPayloadXdr
-import com.soneso.stellar.sdk.xdr.SignerKeyTypeXdr
 import com.soneso.stellar.sdk.xdr.SignerKeyXdr
 import com.soneso.stellar.sdk.xdr.Uint256Xdr
 
@@ -171,7 +170,9 @@ sealed class SignerKey {
         fun encodedEd25519PublicKey(): String = StrKey.encodeEd25519PublicKey(ed25519PublicKey)
 
         override fun encodeSignerKey(): String {
-            // Encode as described in Java SDK: public key (32) + length (4) + padded payload
+            // A signed payload strkey carries the 32-byte ed25519 public key, the payload length
+            // as a big-endian four-byte value, and the payload padded with zeros to a four-byte
+            // boundary.
             val payloadLength = payload.size
             val paddingSize = (4 - payloadLength % 4) % 4
             val paddedPayload = ByteArray(payloadLength + paddingSize)
@@ -227,7 +228,10 @@ sealed class SignerKey {
          *
          * @param encodedSignerKey The StrKey-encoded signer key string
          * @return A new SignerKey instance
-         * @throws IllegalArgumentException if the encoded signer key is invalid
+         * @throws IllegalArgumentException if [encodedSignerKey] is not a well-formed strkey of
+         * one of the four signer key forms. It is the only exception this function raises: a
+         * signed payload is checked against the framing it declares before any byte that framing
+         * names is read.
          */
         fun fromEncodedSignerKey(encodedSignerKey: String): SignerKey {
             return when {
@@ -241,21 +245,17 @@ sealed class SignerKey {
                     hashX(StrKey.decodeSha256Hash(encodedSignerKey))
                 }
                 StrKey.isValidSignedPayload(encodedSignerKey) -> {
+                    // The signed payload format: public key (32) + declared length (4) + the
+                    // payload padded with zeros to a four-byte boundary. Decoding checks that
+                    // framing, so a string that reaches here declares a payload length the type
+                    // admits and carries every byte of the payload that length names.
                     val decoded = StrKey.decodeSignedPayload(encodedSignerKey)
-                    // Decode the signed payload format: public key (32) + length (4) + padded payload
-                    require(decoded.size >= 36) {
-                        "Invalid signed payload encoding, must be at least 36 bytes"
-                    }
 
                     val publicKey = decoded.copyOfRange(0, 32)
                     val payloadLength = ((decoded[32].toInt() and 0xFF) shl 24) or
                             ((decoded[33].toInt() and 0xFF) shl 16) or
                             ((decoded[34].toInt() and 0xFF) shl 8) or
                             (decoded[35].toInt() and 0xFF)
-
-                    require(payloadLength in 1..SIGNED_PAYLOAD_MAX_PAYLOAD_LENGTH) {
-                        "Invalid payload length: $payloadLength"
-                    }
 
                     val payload = decoded.copyOfRange(36, 36 + payloadLength)
                     ed25519SignedPayload(publicKey, payload)

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/SignerKey.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/SignerKey.kt
@@ -221,6 +221,17 @@ sealed class SignerKey {
         const val SIGNED_PAYLOAD_MAX_PAYLOAD_LENGTH = 64
 
         /**
+         * The character a signed payload strkey is written under.
+         */
+        private const val SIGNED_PAYLOAD_PREFIX = "P"
+
+        /**
+         * Characters a signed payload strkey has. The range is the codec's own, so the two
+         * cannot drift apart.
+         */
+        private val signedPayloadEncodedLengths: IntRange = StrKey.SIGNED_PAYLOAD_STRKEY_LENGTHS
+
+        /**
          * Creates a SignerKey from an encoded signer key string.
          *
          * This method automatically detects the signer key type based on the encoded string format and
@@ -231,7 +242,9 @@ sealed class SignerKey {
          * @throws IllegalArgumentException if [encodedSignerKey] is not a well-formed strkey of
          * one of the four signer key forms. It is the only exception this function raises: a
          * signed payload is checked against the framing it declares before any byte that framing
-         * names is read.
+         * names is read. A string written under the character a signed payload carries and as
+         * long as one is refused for the rule it broke; every other input is refused by naming
+         * itself.
          */
         fun fromEncodedSignerKey(encodedSignerKey: String): SignerKey {
             return when {
@@ -260,7 +273,21 @@ sealed class SignerKey {
                     val payload = decoded.copyOfRange(36, 36 + payloadLength)
                     ed25519SignedPayload(publicKey, payload)
                 }
-                else -> throw IllegalArgumentException("Invalid encoded signer key: $encodedSignerKey")
+                else -> {
+                    if (encodedSignerKey.startsWith(SIGNED_PAYLOAD_PREFIX) &&
+                        encodedSignerKey.length in signedPayloadEncodedLengths
+                    ) {
+                        // The string is written under the character a signed payload carries and
+                        // holds a count of characters one holds, so it describes a signed payload
+                        // and no other signer key. Decoding it raises the rule it broke, which
+                        // the refusal below cannot name.
+                        StrKey.decodeSignedPayload(encodedSignerKey)
+                        throw IllegalStateException(
+                            "decodeSignedPayload accepted a string isValidSignedPayload rejected"
+                        )
+                    }
+                    throw IllegalArgumentException("Invalid encoded signer key: $encodedSignerKey")
+                }
             }
         }
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/SignerKey.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/SignerKey.kt
@@ -257,11 +257,15 @@ sealed class SignerKey {
                 StrKey.isValidSha256Hash(encodedSignerKey) -> {
                     hashX(StrKey.decodeSha256Hash(encodedSignerKey))
                 }
-                StrKey.isValidSignedPayload(encodedSignerKey) -> {
-                    // The signed payload format: public key (32) + declared length (4) + the
-                    // payload padded with zeros to a four-byte boundary. Decoding checks that
-                    // framing, so a string that reaches here declares a payload length the type
-                    // admits and carries every byte of the payload that length names.
+                encodedSignerKey.startsWith(SIGNED_PAYLOAD_PREFIX) &&
+                    encodedSignerKey.length in signedPayloadEncodedLengths -> {
+                    // The string is written under the character a signed payload carries and holds
+                    // a count of characters one holds, so it describes a signed payload and no
+                    // other signer key. Decoding is what judges it: the format is the public key
+                    // (32), the declared length (4) and the payload padded with zeros to a
+                    // four-byte boundary, so a string the decode accepts declares a payload length
+                    // the type admits and carries every byte of the payload that length names, and
+                    // one it refuses is refused for the rule it broke.
                     val decoded = StrKey.decodeSignedPayload(encodedSignerKey)
 
                     val publicKey = decoded.copyOfRange(0, 32)
@@ -273,21 +277,9 @@ sealed class SignerKey {
                     val payload = decoded.copyOfRange(36, 36 + payloadLength)
                     ed25519SignedPayload(publicKey, payload)
                 }
-                else -> {
-                    if (encodedSignerKey.startsWith(SIGNED_PAYLOAD_PREFIX) &&
-                        encodedSignerKey.length in signedPayloadEncodedLengths
-                    ) {
-                        // The string is written under the character a signed payload carries and
-                        // holds a count of characters one holds, so it describes a signed payload
-                        // and no other signer key. Decoding it raises the rule it broke, which
-                        // the refusal below cannot name.
-                        StrKey.decodeSignedPayload(encodedSignerKey)
-                        throw IllegalStateException(
-                            "decodeSignedPayload accepted a string isValidSignedPayload rejected"
-                        )
-                    }
-                    throw IllegalArgumentException("Invalid encoded signer key: $encodedSignerKey")
-                }
+                else -> throw IllegalArgumentException(
+                    "Invalid encoded signer key: $encodedSignerKey"
+                )
             }
         }
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/StrKey.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/StrKey.kt
@@ -8,8 +8,7 @@ import kotlin.experimental.and
  * [isInAlphabet] is the gate every strkey decode passes through. It accepts only the 32
  * characters of the base32 alphabet, so the pad character, whitespace and any other byte make it
  * return false and the same string is accepted or rejected identically on every platform.
- * [decode] takes input that gate accepts, and reports anything else as an invalid argument
- * rather than decoding it to bytes the input does not spell.
+ * [decode] takes input that gate accepts, and reports anything else as an invalid argument.
  */
 internal expect object Base32Codec {
     fun encode(data: ByteArray): ByteArray
@@ -39,6 +38,14 @@ private fun paddedToFourBytes(length: Int): Int = (length + 3) / 4 * 4
 internal const val BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
 
 /**
+ * What a decode reports about a string that is not written in [BASE32_ALPHABET].
+ *
+ * Every check that asks that question - the guard on the ASCII range, the alphabet check and each
+ * platform codec - reports it in these words, so one string is never described two ways.
+ */
+internal const val INVALID_BASE32_MESSAGE = "Invalid base32 encoded string"
+
+/**
  * Renders the lengths [range] admits for an error message: the single value of a one-element
  * range, or the bounds of a wider one.
  */
@@ -48,6 +55,31 @@ private fun expectedLengthText(range: IntRange): String =
 /**
  * StrKey is a helper class for encoding and decoding Stellar keys to/from strings.
  * Stellar uses a base32 encoding with checksums called "strkey" for human-readable keys.
+ *
+ * ## The decode contract
+ *
+ * Every `decodeX` runs the same checks in the same order and reports the first one the string
+ * fails as an `IllegalArgumentException`:
+ *
+ * 1. the character count is one the requested type has;
+ * 2. every character is inside the ASCII range;
+ * 3. the character count leaves no partially filled trailing character;
+ * 4. every character is one of the 32 in [BASE32_ALPHABET];
+ * 5. the unused trailing bits of the last character are zero;
+ * 6. the version byte names a strkey type;
+ * 7. the decoded payload has a size that type admits;
+ * 8. the framing that type defines inside its payload holds;
+ * 9. the version byte names the type the caller asked for;
+ * 10. the checksum matches the payload it covers.
+ *
+ * Checks 2 and 4 answer one question - whether the string is written in the characters a strkey
+ * is written in - and report it in the same words. Check 5 has nothing to read for a type whose
+ * character count fills its last character, and check 8 nothing to read for a type whose payload
+ * is an opaque key of a fixed size.
+ *
+ * Each `decodeX` documents only what its own type fixes: the character count it has, the version
+ * byte it is written under and the framing it defines. Each `isValidX` reports whether the
+ * matching `decodeX` accepts the string, so it is false wherever that decode throws.
  */
 object StrKey {
 
@@ -153,6 +185,13 @@ object StrKey {
     internal val CLAIMABLE_BALANCE_STRKEY_LENGTH: Int =
         VersionByte.CLAIMABLE_BALANCE.encodedLengths.first
 
+    /**
+     * Characters an encoded signed payload strkey (P...) has, across the payload lengths the
+     * type declares.
+     */
+    internal val SIGNED_PAYLOAD_STRKEY_LENGTHS: IntRange =
+        VersionByte.SIGNED_PAYLOAD.encodedLengths
+
     // Decoding table for base32
     private val decodingTable: ByteArray = ByteArray(256) { 0xff.toByte() }.apply {
         BASE32_ALPHABET.forEachIndexed { index, char ->
@@ -176,9 +215,8 @@ object StrKey {
      *
      * @param data The strkey to decode. An ed25519 public key strkey is 56 characters long.
      * @return The 32 raw public key bytes
-     * @throws IllegalArgumentException if the string is not 56 characters long, contains
-     * characters outside the base32 alphabet, does not carry the ed25519 public key version
-     * byte, or fails the checksum
+     * @throws IllegalArgumentException if [data] fails a check of the [StrKey] decode contract,
+     * which this type holds to 56 characters and the ed25519 public key version byte
      */
     fun decodeEd25519PublicKey(data: String): ByteArray {
         return decodeCheck(VersionByte.ACCOUNT_ID, data.toCharArray())
@@ -188,8 +226,7 @@ object StrKey {
      * Checks validity of Stellar account ID (G...)
      *
      * @param accountId The strkey to check
-     * @return true if [accountId] is a 56-character G... strkey with a matching checksum,
-     * false otherwise
+     * @return true if [accountId] is a strkey [decodeEd25519PublicKey] accepts, false otherwise
      */
     fun isValidEd25519PublicKey(accountId: String): Boolean {
         return try {
@@ -216,9 +253,8 @@ object StrKey {
      *
      * @param data The strkey to decode. An ed25519 secret seed strkey is 56 characters long.
      * @return The 32 raw seed bytes
-     * @throws IllegalArgumentException if the input is not 56 characters long, contains
-     * characters outside the base32 alphabet, does not carry the secret seed version byte,
-     * or fails the checksum
+     * @throws IllegalArgumentException if [data] fails a check of the [StrKey] decode contract,
+     * which this type holds to 56 characters and the secret seed version byte
      */
     fun decodeEd25519SecretSeed(data: CharArray): ByteArray {
         return decodeCheck(VersionByte.SEED, data)
@@ -228,8 +264,7 @@ object StrKey {
      * Checks validity of seed (S...)
      *
      * @param seed The strkey to check
-     * @return true if [seed] is a 56-character S... strkey with a matching checksum,
-     * false otherwise
+     * @return true if [seed] is a strkey [decodeEd25519SecretSeed] accepts, false otherwise
      */
     fun isValidEd25519SecretSeed(seed: CharArray): Boolean {
         return try {
@@ -256,10 +291,8 @@ object StrKey {
      *
      * @param data The strkey to decode. A muxed ed25519 public key strkey is 69 characters long.
      * @return The 40 raw bytes: the 32-byte ed25519 public key followed by the 8-byte muxed id
-     * @throws IllegalArgumentException if the string is not 69 characters long, contains
-     * characters outside the base32 alphabet, leaves the unused trailing bits of its last
-     * character non-zero, does not carry the muxed ed25519 public key version byte, or fails
-     * the checksum
+     * @throws IllegalArgumentException if [data] fails a check of the [StrKey] decode contract,
+     * which this type holds to 69 characters and the muxed ed25519 public key version byte
      */
     fun decodeMed25519PublicKey(data: String): ByteArray {
         return decodeCheck(VersionByte.MED25519_PUBLIC_KEY, data.toCharArray())
@@ -272,8 +305,8 @@ object StrKey {
      * but have different IDs. They are used for memo-less payments as defined in SEP-0023.
      *
      * @param med25519PublicKey The muxed public key to check
-     * @return true if [med25519PublicKey] is a 69-character M... strkey whose unused trailing
-     * bits are zero and whose checksum matches, false otherwise
+     * @return true if [med25519PublicKey] is a strkey [decodeMed25519PublicKey] accepts,
+     * false otherwise
      * @see <a href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md">SEP-0023</a>
      */
     fun isValidMed25519PublicKey(med25519PublicKey: String): Boolean {
@@ -301,9 +334,8 @@ object StrKey {
      *
      * @param data The strkey to decode. A pre-authorized transaction strkey is 56 characters long.
      * @return The 32 raw hash bytes
-     * @throws IllegalArgumentException if the string is not 56 characters long, contains
-     * characters outside the base32 alphabet, does not carry the pre-authorized transaction
-     * version byte, or fails the checksum
+     * @throws IllegalArgumentException if [data] fails a check of the [StrKey] decode contract,
+     * which this type holds to 56 characters and the pre-authorized transaction version byte
      */
     fun decodePreAuthTx(data: String): ByteArray {
         return decodeCheck(VersionByte.PRE_AUTH_TX, data.toCharArray())
@@ -313,8 +345,7 @@ object StrKey {
      * Checks validity of pre-authorized transaction hash (T...)
      *
      * @param preAuthTx The strkey to check
-     * @return true if [preAuthTx] is a 56-character T... strkey with a matching checksum,
-     * false otherwise
+     * @return true if [preAuthTx] is a strkey [decodePreAuthTx] accepts, false otherwise
      */
     fun isValidPreAuthTx(preAuthTx: String): Boolean {
         return try {
@@ -341,9 +372,8 @@ object StrKey {
      *
      * @param data The strkey to decode. A SHA-256 hash strkey is 56 characters long.
      * @return The 32 raw hash bytes
-     * @throws IllegalArgumentException if the string is not 56 characters long, contains
-     * characters outside the base32 alphabet, does not carry the SHA-256 hash version byte,
-     * or fails the checksum
+     * @throws IllegalArgumentException if [data] fails a check of the [StrKey] decode contract,
+     * which this type holds to 56 characters and the SHA-256 hash version byte
      */
     fun decodeSha256Hash(data: String): ByteArray {
         return decodeCheck(VersionByte.SHA256_HASH, data.toCharArray())
@@ -353,8 +383,7 @@ object StrKey {
      * Checks validity of SHA-256 hash (X...)
      *
      * @param sha256Hash The strkey to check
-     * @return true if [sha256Hash] is a 56-character X... strkey with a matching checksum,
-     * false otherwise
+     * @return true if [sha256Hash] is a strkey [decodeSha256Hash] accepts, false otherwise
      */
     fun isValidSha256Hash(sha256Hash: String): Boolean {
         return try {
@@ -394,13 +423,10 @@ object StrKey {
      * characters long, depending on the size of the payload it carries.
      * @return The raw bytes: the 32-byte ed25519 public key, the 4-byte declared payload
      * length and the payload padded to a four-byte boundary
-     * @throws IllegalArgumentException if the string length is outside 69 to 165 characters,
-     * has a length that leaves a partially filled trailing character, contains characters
-     * outside the base32 alphabet, leaves the unused trailing bits of its last character
-     * non-zero, does not carry the signed payload version byte, decodes to fewer than 40 or
-     * more than 100 data bytes, declares a payload length outside 1 to 64, decodes to a size
-     * that does not fit its declared payload length exactly, leaves a padding byte after the
-     * payload non-zero, or fails the checksum
+     * @throws IllegalArgumentException if [data] fails a check of the [StrKey] decode contract,
+     * which this type holds to 69 to 165 characters, the signed payload version byte, 40 to 100
+     * data bytes, and the framing it defines inside them: a declared payload length of 1 to 64
+     * that the data size fits exactly, and zero padding after the payload
      */
     fun decodeSignedPayload(data: String): ByteArray {
         return decodeCheck(VersionByte.SIGNED_PAYLOAD, data.toCharArray())
@@ -410,8 +436,7 @@ object StrKey {
      * Checks validity of signed payload (P...)
      *
      * @param signedPayload The strkey to check
-     * @return true if [signedPayload] is a signed payload strkey [decodeSignedPayload] accepts,
-     * false otherwise
+     * @return true if [signedPayload] is a strkey [decodeSignedPayload] accepts, false otherwise
      */
     fun isValidSignedPayload(signedPayload: String): Boolean {
         return try {
@@ -438,9 +463,8 @@ object StrKey {
      *
      * @param data The strkey to decode. A contract address strkey is 56 characters long.
      * @return The 32 raw contract id bytes
-     * @throws IllegalArgumentException if the string is not 56 characters long, contains
-     * characters outside the base32 alphabet, does not carry the contract version byte,
-     * or fails the checksum
+     * @throws IllegalArgumentException if [data] fails a check of the [StrKey] decode contract,
+     * which this type holds to 56 characters and the contract version byte
      */
     fun decodeContract(data: String): ByteArray {
         return decodeCheck(VersionByte.CONTRACT, data.toCharArray())
@@ -450,8 +474,7 @@ object StrKey {
      * Checks validity of contract address (C...)
      *
      * @param address The strkey to check
-     * @return true if [address] is a 56-character C... strkey with a matching checksum,
-     * false otherwise
+     * @return true if [address] is a strkey [decodeContract] accepts, false otherwise
      */
     fun isValidContract(address: String): Boolean {
         return try {
@@ -478,9 +501,8 @@ object StrKey {
      *
      * @param data The strkey to decode. A liquidity pool id strkey is 56 characters long.
      * @return The 32 raw liquidity pool id bytes
-     * @throws IllegalArgumentException if the string is not 56 characters long, contains
-     * characters outside the base32 alphabet, does not carry the liquidity pool version byte,
-     * or fails the checksum
+     * @throws IllegalArgumentException if [data] fails a check of the [StrKey] decode contract,
+     * which this type holds to 56 characters and the liquidity pool version byte
      */
     fun decodeLiquidityPool(data: String): ByteArray {
         return decodeCheck(VersionByte.LIQUIDITY_POOL, data.toCharArray())
@@ -490,8 +512,7 @@ object StrKey {
      * Checks validity of liquidity pool ID (L...)
      *
      * @param liquidityPoolId The strkey to check
-     * @return true if [liquidityPoolId] is a 56-character L... strkey with a matching
-     * checksum, false otherwise
+     * @return true if [liquidityPoolId] is a strkey [decodeLiquidityPool] accepts, false otherwise
      */
     fun isValidLiquidityPool(liquidityPoolId: String): Boolean {
         return try {
@@ -524,8 +545,7 @@ object StrKey {
             // type the XDR union declares.
             CLAIMABLE_BALANCE_BODY_SIZE -> data
             // The XDR wire form. Every byte of the wider discriminant is judged before the id
-            // is narrowed to the strkey body, so a value that names another type cannot reach
-            // the strkey by having its high bytes dropped.
+            // is narrowed to the strkey body.
             CLAIMABLE_BALANCE_XDR_SIZE -> {
                 requireClaimableBalanceXdrDiscriminant(data)
                 byteArrayOf(CLAIMABLE_BALANCE_V0_DISCRIMINANT) +
@@ -548,10 +568,9 @@ object StrKey {
      *
      * @param data The strkey to decode. A claimable balance id strkey is 58 characters long.
      * @return The 33 raw bytes: the type discriminant followed by the 32-byte hash
-     * @throws IllegalArgumentException if the string is not 58 characters long, contains
-     * characters outside the base32 alphabet, leaves the unused trailing bits of its last
-     * character non-zero, does not carry the claimable balance version byte, carries a type
-     * discriminant other than the one the XDR union declares, or fails the checksum
+     * @throws IllegalArgumentException if [data] fails a check of the [StrKey] decode contract,
+     * which this type holds to 58 characters, the claimable balance version byte, and the
+     * framing it defines inside its payload: the one type discriminant the XDR union declares
      */
     fun decodeClaimableBalance(data: String): ByteArray {
         return decodeCheck(VersionByte.CLAIMABLE_BALANCE, data.toCharArray())
@@ -561,9 +580,8 @@ object StrKey {
      * Checks validity of claimable balance ID (B...)
      *
      * @param claimableBalanceId The strkey to check
-     * @return true if [claimableBalanceId] is a 58-character B... strkey whose unused trailing
-     * bits are zero, whose type discriminant is the one the XDR union declares and whose
-     * checksum matches, false otherwise
+     * @return true if [claimableBalanceId] is a strkey [decodeClaimableBalance] accepts,
+     * false otherwise
      */
     fun isValidClaimableBalance(claimableBalanceId: String): Boolean {
         return try {
@@ -602,13 +620,18 @@ object StrKey {
         // reads those bytes. A character outside the ASCII range would be narrowed onto whatever
         // alphabet character its low byte spells, which would let two different strings decode
         // to one key, so only characters that survive the narrowing unchanged get past here.
-        require(encoded.all { it.code <= 0x7F }) { "Invalid base32 encoded string" }
+        require(encoded.all { it.code <= 0x7F }) { INVALID_BASE32_MESSAGE }
 
         val bytes = encoded.map { it.code.toByte() }.toByteArray()
 
         // Validate no leftover character
         val leftoverBits = (bytes.size * 5) % 8
         require(leftoverBits < 5) { "Encoded char array has leftover character" }
+
+        // A character outside the alphabet stands for no five-bit value, so the string is held to
+        // the alphabet before anything reads the value of one of its characters. That makes the
+        // lookup below total, and it is also the precondition the codec decodes under.
+        require(Base32Codec.isInAlphabet(bytes)) { INVALID_BASE32_MESSAGE }
 
         // Validate unused bits are zero
         if (leftoverBits > 0) {
@@ -618,7 +641,7 @@ object StrKey {
             require((decodedLastChar and leftoverBitsMask) == 0.toByte()) { "Unused bits should be set to 0" }
         }
 
-        val decoded = base32Decode(bytes)
+        val decoded = Base32Codec.decode(bytes)
         val decodedVersionByte = decoded[0]
         val decodedVersion = VersionByte.fromValue(decodedVersionByte)
             ?: throw IllegalArgumentException("Version byte is invalid")
@@ -715,8 +738,7 @@ object StrKey {
     /**
      * Checks the type discriminant the XDR wire form of a claimable balance id carries: the
      * type as a big-endian value across [XDR_UNION_DISCRIMINANT_SIZE] bytes. All of them are
-     * read, so a value that differs only in the bytes above the last one is rejected rather
-     * than narrowed away.
+     * read.
      *
      * [data] must hold at least [XDR_UNION_DISCRIMINANT_SIZE] bytes. The per-width size check
      * establishes that, and it is what makes reading the discriminant here safe.
@@ -754,15 +776,5 @@ object StrKey {
 
         // Return little-endian
         return byteArrayOf(crc.toByte(), (crc ushr 8).toByte())
-    }
-
-
-    private fun base32Decode(data: ByteArray): ByteArray {
-        // Validate all characters are in alphabet
-        require(Base32Codec.isInAlphabet(data)) {
-            "Invalid base32 encoded string"
-        }
-
-        return Base32Codec.decode(data)
     }
 }

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/StrKey.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/StrKey.kt
@@ -4,6 +4,12 @@ import kotlin.experimental.and
 
 /**
  * Platform-specific Base32 codec interface.
+ *
+ * [isInAlphabet] is the gate every strkey decode passes through. It accepts only the 32
+ * characters of the base32 alphabet, so the pad character, whitespace and any other byte make it
+ * return false and the same string is accepted or rejected identically on every platform.
+ * [decode] takes input that gate accepts, and reports anything else as an invalid argument
+ * rather than decoding it to bytes the input does not spell.
  */
 internal expect object Base32Codec {
     fun encode(data: ByteArray): ByteArray
@@ -12,28 +18,140 @@ internal expect object Base32Codec {
 }
 
 /**
+ * Number of base32 characters a strkey carrying [dataLength] payload bytes encodes to.
+ *
+ * A strkey encodes one version byte, the payload and two checksum bytes, base32 without
+ * padding, so the encoded length is `ceil((1 + dataLength + 2) * 8 / 5)`.
+ */
+private fun encodedStrKeyLength(dataLength: Int): Int = ((1 + dataLength + 2) * 8 + 4) / 5
+
+/**
+ * [length] rounded up to the four-byte boundary variable-length opaque data is padded to.
+ */
+private fun paddedToFourBytes(length: Int): Int = (length + 3) / 4 * 4
+
+/**
+ * The characters a strkey is written in, in the order that gives each its five-bit value.
+ *
+ * Every codec in this module builds its tables from this one declaration, so no platform can
+ * hold a different idea of which characters a strkey may contain.
+ */
+internal const val BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+/**
+ * Renders the lengths [range] admits for an error message: the single value of a one-element
+ * range, or the bounds of a wider one.
+ */
+private fun expectedLengthText(range: IntRange): String =
+    if (range.first == range.last) "${range.first}" else "between ${range.first} and ${range.last}"
+
+/**
  * StrKey is a helper class for encoding and decoding Stellar keys to/from strings.
  * Stellar uses a base32 encoding with checksums called "strkey" for human-readable keys.
  */
 object StrKey {
 
-    private enum class VersionByte(val value: Byte) {
-        ACCOUNT_ID((6 shl 3).toByte()),           // G
-        MED25519_PUBLIC_KEY((12 shl 3).toByte()), // M
-        SEED((18 shl 3).toByte()),                // S
-        PRE_AUTH_TX((19 shl 3).toByte()),         // T
-        SHA256_HASH((23 shl 3).toByte()),         // X
-        SIGNED_PAYLOAD((15 shl 3).toByte()),      // P
-        CONTRACT((2 shl 3).toByte()),             // C
-        LIQUIDITY_POOL((11 shl 3).toByte()),      // L
-        CLAIMABLE_BALANCE((1 shl 3).toByte());    // B
+    /**
+     * Strkey type discriminants together with the payload sizes each type admits.
+     *
+     * [dataLengths] is the single source of the length expectations: it is what the decoded
+     * payload is checked against, and through [encodedStrKeyLength] it also fixes the number
+     * of characters the encoded strkey has.
+     */
+    private enum class VersionByte(val value: Byte, val dataLengths: IntRange) {
+        ACCOUNT_ID((6 shl 3).toByte(), 32..32),           // G
+        MED25519_PUBLIC_KEY((12 shl 3).toByte(), 40..40), // M
+        SEED((18 shl 3).toByte(), 32..32),                // S
+        PRE_AUTH_TX((19 shl 3).toByte(), 32..32),         // T
+        SHA256_HASH((23 shl 3).toByte(), 32..32),         // X
+        SIGNED_PAYLOAD((15 shl 3).toByte(), 40..100),     // P
+        CONTRACT((2 shl 3).toByte(), 32..32),             // C
+        LIQUIDITY_POOL((11 shl 3).toByte(), 32..32),      // L
+        CLAIMABLE_BALANCE((1 shl 3).toByte(), 33..33);    // B
+
+        /**
+         * Character counts an encoded strkey of this type can have.
+         *
+         * For every type but [SIGNED_PAYLOAD] the range holds a single value. A signed
+         * payload carries a variable payload padded to a four-byte boundary, so its range
+         * also spans lengths that no well-formed key produces; the exact length follows
+         * from the declared payload length.
+         */
+        val encodedLengths: IntRange =
+            encodedStrKeyLength(dataLengths.first)..encodedStrKeyLength(dataLengths.last)
 
         companion object {
             fun fromValue(value: Byte): VersionByte? = entries.find { it.value == value }
         }
     }
 
-    private const val BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+    /**
+     * Bytes a signed payload spends on the ed25519 public key it names.
+     */
+    private const val SIGNED_PAYLOAD_KEY_SIZE = 32
+
+    /**
+     * Bytes a signed payload spends before the payload itself: the ed25519 public key followed
+     * by the declared payload length, written as a big-endian four-byte value.
+     */
+    private const val SIGNED_PAYLOAD_HEADER_SIZE = SIGNED_PAYLOAD_KEY_SIZE + 4
+
+    /**
+     * Payload lengths a signed payload can declare.
+     *
+     * The upper bound follows from the payload sizes the type admits: the largest of them is
+     * the header plus a payload padded to the four-byte boundary, so the two bounds cannot
+     * drift apart.
+     */
+    private val declaredPayloadLengths: IntRange =
+        1..(VersionByte.SIGNED_PAYLOAD.dataLengths.last - SIGNED_PAYLOAD_HEADER_SIZE)
+
+    /**
+     * The type discriminant a claimable balance id is written under.
+     *
+     * The XDR union a claimable balance id describes declares a single case, so this is the one
+     * value its wire form carries and the one value a B... strkey can spell.
+     */
+    internal const val CLAIMABLE_BALANCE_V0_DISCRIMINANT: Byte = 0
+
+    /**
+     * Bytes an XDR union spends on its type discriminant, written big-endian.
+     *
+     * The XDR wire form of a claimable balance id opens with the discriminant in this width,
+     * where the strkey body carries it in a single byte.
+     */
+    internal const val XDR_UNION_DISCRIMINANT_SIZE = 4
+
+    /**
+     * Bytes the strkey body of a claimable balance id spends on its type discriminant.
+     */
+    internal const val CLAIMABLE_BALANCE_DISCRIMINANT_SIZE = 1
+
+    /**
+     * Bytes the strkey body of a claimable balance id holds: the type discriminant followed by
+     * the hash.
+     */
+    internal val CLAIMABLE_BALANCE_BODY_SIZE: Int =
+        VersionByte.CLAIMABLE_BALANCE.dataLengths.last
+
+    /**
+     * Bytes a claimable balance id hash holds.
+     */
+    internal val CLAIMABLE_BALANCE_HASH_SIZE: Int =
+        CLAIMABLE_BALANCE_BODY_SIZE - CLAIMABLE_BALANCE_DISCRIMINANT_SIZE
+
+    /**
+     * Bytes the XDR wire form of a claimable balance id holds: the four-byte union
+     * discriminant followed by the hash.
+     */
+    internal val CLAIMABLE_BALANCE_XDR_SIZE: Int =
+        XDR_UNION_DISCRIMINANT_SIZE + CLAIMABLE_BALANCE_HASH_SIZE
+
+    /**
+     * Characters an encoded claimable balance strkey (B...) has.
+     */
+    internal val CLAIMABLE_BALANCE_STRKEY_LENGTH: Int =
+        VersionByte.CLAIMABLE_BALANCE.encodedLengths.first
 
     // Decoding table for base32
     private val decodingTable: ByteArray = ByteArray(256) { 0xff.toByte() }.apply {
@@ -46,12 +164,21 @@ object StrKey {
      * Encodes raw bytes to strkey ed25519 public key (G...)
      */
     fun encodeEd25519PublicKey(data: ByteArray): String {
-        require(data.size == 32) { "Public key must be 32 bytes" }
+        val dataLengths = VersionByte.ACCOUNT_ID.dataLengths
+        require(data.size in dataLengths) {
+            "Public key must be ${expectedLengthText(dataLengths)} bytes, got ${data.size}"
+        }
         return encodeCheck(VersionByte.ACCOUNT_ID, data).concatToString()
     }
 
     /**
      * Decodes strkey ed25519 public key (G...) to raw bytes
+     *
+     * @param data The strkey to decode. An ed25519 public key strkey is 56 characters long.
+     * @return The 32 raw public key bytes
+     * @throws IllegalArgumentException if the string is not 56 characters long, contains
+     * characters outside the base32 alphabet, does not carry the ed25519 public key version
+     * byte, or fails the checksum
      */
     fun decodeEd25519PublicKey(data: String): ByteArray {
         return decodeCheck(VersionByte.ACCOUNT_ID, data.toCharArray())
@@ -59,6 +186,10 @@ object StrKey {
 
     /**
      * Checks validity of Stellar account ID (G...)
+     *
+     * @param accountId The strkey to check
+     * @return true if [accountId] is a 56-character G... strkey with a matching checksum,
+     * false otherwise
      */
     fun isValidEd25519PublicKey(accountId: String): Boolean {
         return try {
@@ -73,12 +204,21 @@ object StrKey {
      * Encodes raw bytes to strkey ed25519 secret seed (S...)
      */
     fun encodeEd25519SecretSeed(data: ByteArray): CharArray {
-        require(data.size == 32) { "Secret seed must be 32 bytes" }
+        val dataLengths = VersionByte.SEED.dataLengths
+        require(data.size in dataLengths) {
+            "Secret seed must be ${expectedLengthText(dataLengths)} bytes, got ${data.size}"
+        }
         return encodeCheck(VersionByte.SEED, data)
     }
 
     /**
      * Decodes strkey ed25519 secret seed (S...) to raw bytes
+     *
+     * @param data The strkey to decode. An ed25519 secret seed strkey is 56 characters long.
+     * @return The 32 raw seed bytes
+     * @throws IllegalArgumentException if the input is not 56 characters long, contains
+     * characters outside the base32 alphabet, does not carry the secret seed version byte,
+     * or fails the checksum
      */
     fun decodeEd25519SecretSeed(data: CharArray): ByteArray {
         return decodeCheck(VersionByte.SEED, data)
@@ -86,6 +226,10 @@ object StrKey {
 
     /**
      * Checks validity of seed (S...)
+     *
+     * @param seed The strkey to check
+     * @return true if [seed] is a 56-character S... strkey with a matching checksum,
+     * false otherwise
      */
     fun isValidEd25519SecretSeed(seed: CharArray): Boolean {
         return try {
@@ -100,12 +244,22 @@ object StrKey {
      * Encodes raw bytes to strkey muxed ed25519 public key (M...)
      */
     fun encodeMed25519PublicKey(data: ByteArray): String {
-        require(data.size == 40) { "Muxed public key must be 40 bytes" }
+        val dataLengths = VersionByte.MED25519_PUBLIC_KEY.dataLengths
+        require(data.size in dataLengths) {
+            "Muxed public key must be ${expectedLengthText(dataLengths)} bytes, got ${data.size}"
+        }
         return encodeCheck(VersionByte.MED25519_PUBLIC_KEY, data).concatToString()
     }
 
     /**
      * Decodes strkey muxed ed25519 public key (M...) to raw bytes
+     *
+     * @param data The strkey to decode. A muxed ed25519 public key strkey is 69 characters long.
+     * @return The 40 raw bytes: the 32-byte ed25519 public key followed by the 8-byte muxed id
+     * @throws IllegalArgumentException if the string is not 69 characters long, contains
+     * characters outside the base32 alphabet, leaves the unused trailing bits of its last
+     * character non-zero, does not carry the muxed ed25519 public key version byte, or fails
+     * the checksum
      */
     fun decodeMed25519PublicKey(data: String): ByteArray {
         return decodeCheck(VersionByte.MED25519_PUBLIC_KEY, data.toCharArray())
@@ -118,7 +272,8 @@ object StrKey {
      * but have different IDs. They are used for memo-less payments as defined in SEP-0023.
      *
      * @param med25519PublicKey The muxed public key to check
-     * @return true if the given muxed public key is valid, false otherwise
+     * @return true if [med25519PublicKey] is a 69-character M... strkey whose unused trailing
+     * bits are zero and whose checksum matches, false otherwise
      * @see <a href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md">SEP-0023</a>
      */
     fun isValidMed25519PublicKey(med25519PublicKey: String): Boolean {
@@ -134,12 +289,21 @@ object StrKey {
      * Encodes raw bytes to strkey pre-authorized transaction hash (T...)
      */
     fun encodePreAuthTx(data: ByteArray): String {
-        require(data.size == 32) { "Pre-auth transaction hash must be 32 bytes" }
+        val dataLengths = VersionByte.PRE_AUTH_TX.dataLengths
+        require(data.size in dataLengths) {
+            "Pre-auth transaction hash must be ${expectedLengthText(dataLengths)} bytes, got ${data.size}"
+        }
         return encodeCheck(VersionByte.PRE_AUTH_TX, data).concatToString()
     }
 
     /**
      * Decodes strkey pre-authorized transaction hash (T...) to raw bytes
+     *
+     * @param data The strkey to decode. A pre-authorized transaction strkey is 56 characters long.
+     * @return The 32 raw hash bytes
+     * @throws IllegalArgumentException if the string is not 56 characters long, contains
+     * characters outside the base32 alphabet, does not carry the pre-authorized transaction
+     * version byte, or fails the checksum
      */
     fun decodePreAuthTx(data: String): ByteArray {
         return decodeCheck(VersionByte.PRE_AUTH_TX, data.toCharArray())
@@ -147,6 +311,10 @@ object StrKey {
 
     /**
      * Checks validity of pre-authorized transaction hash (T...)
+     *
+     * @param preAuthTx The strkey to check
+     * @return true if [preAuthTx] is a 56-character T... strkey with a matching checksum,
+     * false otherwise
      */
     fun isValidPreAuthTx(preAuthTx: String): Boolean {
         return try {
@@ -161,12 +329,21 @@ object StrKey {
      * Encodes raw bytes to strkey SHA-256 hash (X...)
      */
     fun encodeSha256Hash(data: ByteArray): String {
-        require(data.size == 32) { "SHA-256 hash must be 32 bytes" }
+        val dataLengths = VersionByte.SHA256_HASH.dataLengths
+        require(data.size in dataLengths) {
+            "SHA-256 hash must be ${expectedLengthText(dataLengths)} bytes, got ${data.size}"
+        }
         return encodeCheck(VersionByte.SHA256_HASH, data).concatToString()
     }
 
     /**
      * Decodes strkey SHA-256 hash (X...) to raw bytes
+     *
+     * @param data The strkey to decode. A SHA-256 hash strkey is 56 characters long.
+     * @return The 32 raw hash bytes
+     * @throws IllegalArgumentException if the string is not 56 characters long, contains
+     * characters outside the base32 alphabet, does not carry the SHA-256 hash version byte,
+     * or fails the checksum
      */
     fun decodeSha256Hash(data: String): ByteArray {
         return decodeCheck(VersionByte.SHA256_HASH, data.toCharArray())
@@ -174,6 +351,10 @@ object StrKey {
 
     /**
      * Checks validity of SHA-256 hash (X...)
+     *
+     * @param sha256Hash The strkey to check
+     * @return true if [sha256Hash] is a 56-character X... strkey with a matching checksum,
+     * false otherwise
      */
     fun isValidSha256Hash(sha256Hash: String): Boolean {
         return try {
@@ -186,16 +367,40 @@ object StrKey {
 
     /**
      * Encodes raw bytes to strkey signed payload (P...)
+     *
+     * The framing [data] carries is checked here as well as on decode, so every string this
+     * function returns is one [decodeSignedPayload] accepts.
+     *
+     * @param data The 32-byte ed25519 public key, the declared payload length as a big-endian
+     * four-byte value, and the payload padded with zeros to a four-byte boundary
+     * @return The encoded strkey, 69 to 165 characters long
+     * @throws IllegalArgumentException if [data] is outside 40 to 100 bytes, declares a payload
+     * length outside 1 to 64, has a size that does not fit its declared payload length exactly,
+     * or leaves a padding byte after the payload non-zero
      */
     fun encodeSignedPayload(data: ByteArray): String {
-        require(data.size in (32 + 4 + 4)..(32 + 4 + 64)) {
-            "Signed payload must be between 40 and 100 bytes, got ${data.size}"
+        val dataLengths = VersionByte.SIGNED_PAYLOAD.dataLengths
+        require(data.size in dataLengths) {
+            "Signed payload must be ${expectedLengthText(dataLengths)} bytes, got ${data.size}"
         }
+        requireSignedPayloadFraming(data)
         return encodeCheck(VersionByte.SIGNED_PAYLOAD, data).concatToString()
     }
 
     /**
      * Decodes strkey signed payload (P...) to raw bytes
+     *
+     * @param data The strkey to decode. A signed payload strkey is between 69 and 165
+     * characters long, depending on the size of the payload it carries.
+     * @return The raw bytes: the 32-byte ed25519 public key, the 4-byte declared payload
+     * length and the payload padded to a four-byte boundary
+     * @throws IllegalArgumentException if the string length is outside 69 to 165 characters,
+     * has a length that leaves a partially filled trailing character, contains characters
+     * outside the base32 alphabet, leaves the unused trailing bits of its last character
+     * non-zero, does not carry the signed payload version byte, decodes to fewer than 40 or
+     * more than 100 data bytes, declares a payload length outside 1 to 64, decodes to a size
+     * that does not fit its declared payload length exactly, leaves a padding byte after the
+     * payload non-zero, or fails the checksum
      */
     fun decodeSignedPayload(data: String): ByteArray {
         return decodeCheck(VersionByte.SIGNED_PAYLOAD, data.toCharArray())
@@ -203,6 +408,10 @@ object StrKey {
 
     /**
      * Checks validity of signed payload (P...)
+     *
+     * @param signedPayload The strkey to check
+     * @return true if [signedPayload] is a signed payload strkey [decodeSignedPayload] accepts,
+     * false otherwise
      */
     fun isValidSignedPayload(signedPayload: String): Boolean {
         return try {
@@ -217,12 +426,21 @@ object StrKey {
      * Encodes raw bytes to strkey contract address (C...)
      */
     fun encodeContract(data: ByteArray): String {
-        require(data.size == 32) { "Contract address must be 32 bytes" }
+        val dataLengths = VersionByte.CONTRACT.dataLengths
+        require(data.size in dataLengths) {
+            "Contract address must be ${expectedLengthText(dataLengths)} bytes, got ${data.size}"
+        }
         return encodeCheck(VersionByte.CONTRACT, data).concatToString()
     }
 
     /**
      * Decodes strkey contract address (C...) to raw bytes
+     *
+     * @param data The strkey to decode. A contract address strkey is 56 characters long.
+     * @return The 32 raw contract id bytes
+     * @throws IllegalArgumentException if the string is not 56 characters long, contains
+     * characters outside the base32 alphabet, does not carry the contract version byte,
+     * or fails the checksum
      */
     fun decodeContract(data: String): ByteArray {
         return decodeCheck(VersionByte.CONTRACT, data.toCharArray())
@@ -230,6 +448,10 @@ object StrKey {
 
     /**
      * Checks validity of contract address (C...)
+     *
+     * @param address The strkey to check
+     * @return true if [address] is a 56-character C... strkey with a matching checksum,
+     * false otherwise
      */
     fun isValidContract(address: String): Boolean {
         return try {
@@ -244,12 +466,21 @@ object StrKey {
      * Encodes raw bytes to strkey liquidity pool ID (L...)
      */
     fun encodeLiquidityPool(data: ByteArray): String {
-        require(data.size == 32) { "Liquidity pool ID must be 32 bytes" }
+        val dataLengths = VersionByte.LIQUIDITY_POOL.dataLengths
+        require(data.size in dataLengths) {
+            "Liquidity pool ID must be ${expectedLengthText(dataLengths)} bytes, got ${data.size}"
+        }
         return encodeCheck(VersionByte.LIQUIDITY_POOL, data).concatToString()
     }
 
     /**
      * Decodes strkey liquidity pool ID (L...) to raw bytes
+     *
+     * @param data The strkey to decode. A liquidity pool id strkey is 56 characters long.
+     * @return The 32 raw liquidity pool id bytes
+     * @throws IllegalArgumentException if the string is not 56 characters long, contains
+     * characters outside the base32 alphabet, does not carry the liquidity pool version byte,
+     * or fails the checksum
      */
     fun decodeLiquidityPool(data: String): ByteArray {
         return decodeCheck(VersionByte.LIQUIDITY_POOL, data.toCharArray())
@@ -257,6 +488,10 @@ object StrKey {
 
     /**
      * Checks validity of liquidity pool ID (L...)
+     *
+     * @param liquidityPoolId The strkey to check
+     * @return true if [liquidityPoolId] is a 56-character L... strkey with a matching
+     * checksum, false otherwise
      */
     fun isValidLiquidityPool(liquidityPoolId: String): Boolean {
         return try {
@@ -270,33 +505,53 @@ object StrKey {
     /**
      * Encodes raw bytes to strkey claimable balance ID (B...)
      *
-     * Accepts both 32-byte and 33-byte inputs:
-     * - 32 bytes: Just the hash - automatically prepends V0 type discriminant (0x00)
-     * - 33 bytes: Type (1 byte) + hash (32 bytes) - used as-is
+     * The type discriminant [data] carries is checked here as well as on decode, so every string
+     * this function returns is one [decodeClaimableBalance] accepts.
      *
-     * This handles RPC responses that may return only the 32-byte hash without the type byte.
+     * @param data The 33-byte strkey body (the type discriminant followed by the 32-byte
+     * hash), the 32-byte hash alone, or the 36-byte XDR wire form (the four-byte big-endian
+     * union discriminant followed by the hash)
+     * @return The encoded strkey, 58 characters long
+     * @throws IllegalArgumentException if [data] has none of those widths, or if the
+     * discriminant in the 33- or 36-byte form is not the one the XDR union declares
      */
     fun encodeClaimableBalance(data: ByteArray): String {
         val fullData = when (data.size) {
-            32 -> {
-                // Type is missing, prepend V0 type discriminant (0x00)
-                byteArrayOf(0x00) + data
-            }
-            33 -> {
-                // Already has type byte, use as-is
-                data
+            // The hash on its own names no type, so it is written under the one type a
+            // claimable balance id has.
+            CLAIMABLE_BALANCE_HASH_SIZE -> byteArrayOf(CLAIMABLE_BALANCE_V0_DISCRIMINANT) + data
+            // The discriminant followed by the hash, which the check below holds to the one
+            // type the XDR union declares.
+            CLAIMABLE_BALANCE_BODY_SIZE -> data
+            // The XDR wire form. Every byte of the wider discriminant is judged before the id
+            // is narrowed to the strkey body, so a value that names another type cannot reach
+            // the strkey by having its high bytes dropped.
+            CLAIMABLE_BALANCE_XDR_SIZE -> {
+                requireClaimableBalanceXdrDiscriminant(data)
+                byteArrayOf(CLAIMABLE_BALANCE_V0_DISCRIMINANT) +
+                    data.copyOfRange(XDR_UNION_DISCRIMINANT_SIZE, data.size)
             }
             else -> {
                 throw IllegalArgumentException(
-                    "Claimable balance ID must be 32 bytes (hash only) or 33 bytes (type + hash), got ${data.size} bytes"
+                    "Claimable balance ID must be $CLAIMABLE_BALANCE_HASH_SIZE bytes (hash only), " +
+                        "$CLAIMABLE_BALANCE_BODY_SIZE bytes (type + hash) or " +
+                        "$CLAIMABLE_BALANCE_XDR_SIZE bytes (XDR form), got ${data.size} bytes"
                 )
             }
         }
+        requireClaimableBalanceDiscriminant(fullData)
         return encodeCheck(VersionByte.CLAIMABLE_BALANCE, fullData).concatToString()
     }
 
     /**
      * Decodes strkey claimable balance ID (B...) to raw bytes
+     *
+     * @param data The strkey to decode. A claimable balance id strkey is 58 characters long.
+     * @return The 33 raw bytes: the type discriminant followed by the 32-byte hash
+     * @throws IllegalArgumentException if the string is not 58 characters long, contains
+     * characters outside the base32 alphabet, leaves the unused trailing bits of its last
+     * character non-zero, does not carry the claimable balance version byte, carries a type
+     * discriminant other than the one the XDR union declares, or fails the checksum
      */
     fun decodeClaimableBalance(data: String): ByteArray {
         return decodeCheck(VersionByte.CLAIMABLE_BALANCE, data.toCharArray())
@@ -304,6 +559,11 @@ object StrKey {
 
     /**
      * Checks validity of claimable balance ID (B...)
+     *
+     * @param claimableBalanceId The strkey to check
+     * @return true if [claimableBalanceId] is a 58-character B... strkey whose unused trailing
+     * bits are zero, whose type discriminant is the one the XDR union declares and whose
+     * checksum matches, false otherwise
      */
     fun isValidClaimableBalance(claimableBalanceId: String): Boolean {
         return try {
@@ -329,7 +589,20 @@ object StrKey {
     }
 
     private fun decodeCheck(versionByte: VersionByte, encoded: CharArray): ByteArray {
-        require(encoded.size >= 5) { "Encoded char array must have a length of at least 5" }
+        // The requested type fixes the length of its encoded form, so the length is checked
+        // against the caller's expectation before anything is decoded. This rejects every
+        // string that cannot describe a strkey of the requested type and bounds the work an
+        // unvalidated input can cause.
+        require(encoded.size in versionByte.encodedLengths) {
+            "Invalid encoded length, expected ${expectedLengthText(versionByte.encodedLengths)} " +
+                "characters, got ${encoded.size}"
+        }
+
+        // The conversion below narrows every character to its low byte, and every check after it
+        // reads those bytes. A character outside the ASCII range would be narrowed onto whatever
+        // alphabet character its low byte spells, which would let two different strings decode
+        // to one key, so only characters that survive the narrowing unchanged get past here.
+        require(encoded.all { it.code <= 0x7F }) { "Invalid base32 encoded string" }
 
         val bytes = encoded.map { it.code.toByte() }.toByteArray()
 
@@ -354,22 +627,22 @@ object StrKey {
         val data = payload.copyOfRange(1, payload.size)
         val checksum = decoded.copyOfRange(decoded.size - 2, decoded.size)
 
-        // Validate data length
+        // Validate data length. The type read from the decoded data decides how many payload
+        // bytes are admissible, and this runs ahead of any type-specific validation so that
+        // such validation can rely on the payload having a size its type admits.
+        require(data.size in decodedVersion.dataLengths) {
+            "Invalid data length, expected ${expectedLengthText(decodedVersion.dataLengths)} " +
+                "bytes, got ${data.size}"
+        }
+
+        // Validation of the structure a type frames inside its payload. The size check above
+        // has already established a size the type admits, which is what lets each branch read
+        // the fields its type defines. A type whose payload is an opaque key of a fixed size
+        // frames nothing further and needs no branch.
         when (decodedVersion) {
-            VersionByte.SIGNED_PAYLOAD -> {
-                require(data.size in (32 + 4 + 4)..(32 + 4 + 64)) {
-                    "Invalid data length, the length should be between 40 and 100 bytes, got ${data.size}"
-                }
-            }
-            VersionByte.MED25519_PUBLIC_KEY -> {
-                require(data.size == 40) { "Invalid data length, expected 40 bytes, got ${data.size}" }
-            }
-            VersionByte.CLAIMABLE_BALANCE -> {
-                require(data.size == 33) { "Invalid data length, expected 33 bytes, got ${data.size}" }
-            }
-            else -> {
-                require(data.size == 32) { "Invalid data length, expected 32 bytes, got ${data.size}" }
-            }
+            VersionByte.SIGNED_PAYLOAD -> requireSignedPayloadFraming(data)
+            VersionByte.CLAIMABLE_BALANCE -> requireClaimableBalanceDiscriminant(data)
+            else -> Unit
         }
 
         require(decodedVersion == versionByte) { "Version byte mismatch" }
@@ -378,6 +651,87 @@ object StrKey {
         require(expectedChecksum.contentEquals(checksum)) { "Checksum invalid" }
 
         return data
+    }
+
+    /**
+     * Checks the framing a signed payload carries: the ed25519 public key, the declared payload
+     * length, and the payload padded with zeros to a four-byte boundary. It is the framing the
+     * XDR wire form defines, so a strkey that passes here describes a signed payload the wire
+     * decoder reads back unchanged.
+     *
+     * [data] must hold at least [SIGNED_PAYLOAD_HEADER_SIZE] bytes. The per-type payload size
+     * check establishes that, and it is what makes reading the declared length here safe.
+     *
+     * @throws IllegalArgumentException if the declared payload length is outside the range a
+     * signed payload can carry, if the payload size does not fit the declared length exactly,
+     * or if a padding byte after the payload is non-zero
+     */
+    private fun requireSignedPayloadFraming(data: ByteArray) {
+        var declaredLength = 0L
+        for (index in SIGNED_PAYLOAD_KEY_SIZE until SIGNED_PAYLOAD_HEADER_SIZE) {
+            declaredLength = (declaredLength shl 8) or (data[index].toLong() and 0xFF)
+        }
+
+        require(
+            declaredLength >= declaredPayloadLengths.first &&
+                declaredLength <= declaredPayloadLengths.last
+        ) {
+            "Invalid signed payload declared length, expected " +
+                "${expectedLengthText(declaredPayloadLengths)} bytes, got $declaredLength"
+        }
+
+        val payloadLength = declaredLength.toInt()
+        val requiredSize = SIGNED_PAYLOAD_HEADER_SIZE + paddedToFourBytes(payloadLength)
+        require(data.size == requiredSize) {
+            "Invalid signed payload size, a declared length of $payloadLength requires " +
+                "$requiredSize bytes, got ${data.size}"
+        }
+
+        for (index in SIGNED_PAYLOAD_HEADER_SIZE + payloadLength until data.size) {
+            require(data[index] == 0.toByte()) {
+                "Invalid signed payload padding, expected zero at index $index after a declared " +
+                    "length of $payloadLength, got ${data[index].toInt() and 0xFF}"
+            }
+        }
+    }
+
+    /**
+     * Checks the type discriminant a claimable balance id carries. Only
+     * [CLAIMABLE_BALANCE_V0_DISCRIMINANT] names a case the XDR union declares, so a payload
+     * written under any other value describes a type the wire decoder cannot read back.
+     *
+     * [data] must hold at least one byte. The per-type payload size check establishes that, and
+     * it is what makes reading the discriminant here safe.
+     *
+     * @throws IllegalArgumentException if the discriminant is not the one the union declares
+     */
+    private fun requireClaimableBalanceDiscriminant(data: ByteArray) {
+        require(data[0] == CLAIMABLE_BALANCE_V0_DISCRIMINANT) {
+            "Invalid claimable balance discriminant, expected " +
+                "$CLAIMABLE_BALANCE_V0_DISCRIMINANT, got ${data[0].toInt() and 0xFF}"
+        }
+    }
+
+    /**
+     * Checks the type discriminant the XDR wire form of a claimable balance id carries: the
+     * type as a big-endian value across [XDR_UNION_DISCRIMINANT_SIZE] bytes. All of them are
+     * read, so a value that differs only in the bytes above the last one is rejected rather
+     * than narrowed away.
+     *
+     * [data] must hold at least [XDR_UNION_DISCRIMINANT_SIZE] bytes. The per-width size check
+     * establishes that, and it is what makes reading the discriminant here safe.
+     *
+     * @throws IllegalArgumentException if the discriminant is not the one the union declares
+     */
+    private fun requireClaimableBalanceXdrDiscriminant(data: ByteArray) {
+        var carried = 0L
+        for (index in 0 until XDR_UNION_DISCRIMINANT_SIZE) {
+            carried = (carried shl 8) or (data[index].toLong() and 0xFF)
+        }
+        require(carried == CLAIMABLE_BALANCE_V0_DISCRIMINANT.toLong()) {
+            "Invalid claimable balance discriminant, expected " +
+                "$CLAIMABLE_BALANCE_V0_DISCRIMINANT, got 0x${carried.toString(16)}"
+        }
     }
 
     /**

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Util.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/Util.kt
@@ -115,6 +115,17 @@ object Util {
      * @throws IllegalArgumentException if the hex string has odd length or contains invalid characters
      */
     internal fun hexToBytes(hex: String): ByteArray {
+        // Restricting to the ASCII hex alphabet is load-bearing: a bare radix parse of each pair
+        // also accepts sign characters and non-ASCII Unicode digits, which would silently decode
+        // to a byte array that does not correspond to the caller's string. Judging the caller's
+        // own characters also names the offender as written and keeps the length check below on
+        // the caller's count, which case folding a non-ASCII character can change.
+        val invalidChar = hex.firstOrNull {
+            it !in '0'..'9' && it !in 'a'..'f' && it !in 'A'..'F'
+        }
+        require(invalidChar == null) {
+            "Hex string must contain only the characters 0-9 and a-f, got: '$invalidChar'"
+        }
         val cleanHex = hex.lowercase()
         require(cleanHex.length % 2 == 0) { "Hex string must have even length" }
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/contract/ContractSpec.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/contract/ContractSpec.kt
@@ -1,6 +1,7 @@
 package com.soneso.stellar.sdk.contract
 
 import com.soneso.stellar.sdk.Address
+import com.soneso.stellar.sdk.Util
 import com.soneso.stellar.sdk.contract.exception.ContractSpecException
 import com.soneso.stellar.sdk.scval.Scv
 import com.soneso.stellar.sdk.xdr.*
@@ -1157,14 +1158,9 @@ class ContractSpec(private val entries: List<SCSpecEntryXdr>) {
     }
 
     /**
-     * Convert hex string to bytes
+     * Convert hex string to bytes, accepting an optional "0x" prefix.
      */
     private fun hexToBytes(hex: String): ByteArray {
-        val cleanHex = hex.removePrefix("0x").replace(" ", "")
-        require(cleanHex.length % 2 == 0) { "Hex string must have even length" }
-
-        return ByteArray(cleanHex.length / 2) { i ->
-            cleanHex.substring(i * 2, i * 2 + 2).toInt(16).toByte()
-        }
+        return Util.hexToBytes(hex.removePrefix("0x"))
     }
 }

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/ClaimableBalancesRequestBuilder.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/ClaimableBalancesRequestBuilder.kt
@@ -48,8 +48,8 @@ class ClaimableBalancesRequestBuilder(
     /**
      * Requests a specific claimable balance by ID.
      *
-     * The id may be given in any spelling [ClaimableBalanceId.forId] accepts; the route carries
-     * the one Horizon serves, the hexadecimal of the XDR form.
+     * The id may be given in any spelling [ClaimableBalanceId.forId] accepts; the route
+     * carries the 72-character hexadecimal of the XDR form, the spelling Horizon serves.
      *
      * @param claimableBalanceId The claimable balance ID to fetch
      * @return The claimable balance response

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/ClaimableBalancesRequestBuilder.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/ClaimableBalancesRequestBuilder.kt
@@ -2,6 +2,7 @@ package com.soneso.stellar.sdk.horizon.requests
 
 import io.ktor.client.*
 import io.ktor.http.*
+import com.soneso.stellar.sdk.ClaimableBalanceId
 import com.soneso.stellar.sdk.horizon.exceptions.*
 import com.soneso.stellar.sdk.horizon.responses.ClaimableBalanceResponse
 import com.soneso.stellar.sdk.horizon.responses.Page
@@ -47,8 +48,13 @@ class ClaimableBalancesRequestBuilder(
     /**
      * Requests a specific claimable balance by ID.
      *
+     * The id may be given in any spelling [ClaimableBalanceId.forId] accepts; the route carries
+     * the one Horizon serves, the hexadecimal of the XDR form.
+     *
      * @param claimableBalanceId The claimable balance ID to fetch
      * @return The claimable balance response
+     * @throws IllegalArgumentException If [claimableBalanceId] names no claimable balance, in
+     * which case no request is sent
      * @throws NetworkException All the exceptions below are subclasses of NetworkException
      * @throws BadRequestException If the request fails due to a bad request (4xx)
      * @throws BadResponseException If the request fails due to a bad response from the server (5xx)
@@ -60,7 +66,7 @@ class ClaimableBalancesRequestBuilder(
      * @see <a href="https://developers.stellar.org/api/resources/claimablebalances/single/">Claimable Balance Details</a>
      */
     suspend fun claimableBalance(claimableBalanceId: String): ClaimableBalanceResponse {
-        setSegments("claimable_balances", claimableBalanceId)
+        setSegments("claimable_balances", ClaimableBalanceId.forId(claimableBalanceId).toPaddedHex())
         return executeGetRequest(buildUrl())
     }
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/EffectsRequestBuilder.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/EffectsRequestBuilder.kt
@@ -77,18 +77,6 @@ class EffectsRequestBuilder(
         return this
     }
 
-    /**
-     * Builds request to `GET /claimable_balances/{claimableBalanceId}/effects`
-     *
-     * @param claimableBalanceId Claimable balance ID for which to get effects
-     * @return Current [EffectsRequestBuilder] instance
-     * @see [Effects for Claimable Balance](https://developers.stellar.org/api/resources/claimablebalances/effects/)
-     */
-    fun forClaimableBalance(claimableBalanceId: String): EffectsRequestBuilder {
-        setSegments("claimable_balances", claimableBalanceId, "effects")
-        return this
-    }
-
     override fun cursor(cursor: String): EffectsRequestBuilder {
         super.cursor(cursor)
         return this

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/OperationsRequestBuilder.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/OperationsRequestBuilder.kt
@@ -54,8 +54,8 @@ class OperationsRequestBuilder(
      * Builds request to GET /claimable_balances/{claimable_balance_id}/operations
      * Returns all operations for a specific claimable balance.
      *
-     * The id may be given in any spelling [ClaimableBalanceId.forId] accepts; the route carries
-     * the one Horizon serves, the hexadecimal of the XDR form.
+     * The id may be given in any spelling [ClaimableBalanceId.forId] accepts; the route
+     * carries the 72-character hexadecimal of the XDR form, the spelling Horizon serves.
      *
      * @param claimableBalance Claimable Balance ID for which to get operations
      * @return This request builder instance

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/OperationsRequestBuilder.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/OperationsRequestBuilder.kt
@@ -2,6 +2,7 @@ package com.soneso.stellar.sdk.horizon.requests
 
 import io.ktor.client.*
 import io.ktor.http.*
+import com.soneso.stellar.sdk.ClaimableBalanceId
 import com.soneso.stellar.sdk.horizon.exceptions.*
 import com.soneso.stellar.sdk.horizon.responses.Page
 import com.soneso.stellar.sdk.horizon.responses.operations.OperationResponse
@@ -53,12 +54,21 @@ class OperationsRequestBuilder(
      * Builds request to GET /claimable_balances/{claimable_balance_id}/operations
      * Returns all operations for a specific claimable balance.
      *
+     * The id may be given in any spelling [ClaimableBalanceId.forId] accepts; the route carries
+     * the one Horizon serves, the hexadecimal of the XDR form.
+     *
      * @param claimableBalance Claimable Balance ID for which to get operations
      * @return This request builder instance
+     * @throws IllegalArgumentException If [claimableBalance] names no claimable balance, in
+     * which case no request is sent
      * @see <a href="https://developers.stellar.org/api/resources/claimablebalances/operations/">Operations for ClaimableBalance</a>
      */
     fun forClaimableBalance(claimableBalance: String): OperationsRequestBuilder {
-        setSegments("claimable_balances", claimableBalance, "operations")
+        setSegments(
+            "claimable_balances",
+            ClaimableBalanceId.forId(claimableBalance).toPaddedHex(),
+            "operations"
+        )
         return this
     }
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/TransactionsRequestBuilder.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/TransactionsRequestBuilder.kt
@@ -2,6 +2,7 @@ package com.soneso.stellar.sdk.horizon.requests
 
 import io.ktor.client.*
 import io.ktor.http.*
+import com.soneso.stellar.sdk.ClaimableBalanceId
 import com.soneso.stellar.sdk.horizon.exceptions.*
 import com.soneso.stellar.sdk.horizon.responses.Page
 import com.soneso.stellar.sdk.horizon.responses.TransactionResponse
@@ -51,12 +52,21 @@ class TransactionsRequestBuilder(
      * Builds request to GET /claimable_balances/{claimable_balance_id}/transactions
      * Returns all transactions for a specific claimable balance.
      *
+     * The id may be given in any spelling [ClaimableBalanceId.forId] accepts; the route carries
+     * the one Horizon serves, the hexadecimal of the XDR form.
+     *
      * @param claimableBalance Claimable Balance ID for which to get transactions
      * @return This request builder instance
+     * @throws IllegalArgumentException If [claimableBalance] names no claimable balance, in
+     * which case no request is sent
      * @see <a href="https://developers.stellar.org/api/resources/claimablebalances/transactions/">Transactions for ClaimableBalance</a>
      */
     fun forClaimableBalance(claimableBalance: String): TransactionsRequestBuilder {
-        setSegments("claimable_balances", claimableBalance, "transactions")
+        setSegments(
+            "claimable_balances",
+            ClaimableBalanceId.forId(claimableBalance).toPaddedHex(),
+            "transactions"
+        )
         return this
     }
 

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/TransactionsRequestBuilder.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/requests/TransactionsRequestBuilder.kt
@@ -52,8 +52,8 @@ class TransactionsRequestBuilder(
      * Builds request to GET /claimable_balances/{claimable_balance_id}/transactions
      * Returns all transactions for a specific claimable balance.
      *
-     * The id may be given in any spelling [ClaimableBalanceId.forId] accepts; the route carries
-     * the one Horizon serves, the hexadecimal of the XDR form.
+     * The id may be given in any spelling [ClaimableBalanceId.forId] accepts; the route
+     * carries the 72-character hexadecimal of the XDR form, the spelling Horizon serves.
      *
      * @param claimableBalance Claimable Balance ID for which to get transactions
      * @return This request builder instance

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/responses/TransactionResponse.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/responses/TransactionResponse.kt
@@ -1,5 +1,17 @@
 package com.soneso.stellar.sdk.horizon.responses
 
+import com.soneso.stellar.sdk.ClaimableBalanceId
+import com.soneso.stellar.sdk.isFatal
+import com.soneso.stellar.sdk.xdr.CreateClaimableBalanceResultXdr
+import com.soneso.stellar.sdk.xdr.InnerTransactionResultResultXdr
+import com.soneso.stellar.sdk.xdr.OperationResultTrXdr
+import com.soneso.stellar.sdk.xdr.OperationResultXdr
+import com.soneso.stellar.sdk.xdr.TransactionResultCodeXdr
+import com.soneso.stellar.sdk.xdr.TransactionResultResultXdr
+import com.soneso.stellar.sdk.xdr.TransactionResultXdr
+import com.soneso.stellar.sdk.xdr.XdrReader
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -94,6 +106,58 @@ data class TransactionResponse(
     @SerialName("_links")
     val links: Links
 ) : Response(), Pageable {
+
+    /**
+     * The id of the claimable balance the operation at [operationIndex] created, as a `B...`
+     * strkey.
+     *
+     * A fee bump transaction carries no operations of its own, so the inner transaction's
+     * operation results are read for it.
+     *
+     * @param operationIndex the position of the CreateClaimableBalance operation within the
+     * transaction, 0 for the first
+     * @return the created balance id, or null when the transaction did not succeed, when
+     * [resultXdr] is absent or cannot be decoded, when no operation sits at [operationIndex],
+     * or when the operation there is not a CreateClaimableBalance
+     */
+    @OptIn(ExperimentalEncodingApi::class)
+    fun getCreatedClaimableBalanceId(operationIndex: Int = 0): String? {
+        val encodedResult = resultXdr ?: return null
+        val result = try {
+            TransactionResultXdr.decode(XdrReader(Base64.decode(encodedResult)))
+        } catch (e: Throwable) {
+            if (isFatal(e)) throw e
+            return null
+        }
+
+        val operationResults = when (val outcome = result.result) {
+            is TransactionResultResultXdr.Results -> {
+                if (outcome.discriminant != TransactionResultCodeXdr.txSUCCESS) return null
+                outcome.value
+            }
+            is TransactionResultResultXdr.InnerResultPair -> {
+                if (outcome.discriminant != TransactionResultCodeXdr.txFEE_BUMP_INNER_SUCCESS) {
+                    return null
+                }
+                when (val inner = outcome.value.result.result) {
+                    is InnerTransactionResultResultXdr.Results -> {
+                        if (inner.discriminant != TransactionResultCodeXdr.txSUCCESS) return null
+                        inner.value
+                    }
+                    is InnerTransactionResultResultXdr.Void -> return null
+                }
+            }
+            is TransactionResultResultXdr.Void -> return null
+        }
+
+        val operationResult = operationResults.getOrNull(operationIndex) ?: return null
+        val inner = (operationResult as? OperationResultXdr.Tr)?.value ?: return null
+        val created = (inner as? OperationResultTrXdr.CreateClaimableBalanceResult)?.value
+            ?: return null
+        val balanceId = (created as? CreateClaimableBalanceResultXdr.BalanceID)?.value
+            ?: return null
+        return ClaimableBalanceId.fromXdr(balanceId).toStrKey()
+    }
 
     /**
      * Preconditions of a transaction per CAP-21.

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/responses/TransactionResponse.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/responses/TransactionResponse.kt
@@ -151,12 +151,12 @@ data class TransactionResponse(
         }
 
         val operationResult = operationResults.getOrNull(operationIndex) ?: return null
-        val inner = (operationResult as? OperationResultXdr.Tr)?.value ?: return null
-        val created = (inner as? OperationResultTrXdr.CreateClaimableBalanceResult)?.value
-            ?: return null
-        val balanceId = (created as? CreateClaimableBalanceResultXdr.BalanceID)?.value
-            ?: return null
-        return ClaimableBalanceId.fromXdr(balanceId).toStrKey()
+        if (operationResult !is OperationResultXdr.Tr) return null
+        val inner = operationResult.value
+        if (inner !is OperationResultTrXdr.CreateClaimableBalanceResult) return null
+        val created = inner.value
+        if (created !is CreateClaimableBalanceResultXdr.BalanceID) return null
+        return ClaimableBalanceId.fromXdr(created.value).toStrKey()
     }
 
     /**

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/responses/operations/InvokeHostFunctionOperationResponse.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/horizon/responses/operations/InvokeHostFunctionOperationResponse.kt
@@ -85,10 +85,10 @@ data class InvokeHostFunctionOperationResponse(
         val type: String,
 
         @SerialName("from")
-        val from: String,
+        val from: String? = null,
 
         @SerialName("to")
-        val to: String,
+        val to: String? = null,
 
         @SerialName("amount")
         val amount: String,

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/rpc/SorobanServer.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/rpc/SorobanServer.kt
@@ -969,15 +969,19 @@ class SorobanServer(
      * }
      * ```
      *
-     * @param wasmId The contract WASM ID as a hex-encoded hash string
+     * @param wasmId The contract WASM ID as a hex-encoded hash string (64 characters)
      * @return The contract code entry if found, null otherwise
      * @throws SorobanRpcException If the RPC request fails
-     * @throws IllegalArgumentException If wasmId is not a valid hex string
+     * @throws IllegalArgumentException If wasmId is not 64 characters or is not a valid hex string
      *
      * @see loadContractCodeForContractId
      * @see loadContractInfoForWasmId
      */
     suspend fun loadContractCodeForWasmId(wasmId: String): ContractCodeEntryXdr? {
+        require(wasmId.length == 64) {
+            "WASM ID must be 64 hex characters, got ${wasmId.length}"
+        }
+
         // Create ledger key for contract code
         val ledgerKey = LedgerKeyXdr.ContractCode(
             LedgerKeyContractCodeXdr(
@@ -1092,11 +1096,11 @@ class SorobanServer(
      * }
      * ```
      *
-     * @param wasmId The contract WASM ID as a hex-encoded hash string
+     * @param wasmId The contract WASM ID as a hex-encoded hash string (64 characters)
      * @return The parsed contract information if found, null if the contract code doesn't exist
      * @throws SorobanRpcException If the RPC request fails
      * @throws com.soneso.stellar.sdk.contract.SorobanContractParserException If the WASM bytecode cannot be parsed
-     * @throws IllegalArgumentException If wasmId is not a valid hex string
+     * @throws IllegalArgumentException If wasmId is not 64 characters or is not a valid hex string
      *
      * @see loadContractCodeForWasmId
      * @see loadContractInfoForContractId

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/ClaimableBalanceIntegrationTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/ClaimableBalanceIntegrationTest.kt
@@ -56,9 +56,10 @@ class ClaimableBalanceIntegrationTest {
      *    - First claimant: Unconditional predicate
      *    - Second claimant: Complex nested predicate with And, Or, Not, BeforeAbsoluteTime, BeforeRelativeTime
      * 3. Creates a claimable balance with CreateClaimableBalance operation
-     * 4. Verifies the transaction succeeds
+     * 4. Verifies the transaction succeeds and reads the created balance id from the submit
+     *    response with getCreatedClaimableBalanceId
      * 5. Queries effects to extract the claimable balance ID
-     * 6. Tests StrKey encoding for the balance ID (hex to B... format)
+     * 6. Checks that the submit response and the effect name the same balance
      * 7. Queries claimable balances for the first claimant
      * 8. Funds the first claimant account
      * 9. Claims the balance with ClaimClaimableBalance operation
@@ -146,6 +147,14 @@ class ClaimableBalanceIntegrationTest {
 
         println("CreateClaimableBalance transaction hash: ${response.hash}")
 
+        // The result XDR the submit response carries names the created balance, so the id
+        // is available before any effect is queried.
+        val createdBalanceId = assertNotNull(
+            response.getCreatedClaimableBalanceId(),
+            "the submit response must yield the created balance id"
+        )
+        println("Created claimable balance ID: $createdBalanceId")
+
         realDelay(3000)
 
         // Query effects to find the claimable balance ID
@@ -162,33 +171,19 @@ class ClaimableBalanceIntegrationTest {
             if (effect is ClaimableBalanceCreatedEffectResponse) {
                 balanceId = effect.balanceId
                 println("Claimable Balance ID: $balanceId")
-
-                // Test StrKey encoding if balance ID is in hex format (72 chars = 36 bytes hex)
-                // Claimable balance ID format: 1 byte type (0x00) + 32 bytes hash = 33 bytes total
-                if (!balanceId.startsWith("B") && balanceId.length == 72) {
-                    try {
-                        // Hex string is 72 chars = 36 bytes, but we need 33 bytes for StrKey
-                        // The first byte in hex is the type discriminant (0x00 for V0)
-                        val balanceIdBytes = Util.hexToBytes(balanceId)
-                        // For V0 claimable balance: first byte is 0x00, followed by 32-byte hash
-                        // StrKey expects 33 bytes: type byte + 32-byte hash
-                        if (balanceIdBytes.size == 36) {
-                            // Extract the first 33 bytes (type + hash)
-                            val strKeyBytes = balanceIdBytes.copyOfRange(0, 33)
-                            val strKeyId = StrKey.encodeClaimableBalance(strKeyBytes)
-                            println("Claimable Balance ID StrKey: $strKeyId")
-                            assertTrue(strKeyId.startsWith("B"), "StrKey encoded balance ID should start with 'B'")
-                        }
-                    } catch (e: Exception) {
-                        // If hex conversion fails, balance ID might already be in StrKey format
-                        println("Balance ID encoding info: ${e.message}")
-                    }
-                }
                 break
             }
         }
 
-        assertNotNull(balanceId, "Balance ID should be found in effects")
+        val effectBalanceId = assertNotNull(balanceId, "Balance ID should be found in effects")
+
+        // The effect reports the balance in the spelling Horizon serves, the submit response
+        // as the strkey; resolved, both must name the balance the transaction created.
+        assertEquals(
+            ClaimableBalanceId.forId(createdBalanceId),
+            ClaimableBalanceId.forId(effectBalanceId),
+            "the submit response and the effect must name the same balance"
+        )
 
         // Verify operations can be parsed
         val operationsPage = horizonServer.operations()
@@ -204,7 +199,7 @@ class ClaimableBalanceIntegrationTest {
         assertEquals(1, claimableBalances.records.size, "Should have exactly 1 claimable balance")
         val claimableBalance = claimableBalances.records[0]
 
-        assertEquals(balanceId, claimableBalance.id, "Balance IDs should match")
+        assertEquals(effectBalanceId, claimableBalance.id, "Balance IDs should match")
         assertEquals("12.3300000", claimableBalance.amount, "Amount should match (7 decimal places)")
         assertEquals(sourceAccountId, claimableBalance.sponsor, "Sponsor should be source account")
 

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/QueryIntegrationTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/QueryIntegrationTest.kt
@@ -409,112 +409,104 @@ class QueryIntegrationTest {
     }
 
     /**
+     * A claimable balance id, in the spelling Horizon reports.
+     *
+     * The balance need not exist: claimable balance ids change frequently on testnet, so what
+     * these tests check is the route the SDK builds and the answer Horizon gives for it.
+     */
+    private val claimableBalanceId =
+        "000000004dd97cb1a0ba1b6e1a188b49deafbad9e34c80e277c3725f815c757c2d05ddfe"
+
+    /**
+     * The same balance in every spelling a caller may hold: the hexadecimal Horizon reports and
+     * the `B...` strkey, which the SDK normalizes to that hexadecimal before asking for it.
+     */
+    private val claimableBalanceSpellings: List<String>
+        get() = listOf(
+            claimableBalanceId,
+            ClaimableBalanceId.forId(claimableBalanceId).toStrKey()
+        )
+
+    /**
+     * An id naming no claimable balance: 63 characters is a length no spelling has.
+     */
+    private val malformedClaimableBalanceId =
+        "BAAAAAAAJXMXZMNAXINW4GQYRNE55L523HRUZAHCO7BXEX4BLR2XYLIF3X7IL2Y"
+
+    /**
      * Test querying operations for claimable balance.
      *
-     * This test queries operations associated with a claimable balance ID.
-     * Note: Claimable balance IDs change frequently on testnet, so this test
-     * verifies the query mechanism works but doesn't assert on specific results.
+     * This test queries operations associated with a claimable balance ID in each spelling the
+     * SDK accepts, and checks that an id naming no balance is reported without a request.
      */
     @Test
     fun testQueryOperationsForClaimableBalance() = runTest(timeout = 60.seconds) {
-        // Try to query operations with a claimable balance ID
-            // The ID may not exist, which is fine - we're testing the endpoint works
+        assertFailsWith<IllegalArgumentException>(
+            "an id naming no balance must be reported before any request"
+        ) {
+            horizonServer.operations().forClaimableBalance(malformedClaimableBalanceId)
+        }
+
+        for (spelling in claimableBalanceSpellings) {
             try {
-                val operationsPage1 = horizonServer.operations()
-                    .forClaimableBalance("000000004dd97cb1a0ba1b6e1a188b49deafbad9e34c80e277c3725f815c757c2d05ddfe")
+                val operationsPage = horizonServer.operations()
+                    .forClaimableBalance(spelling)
                     .limit(1)
                     .order(com.soneso.stellar.sdk.horizon.requests.RequestBuilder.Order.DESC)
                     .execute()
 
-                // If we get results, verify they're valid
-                if (operationsPage1.records.isNotEmpty()) {
-                    val operation = operationsPage1.records.first()
-                    assertNotNull(operation.id, "Operation should have an ID")
+                operationsPage.records.forEach {
+                    assertNotNull(it.id, "Operation should have an ID")
                 }
             } catch (e: Exception) {
-                // 400 or 404 is acceptable if the claimable balance doesn't exist
+                // A well formed id naming no balance is a 404; a 400 would mean the id did not
+                // reach Horizon in the spelling it serves.
                 assertTrue(
-                    e.message?.contains("400") == true ||
                     e.message?.contains("404") == true ||
                     e.message?.contains("not found") == true,
-                    "Expected 400/404 error for non-existent claimable balance, got: ${e.message}"
+                    "Expected 404 for a claimable balance that does not exist, " +
+                        "spelling $spelling, got: ${e.message}"
                 )
             }
-
-            // Try base58 format
-            try {
-                val operationsPage2 = horizonServer.operations()
-                    .forClaimableBalance("BAAAAAAAJXMXZMNAXINW4GQYRNE55L523HRUZAHCO7BXEX4BLR2XYLIF3X7IL2Y")
-                    .limit(1)
-                    .order(com.soneso.stellar.sdk.horizon.requests.RequestBuilder.Order.DESC)
-                    .execute()
-
-                if (operationsPage2.records.isNotEmpty()) {
-                    assertNotNull(operationsPage2.records.first().id, "Operation should have an ID")
-                }
-            } catch (e: Exception) {
-                // 400 or 404 is acceptable
-                assertTrue(
-                    e.message?.contains("400") == true ||
-                    e.message?.contains("404") == true ||
-                    e.message?.contains("not found") == true,
-                    "Expected 400/404 error for non-existent claimable balance"
-                )
-            }
+        }
     }
 
     /**
      * Test querying transactions for claimable balance.
      *
-     * This test queries transactions associated with a claimable balance ID.
-     * Note: Claimable balance IDs change frequently on testnet, so this test
-     * verifies the query mechanism works but doesn't assert on specific results.
+     * This test queries transactions associated with a claimable balance ID in each spelling the
+     * SDK accepts, and checks that an id naming no balance is reported without a request.
      */
     @Test
     fun testQueryTransactionsForClaimableBalance() = runTest(timeout = 60.seconds) {
-        // Try to query transactions with a claimable balance ID
-            // The ID may not exist, which is fine - we're testing the endpoint works
+        assertFailsWith<IllegalArgumentException>(
+            "an id naming no balance must be reported before any request"
+        ) {
+            horizonServer.transactions().forClaimableBalance(malformedClaimableBalanceId)
+        }
+
+        for (spelling in claimableBalanceSpellings) {
             try {
-                val transactionsPage1 = horizonServer.transactions()
-                    .forClaimableBalance("000000004dd97cb1a0ba1b6e1a188b49deafbad9e34c80e277c3725f815c757c2d05ddfe")
+                val transactionsPage = horizonServer.transactions()
+                    .forClaimableBalance(spelling)
                     .limit(1)
                     .order(com.soneso.stellar.sdk.horizon.requests.RequestBuilder.Order.DESC)
                     .execute()
 
-                // If we get results, verify they're valid
-                if (transactionsPage1.records.isNotEmpty()) {
-                    assertNotNull(transactionsPage1.records.first().hash, "Transaction should have a hash")
+                transactionsPage.records.forEach {
+                    assertNotNull(it.hash, "Transaction should have a hash")
                 }
             } catch (e: Exception) {
-                // 400 or 404 is acceptable if the claimable balance doesn't exist
+                // A well formed id naming no balance is a 404; a 400 would mean the id did not
+                // reach Horizon in the spelling it serves.
                 assertTrue(
-                    e.message?.contains("400") == true ||
                     e.message?.contains("404") == true ||
                     e.message?.contains("not found") == true,
-                    "Expected 400/404 error for non-existent claimable balance, got: ${e.message}"
+                    "Expected 404 for a claimable balance that does not exist, " +
+                        "spelling $spelling, got: ${e.message}"
                 )
             }
-
-            // Try base58 format
-            try {
-                val transactionsPage2 = horizonServer.transactions()
-                    .forClaimableBalance("BAAAAAAAJXMXZMNAXINW4GQYRNE55L523HRUZAHCO7BXEX4BLR2XYLIF3X7IL2Y")
-                    .limit(1)
-                    .order(com.soneso.stellar.sdk.horizon.requests.RequestBuilder.Order.DESC)
-                    .execute()
-
-                if (transactionsPage2.records.isNotEmpty()) {
-                    assertNotNull(transactionsPage2.records.first().hash, "Transaction should have a hash")
-                }
-            } catch (e: Exception) {
-                // 400 or 404 is acceptable
-                assertTrue(
-                    e.message?.contains("400") == true ||
-                    e.message?.contains("404") == true ||
-                    e.message?.contains("not found") == true,
-                    "Expected 400/404 error for non-existent claimable balance"
-                )
-            }
+        }
     }
 
     /**

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/sep/sep01/StellarTomlIntegrationTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/sep/sep01/StellarTomlIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.soneso.stellar.sdk.sep.sep01.*
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
@@ -234,65 +235,30 @@ class StellarTomlIntegrationTest {
 
     @Test
     fun testHttp404NotFound() = runTest {
-        // Domain that doesn't exist
-        try {
-            StellarToml.fromDomain("this-domain-definitely-does-not-exist-12345.com")
-            fail("Should throw exception for 404")
-        } catch (e: Throwable) {
-            // Expected - network error or 404 (any exception is acceptable)
-            assertNotNull(e)
+        // example.com exists and serves no stellar.toml, so the fetch is a
+        // real HTTP 404 reported with its status code.
+        val e = assertFailsWith<IllegalStateException> {
+            StellarToml.fromDomain("example.com")
         }
-    }
-
-    @Test
-    fun testHttp500ServerError() = runTest {
-        // We can't reliably test a 500 error without a mock server,
-        // but we can verify error handling works
-        try {
-            StellarToml.fromDomain("httpstat.us/500")
-            fail("Should throw exception for server error")
-        } catch (e: Throwable) {
-            // Expected - network error or non-200 status
-            assertNotNull(e.message)
-        }
+        assertEquals("Stellar toml not found, response status code 404", e.message)
     }
 
     @Test
     fun testInvalidUrl() = runTest {
-        // Test with invalid domain format - HTTP clients may accept this
-        // This test verifies that malformed domains don't cause crashes
-        try {
+        // An unresolvable domain must be reported to the caller, not returned
+        // as a toml.
+        assertFailsWith<Exception> {
             StellarToml.fromDomain("not-a-valid-domain-12345678.invalidtld9999")
-        } catch (e: Throwable) {
-            // Expected - network error (but not required)
-            assertNotNull(e)
         }
-        // If no exception, that's also acceptable behavior
-    }
-
-    @Test
-    fun testDnsResolutionFailure() = runTest {
-        // Domain with invalid TLD - DNS may still resolve
-        // This test verifies that malformed domains don't cause crashes
-        try {
-            StellarToml.fromDomain("stellar-test-nonexistent-domain-xyz.invalidtld")
-        } catch (e: Throwable) {
-            // Expected - DNS resolution error (but not required)
-            assertNotNull(e)
-        }
-        // If no exception, that's also acceptable behavior
     }
 
     // ========== currencyFromUrl Tests ==========
 
     @Test
     fun testCurrencyFromUrlInvalidUrl() = runTest {
-        try {
+        // An unresolvable host must be reported to the caller.
+        assertFailsWith<Exception> {
             StellarToml.currencyFromUrl("https://stellar-test-invalid-domain-xyz-12345.com/currency.toml")
-            fail("Should throw exception for invalid URL")
-        } catch (e: Throwable) {
-            // Expected - network error
-            assertNotNull(e)
         }
     }
 

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/AddressTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/AddressTest.kt
@@ -335,22 +335,53 @@ class AddressTest {
         assertContentEquals(original.getBytes(), reconstructed.getBytes())
     }
 
-    // ========== toSCAddress: claimable balance type validation ==========
+    // ========== Claimable balance: type discriminant ==========
 
     @Test
-    fun testClaimableBalanceToSCAddressInvalidTypeThrows() {
-        // StrKey.encodeClaimableBalance accepts any 33-byte payload as-is; only the SDK-level
-        // toSCAddress() check enforces that the leading type byte is CLAIMABLE_BALANCE_ID_TYPE_V0.
+    fun testClaimableBalanceAddressRejectsATypeDiscriminantOtherThanV0() {
+        // A claimable balance id names the one type the XDR union declares. Both ways of
+        // building such an address reject any other discriminant, so no Address holds one and
+        // toSCAddress() has no non-V0 discriminant left to meet.
         val nonV0Bytes = ByteArray(33)
         nonV0Bytes[0] = 1
-        val address = Address.fromClaimableBalance(nonV0Bytes)
+        val fromBytes = assertFailsWith<IllegalArgumentException> {
+            Address.fromClaimableBalance(nonV0Bytes)
+        }
+        assertEquals(
+            "Invalid claimable balance discriminant, expected 0, got 1",
+            fromBytes.message
+        )
+
+        // The SEP-0023 invalid claimable balance type vector: a B... strkey whose checksum
+        // holds and whose leading byte is 1.
+        val nonV0StrKey = "BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA"
+        assertFalse(StrKey.isValidClaimableBalance(nonV0StrKey))
+        val fromStrKey = assertFailsWith<IllegalArgumentException> { Address(nonV0StrKey) }
+        assertEquals("Unsupported address type", fromStrKey.message)
+    }
+
+    @Test
+    fun testClaimableBalanceAddressAcceptsTheTypeDiscriminantV0() {
+        // The counterpart of the rejection above: the discriminant the XDR union declares is
+        // carried through construction, encoding and conversion unchanged.
+        val v0Bytes = ByteArray(33) { index -> if (index == 0) 0 else (index * 7).toByte() }
+        val address = Address.fromClaimableBalance(v0Bytes)
 
         assertEquals(Address.AddressType.CLAIMABLE_BALANCE, address.addressType)
+        assertContentEquals(v0Bytes, address.getBytes())
 
-        val exception = assertFailsWith<IllegalArgumentException> {
-            address.toSCAddress()
-        }
-        assertTrue(exception.message!!.contains("CLAIMABLE_BALANCE_ID_TYPE_V0"))
+        val scAddress = assertIs<SCAddressXdr.ClaimableBalanceId>(address.toSCAddress())
+        val v0 = assertIs<ClaimableBalanceIDXdr.V0>(scAddress.value)
+        assertContentEquals(v0Bytes.copyOfRange(1, v0Bytes.size), v0.value.value)
+
+        // The 32-byte hash and the 36-byte XDR wire form name the same balance, so all
+        // three widths build the same address.
+        val hash = v0Bytes.copyOfRange(1, v0Bytes.size)
+        assertEquals(address.toString(), Address.fromClaimableBalance(hash).toString())
+        assertEquals(
+            address.toString(),
+            Address.fromClaimableBalance(ByteArray(4) + hash).toString()
+        )
     }
 
     // ========== equals: reflexive, null, different runtime type, same type different key ==========

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/ClaimableBalanceIdTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/ClaimableBalanceIdTest.kt
@@ -1,0 +1,238 @@
+package com.soneso.stellar.sdk.unitTests
+
+import com.soneso.stellar.sdk.ClaimableBalanceId
+import com.soneso.stellar.sdk.xdr.ClaimableBalanceIDXdr
+import com.soneso.stellar.sdk.xdr.HashXdr
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * The spellings a claimable balance id is written in, and the one balance they name.
+ */
+class ClaimableBalanceIdTest {
+
+    /** The 32-byte balance hash the vectors are built around. */
+    private val hashHex = "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
+
+    private val strKey = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+
+    /** The hash behind the single discriminant byte the strkey body leads with. */
+    private val bodyHex = "00$hashHex"
+
+    /** The hash behind the four-byte union discriminant, the spelling Horizon reports. */
+    private val paddedHex = "00000000$hashHex"
+
+    /** Every spelling of the one balance, the strkey and a case variant among them. */
+    private val spellings = listOf(strKey, hashHex, bodyHex, paddedHex, hashHex.uppercase())
+
+    private val spellingMessage =
+        "claimable balance id must be a 58 character strkey (B...), or hex of the bare id " +
+            "(64 characters), which a discriminant may prefix to 66 or 72 characters; "
+
+    @Test
+    fun testEverySpellingNamesOneBalance() {
+        for (spelling in spellings) {
+            val resolved = ClaimableBalanceId.forId(spelling)
+            assertEquals(hashHex, resolved.hashHex, "spelling: $spelling")
+            assertEquals(paddedHex, resolved.toPaddedHex(), "spelling: $spelling")
+            assertEquals(strKey, resolved.toStrKey(), "spelling: $spelling")
+            assertEquals(ClaimableBalanceId.forId(strKey), resolved, "spelling: $spelling")
+            assertEquals(
+                ClaimableBalanceId.forId(strKey).hashCode(), resolved.hashCode(),
+                "spelling: $spelling"
+            )
+        }
+    }
+
+    @Test
+    fun testHexIsReadInEitherCaseAndReportedInLowerCase() {
+        for (spelling in listOf(bodyHex.uppercase(), paddedHex.uppercase())) {
+            val resolved = ClaimableBalanceId.forId(spelling)
+            assertEquals(hashHex, resolved.hashHex, "spelling: $spelling")
+            assertEquals(paddedHex, resolved.toPaddedHex(), "spelling: $spelling")
+        }
+    }
+
+    @Test
+    fun testAStrKeyIsNotReadInLowerCase() {
+        // Hex reads in either case; a strkey does not. The lowercase form keeps its 58
+        // characters, so it is read as a strkey and rejected for its leading character.
+        val failure = assertFailsWith<IllegalArgumentException> {
+            ClaimableBalanceId.forId(strKey.lowercase())
+        }
+        assertEquals(
+            "a 58 character claimable balance id must be a strkey beginning with \"B\"",
+            failure.message
+        )
+    }
+
+    @Test
+    fun testTheIdRoundTripsThroughTheXdrUnion() {
+        val resolved = ClaimableBalanceId.forId(strKey)
+        val xdr = resolved.toXdr()
+        assertTrue(xdr is ClaimableBalanceIDXdr.V0, "the union declares one case")
+        assertEquals(
+            hashHex,
+            xdr.value.value.joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') },
+            "the union must carry the balance hash"
+        )
+        assertEquals(resolved, ClaimableBalanceId.fromXdr(xdr))
+        assertEquals(strKey, ClaimableBalanceId.fromXdr(xdr).toStrKey())
+    }
+
+    @Test
+    fun testTheXdrUnionIsReadWhicheverSpellingBuiltIt() {
+        for (spelling in spellings) {
+            assertEquals(
+                paddedHex,
+                ClaimableBalanceId.fromXdr(ClaimableBalanceId.forId(spelling).toXdr()).toPaddedHex(),
+                "spelling: $spelling"
+            )
+        }
+    }
+
+    @Test
+    fun testAnIdAsLongAsAStrKeyMustBeOne() {
+        // 58 characters is a length no hexadecimal spelling has, so a string of that length is
+        // read as a strkey and as nothing else, whatever alphabet its characters belong to.
+        val notAStrKey = "A" + strKey.drop(1)
+        val failure = assertFailsWith<IllegalArgumentException> {
+            ClaimableBalanceId.forId(notAStrKey)
+        }
+        assertEquals(
+            "a 58 character claimable balance id must be a strkey beginning with \"B\"",
+            failure.message
+        )
+    }
+
+    @Test
+    fun testAMalformedStrKeyIsRejected() {
+        // The last character carries part of the checksum. "Q" leaves the unused trailing bits
+        // zero as "U" does, so the checksum is the check that rejects the result.
+        val broken = strKey.dropLast(1) + "Q"
+        val failure = assertFailsWith<IllegalArgumentException> {
+            ClaimableBalanceId.forId(broken)
+        }
+        assertEquals("Checksum invalid", failure.message)
+    }
+
+    @Test
+    fun testALengthNoSpellingHasIsRejected() {
+        // The 63-character id below has a length no spelling has. Around it sit the lengths
+        // one character either side of each accepted shape, which a resolver that padded or
+        // truncated would take.
+        val candidates = listOf(
+            "",
+            "BAAAAAAAJXMXZMNAXINW4GQYRNE55L523HRUZAHCO7BXEX4BLR2XYLIF3X7IL2Y",
+            hashHex.dropLast(1),
+            hashHex + "0",
+            bodyHex + "0",
+            paddedHex.dropLast(1),
+            paddedHex + "0"
+        )
+        for (candidate in candidates) {
+            val failure = assertFailsWith<IllegalArgumentException>(
+                "${candidate.length} characters must be rejected"
+            ) {
+                ClaimableBalanceId.forId(candidate)
+            }
+            assertEquals(
+                spellingMessage + "${candidate.length} characters given",
+                failure.message,
+                "${candidate.length} characters: the rejection must name the accepted shapes"
+            )
+        }
+    }
+
+    @Test
+    fun testAnIdThatIsNotHexadecimalIsRejected() {
+        for (candidate in listOf("z".repeat(64), "g".repeat(66), " ".repeat(72))) {
+            val failure = assertFailsWith<IllegalArgumentException>(
+                "${candidate.length} non-hexadecimal characters must be rejected"
+            ) {
+                ClaimableBalanceId.forId(candidate)
+            }
+            assertEquals(
+                "claimable balance id \"$candidate\" is not hexadecimal",
+                failure.message,
+                "${candidate.length} characters: the rejection must name the rule broken"
+            )
+        }
+    }
+
+    @Test
+    fun testAStrKeyBodyDiscriminantTheUnionDoesNotDeclareIsRejected() {
+        for ((prefix, carried) in mapOf("01" to "0x1", "ff" to "0xff")) {
+            val failure = assertFailsWith<IllegalArgumentException>(
+                "the body prefixed $prefix must be rejected"
+            ) {
+                ClaimableBalanceId.forId(prefix + hashHex)
+            }
+            assertEquals(
+                "claimable balance id carries the discriminant $carried, " +
+                    "which names no claimable balance id type",
+                failure.message,
+                "the body prefixed $prefix: the rejection must name the rule broken"
+            )
+        }
+    }
+
+    @Test
+    fun testAnXdrDiscriminantTheUnionDoesNotDeclareIsRejected() {
+        // The first three carry a value only in the bytes above the last one, which a resolver
+        // that judged the last byte alone would let through as the balance the low byte spells.
+        val carriedByPrefix = mapOf(
+            "01000000" to "0x1000000",
+            "00010000" to "0x10000",
+            "00000100" to "0x100",
+            "00000001" to "0x1",
+            "ffffffff" to "0xffffffff"
+        )
+        for ((prefix, carried) in carriedByPrefix) {
+            val failure = assertFailsWith<IllegalArgumentException>(
+                "the XDR form prefixed $prefix must be rejected"
+            ) {
+                ClaimableBalanceId.forId(prefix + hashHex)
+            }
+            assertEquals(
+                "claimable balance id carries the discriminant $carried, " +
+                    "which names no claimable balance id type",
+                failure.message,
+                "the XDR form prefixed $prefix: the rejection must name the rule broken"
+            )
+        }
+    }
+
+    @Test
+    fun testAnIdOfAllZerosResolves() {
+        // A hash of zeros is indistinguishable from padding, so it is the case that shows the
+        // discriminant width, not the leading zeros, decides where the hash begins.
+        val zeroHash = "0".repeat(64)
+        val fromHash = ClaimableBalanceId.forId(zeroHash)
+        assertEquals(zeroHash, fromHash.hashHex)
+        assertEquals("0".repeat(72), fromHash.toPaddedHex())
+        assertEquals(fromHash, ClaimableBalanceId.forId("0".repeat(72)))
+        assertEquals(fromHash, ClaimableBalanceId.forId("0".repeat(66)))
+        assertEquals(fromHash, ClaimableBalanceId.forId(fromHash.toStrKey()))
+    }
+
+    @Test
+    fun testDifferentBalancesAreNotEqual() {
+        val other = ClaimableBalanceId.forId(
+            "f5ea7fb3de18dae9f12af96cf0750749016fbcba6bf09e902a69e54568771d82"
+        )
+        assertTrue(ClaimableBalanceId.forId(strKey) != other)
+        assertEquals(
+            "ClaimableBalanceId($hashHex)",
+            ClaimableBalanceId.forId(strKey).toString()
+        )
+    }
+
+    @Test
+    fun testTheUnionIsReadWhateverBytesItCarries() {
+        val zeros = ClaimableBalanceId.fromXdr(ClaimableBalanceIDXdr.V0(HashXdr(ByteArray(32))))
+        assertEquals("0".repeat(64), zeros.hashHex)
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/ClaimableBalanceIdTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/ClaimableBalanceIdTest.kt
@@ -13,19 +13,11 @@ import kotlin.test.assertTrue
  */
 class ClaimableBalanceIdTest {
 
-    /** The 32-byte balance hash the vectors are built around. */
-    private val hashHex = "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
-
-    private val strKey = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
-
-    /** The hash behind the single discriminant byte the strkey body leads with. */
-    private val bodyHex = "00$hashHex"
-
-    /** The hash behind the four-byte union discriminant, the spelling Horizon reports. */
-    private val paddedHex = "00000000$hashHex"
-
-    /** Every spelling of the one balance, the strkey and a case variant among them. */
-    private val spellings = listOf(strKey, hashHex, bodyHex, paddedHex, hashHex.uppercase())
+    private val hashHex = ClaimableBalanceVectors.hashHex
+    private val strKey = ClaimableBalanceVectors.strKey
+    private val bodyHex = ClaimableBalanceVectors.bodyHex
+    private val paddedHex = ClaimableBalanceVectors.paddedHex
+    private val spellings = ClaimableBalanceVectors.spellings
 
     private val spellingMessage =
         "claimable balance id must be a 58 character strkey (B...), or hex of the bare id " +
@@ -160,6 +152,23 @@ class ClaimableBalanceIdTest {
                 "${candidate.length} characters: the rejection must name the rule broken"
             )
         }
+    }
+
+    @Test
+    fun testAStrKeyCarryingADiscriminantTheUnionDoesNotDeclareIsRejected() {
+        // The SEP-23 invalid vector below is the strkey of the same hash the valid vectors
+        // carry, written under the discriminant 1, at the length and version byte of a
+        // claimable balance id. The pinned message shows the discriminant check is what
+        // rejects it.
+        val nonV0 = "BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA"
+        val failure = assertFailsWith<IllegalArgumentException> {
+            ClaimableBalanceId.forId(nonV0)
+        }
+        assertEquals(
+            "Invalid claimable balance discriminant, expected 0, got 1",
+            failure.message,
+            "the rejection must name the rule broken"
+        )
     }
 
     @Test

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/ClaimableBalanceIdTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/ClaimableBalanceIdTest.kt
@@ -6,6 +6,7 @@ import com.soneso.stellar.sdk.xdr.HashXdr
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 /**
@@ -96,6 +97,24 @@ class ClaimableBalanceIdTest {
         assertEquals(
             "a 58 character claimable balance id must be a strkey beginning with \"B\"",
             failure.message
+        )
+    }
+
+    @Test
+    fun testOneBalanceIsEqualToItselfAndToNoOtherValue() {
+        val resolved = ClaimableBalanceId.forId(strKey)
+
+        assertEquals(resolved, resolved, "a balance must be equal to itself")
+        assertEquals(ClaimableBalanceId.forId(hashHex), resolved, "the same balance, resolved twice")
+        // The balance is the left operand of each comparison, so it is its own equals that runs.
+        assertNotEquals<Any?>(resolved, hashHex, "a balance names no string")
+        assertNotEquals<Any?>(resolved, null, "a balance names nothing absent")
+
+        // A second balance, one hash byte apart from the first.
+        val otherHashHex = hashHex.dropLast(1) + if (hashHex.last() == '0') "1" else "0"
+        assertNotEquals(
+            ClaimableBalanceId.forId(otherHashHex), resolved,
+            "two hashes name two balances"
         )
     }
 

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/ClaimableBalanceVectors.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/ClaimableBalanceVectors.kt
@@ -1,0 +1,30 @@
+package com.soneso.stellar.sdk.unitTests
+
+/**
+ * The one claimable balance the spelling tests are written around, in every spelling that names
+ * it and in spellings that name none.
+ */
+internal object ClaimableBalanceVectors {
+
+    /** The 32-byte hash SEP-0023 builds its strkey vectors on, and the balance these name. */
+    const val hashHex = "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
+
+    /** That balance as a claimable balance id: the SEP-0023 valid vector for the type. */
+    const val strKey = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+
+    /** The hash behind the single discriminant byte the strkey body leads with. */
+    const val bodyHex = "00$hashHex"
+
+    /** The hash behind the four-byte union discriminant, the spelling Horizon reports. */
+    const val paddedHex = "00000000$hashHex"
+
+    /** Every spelling of the one balance, the strkey and a case variant among them. */
+    val spellings = listOf(strKey, hashHex, bodyHex, paddedHex, hashHex.uppercase())
+
+    /**
+     * Ids naming no balance: a discriminant the union does not declare, in the strkey body width
+     * and in the XDR width where it sits above the last byte, and hexadecimal the alphabet does
+     * not contain.
+     */
+    val rejections = listOf("01$hashHex", "01000000$hashHex", "z".repeat(72))
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/MemoTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/MemoTest.kt
@@ -212,6 +212,23 @@ class MemoTest {
     }
 
     @Test
+    fun testMemoHashRejectsNonHexCharacters() {
+        // 64 characters of sign pairs satisfy the length check, so only the hex alphabet
+        // gate stops them from decoding to a 32-byte hash the caller never supplied.
+        val exception = assertFailsWith<IllegalArgumentException> {
+            MemoHash("-1".repeat(32))
+        }
+        assertTrue(
+            exception.message?.contains("0-9 and a-f") ?: false,
+            "Unexpected message: ${exception.message}"
+        )
+
+        assertFailsWith<IllegalArgumentException> { MemoHash("+1".repeat(32)) }
+        assertFailsWith<IllegalArgumentException> { MemoHash("١".repeat(64)) }
+        assertFailsWith<IllegalArgumentException> { MemoHash("１".repeat(64)) }
+    }
+
+    @Test
     fun testMemoHashEquality() {
         val hash = ByteArray(32) { it.toByte() }
         val memo1 = MemoHash(hash)
@@ -283,6 +300,20 @@ class MemoTest {
         assertFailsWith<IllegalArgumentException> {
             MemoReturn(hexString63Chars)
         }
+    }
+
+    @Test
+    fun testMemoReturnRejectsNonHexCharacters() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            MemoReturn("-1".repeat(32))
+        }
+        assertTrue(
+            exception.message?.contains("0-9 and a-f") ?: false,
+            "Unexpected message: ${exception.message}"
+        )
+
+        assertFailsWith<IllegalArgumentException> { MemoReturn("+1".repeat(32)) }
+        assertFailsWith<IllegalArgumentException> { MemoReturn("１".repeat(64)) }
     }
 
     @Test

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/MuxedAccountTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/MuxedAccountTest.kt
@@ -177,6 +177,21 @@ class MuxedAccountTest {
     }
 
     @Test
+    fun testAMultiplexingIdOfZeroIsWrittenAsAMuxedAddress() {
+        // Zero is a multiplexing id like any other, so SEP-23 writes it as an M... address and
+        // reads it back as the id it is. Only an account that carries no id at all is written
+        // as the G... address.
+        val muxed = MuxedAccount(accountId, 0UL)
+
+        assertTrue(muxed.address.startsWith("M"))
+        assertEquals(
+            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ",
+            muxed.address
+        )
+        assertEquals(0UL, MuxedAccount(muxed.address).id)
+    }
+
+    @Test
     fun testDifferentAccountIds() {
         val accountId2 = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ"
 

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/OperationHexIdValidationTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/OperationHexIdValidationTest.kt
@@ -1,0 +1,172 @@
+package com.soneso.stellar.sdk.unitTests
+
+import com.soneso.stellar.sdk.*
+import com.soneso.stellar.sdk.xdr.*
+import kotlin.test.*
+
+/**
+ * Tests the hex alphabet gate on the operation builders that take hex-encoded ids.
+ *
+ * Every id here is the right length, so the length checks pass it through and only the
+ * hex alphabet gate stands between the caller's string and a byte array that does not
+ * correspond to it.
+ */
+class OperationHexIdValidationTest {
+
+    companion object {
+        const val ACCOUNT_ID = "GADBBY4WFXKKFJ7CMTG3J5YAUXMQDBILRQ6W3U5IWN5TQFZU4MWZ5T4K"
+
+        /** 64 characters of "-1" pairs: a radix parse reads each pair as -1 and truncates to 0xff. */
+        const val NEGATIVE_SIGN_ID = "-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1-1"
+
+        /** 64 characters of "+1" pairs: a radix parse reads each pair as 1. */
+        const val POSITIVE_SIGN_ID = "+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1"
+
+        /** 64 fullwidth digits: Unicode decimal digits a radix parse accepts, case folding keeps them fullwidth. */
+        val FULLWIDTH_ID = "１".repeat(64)
+
+        /** 64 Arabic-Indic digits: Unicode decimal digits a radix parse accepts. */
+        val ARABIC_INDIC_ID = "١".repeat(64)
+    }
+
+    // ========== LiquidityPoolDeposit ==========
+
+    @Test
+    fun testLiquidityPoolDepositRejectsSignedPoolId() {
+        val op = LiquidityPoolDepositOperation(
+            liquidityPoolId = NEGATIVE_SIGN_ID,
+            maxAmountA = "100.0000000",
+            maxAmountB = "200.0000000",
+            minPrice = Price(1, 2),
+            maxPrice = Price(2, 1)
+        )
+        val exception = assertFailsWith<IllegalArgumentException> { op.toOperationBody() }
+        assertTrue(
+            exception.message?.contains("0-9 and a-f") ?: false,
+            "Unexpected message: ${exception.message}"
+        )
+    }
+
+    @Test
+    fun testLiquidityPoolDepositRejectsUnicodeDigitPoolId() {
+        val fullwidth = LiquidityPoolDepositOperation(
+            liquidityPoolId = FULLWIDTH_ID,
+            maxAmountA = "1.0000000",
+            maxAmountB = "1.0000000",
+            minPrice = Price(1, 1),
+            maxPrice = Price(1, 1)
+        )
+        assertFailsWith<IllegalArgumentException> { fullwidth.toOperationBody() }
+
+        val arabicIndic = LiquidityPoolDepositOperation(
+            liquidityPoolId = ARABIC_INDIC_ID,
+            maxAmountA = "1.0000000",
+            maxAmountB = "1.0000000",
+            minPrice = Price(1, 1),
+            maxPrice = Price(1, 1)
+        )
+        assertFailsWith<IllegalArgumentException> { arabicIndic.toOperationBody() }
+    }
+
+    @Test
+    fun testLiquidityPoolDepositAcceptsMixedCasePoolId() {
+        val poolId = "0A1b2C3d4E5f6789AbCdEf0123456789abcdef0123456789ABCDEF0123456789"
+        val op = LiquidityPoolDepositOperation(
+            liquidityPoolId = poolId,
+            maxAmountA = "100.0000000",
+            maxAmountB = "200.0000000",
+            minPrice = Price(1, 2),
+            maxPrice = Price(2, 1)
+        )
+        val body = op.toOperationBody()
+        assertIs<OperationBodyXdr.LiquidityPoolDepositOp>(body)
+        assertContentEquals(
+            Util.hexToBytes(poolId.lowercase()),
+            body.value.liquidityPoolId.value.value
+        )
+    }
+
+    // ========== LiquidityPoolWithdraw ==========
+
+    @Test
+    fun testLiquidityPoolWithdrawRejectsSignedPoolId() {
+        val op = LiquidityPoolWithdrawOperation(
+            liquidityPoolId = POSITIVE_SIGN_ID,
+            amount = "100.0000000",
+            minAmountA = "1.0000000",
+            minAmountB = "1.0000000"
+        )
+        val exception = assertFailsWith<IllegalArgumentException> { op.toOperationBody() }
+        assertTrue(
+            exception.message?.contains("0-9 and a-f") ?: false,
+            "Unexpected message: ${exception.message}"
+        )
+    }
+
+    @Test
+    fun testLiquidityPoolWithdrawAcceptsMixedCasePoolId() {
+        val poolId = "0A1b2C3d4E5f6789AbCdEf0123456789abcdef0123456789ABCDEF0123456789"
+        val op = LiquidityPoolWithdrawOperation(
+            liquidityPoolId = poolId,
+            amount = "100.0000000",
+            minAmountA = "1.0000000",
+            minAmountB = "1.0000000"
+        )
+        val body = op.toOperationBody()
+        assertIs<OperationBodyXdr.LiquidityPoolWithdrawOp>(body)
+        assertContentEquals(
+            Util.hexToBytes(poolId.lowercase()),
+            body.value.liquidityPoolId.value.value
+        )
+    }
+
+    // ========== InvokeHostFunctionOperation.createContract ==========
+
+    @Test
+    fun testCreateContractRejectsSignedWasmId() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            InvokeHostFunctionOperation.createContract(
+                wasmId = NEGATIVE_SIGN_ID,
+                address = Address(ACCOUNT_ID),
+                salt = ByteArray(32)
+            )
+        }
+        assertTrue(
+            exception.message?.contains("0-9 and a-f") ?: false,
+            "Unexpected message: ${exception.message}"
+        )
+    }
+
+    @Test
+    fun testCreateContractRejectsUnicodeDigitWasmId() {
+        assertFailsWith<IllegalArgumentException> {
+            InvokeHostFunctionOperation.createContract(
+                wasmId = FULLWIDTH_ID,
+                address = Address(ACCOUNT_ID),
+                salt = ByteArray(32)
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            InvokeHostFunctionOperation.createContract(
+                wasmId = ARABIC_INDIC_ID,
+                address = Address(ACCOUNT_ID),
+                salt = ByteArray(32)
+            )
+        }
+    }
+
+    @Test
+    fun testCreateContractAcceptsMixedCaseWasmId() {
+        val wasmId = "0A1b2C3d4E5f6789AbCdEf0123456789abcdef0123456789ABCDEF0123456789"
+        val op = InvokeHostFunctionOperation.createContract(
+            wasmId = wasmId,
+            address = Address(ACCOUNT_ID),
+            salt = ByteArray(32)
+        )
+        val hostFunction = op.hostFunction
+        assertIs<HostFunctionXdr.CreateContract>(hostFunction)
+        val executable = hostFunction.value.executable
+        assertIs<ContractExecutableXdr.WasmHash>(executable)
+        assertContentEquals(Util.hexToBytes(wasmId.lowercase()), executable.value.value)
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/OperationsXdrRoundtripTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/OperationsXdrRoundtripTest.kt
@@ -19,6 +19,44 @@ class OperationsXdrRoundtripTest {
         val ASSET_EUR = AssetTypeCreditAlphaNum4("EUR", ACCOUNT_B)
         val ASSET_LONG = AssetTypeCreditAlphaNum12("LONGASSET", ACCOUNT_A)
         val MUXED_B: String = MuxedAccount(ACCOUNT_B, 42UL).address
+
+        /** The 32-byte hash of the claimable balance the spelling vectors name. */
+        const val BALANCE_HASH_HEX =
+            "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
+
+        /** That balance in the spelling Horizon reports and the operations report back. */
+        const val BALANCE_PADDED_HEX = "00000000$BALANCE_HASH_HEX"
+
+        /** Every spelling of the one balance, the strkey and a case variant among them. */
+        val BALANCE_SPELLINGS = listOf(
+            "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU",
+            BALANCE_HASH_HEX,
+            "00$BALANCE_HASH_HEX",
+            BALANCE_PADDED_HEX,
+            BALANCE_HASH_HEX.uppercase()
+        )
+
+        /**
+         * Ids naming no claimable balance: lengths no spelling has, a discriminant the union
+         * does not declare in either width (among them an XDR form carrying its value only in
+         * the bytes above the last one), and hexadecimal the alphabet does not contain.
+         */
+        val BALANCE_REJECTIONS = listOf(
+            "abc",
+            BALANCE_HASH_HEX.dropLast(1),
+            BALANCE_PADDED_HEX + "0",
+            "01$BALANCE_HASH_HEX",
+            "01000000$BALANCE_HASH_HEX",
+            "00000001$BALANCE_HASH_HEX",
+            "z".repeat(72)
+        )
+
+        /** The XDR bytes [body] encodes to, which is what equivalent spellings must share. */
+        fun encodedBody(body: OperationBodyXdr): ByteArray {
+            val writer = XdrWriter()
+            body.encode(writer)
+            return writer.toByteArray()
+        }
     }
 
     // ========== CreateAccountOperation ==========
@@ -725,9 +763,51 @@ class OperationsXdrRoundtripTest {
     }
 
     @Test
-    fun testClaimClaimableBalanceInvalidLength() {
-        assertFailsWith<IllegalArgumentException> {
-            ClaimClaimableBalanceOperation("abc")
+    fun testClaimClaimableBalanceAcceptsEverySpelling() {
+        val canonical = ClaimClaimableBalanceOperation(BALANCE_PADDED_HEX).toOperationBody()
+        for (spelling in BALANCE_SPELLINGS) {
+            val op = ClaimClaimableBalanceOperation(spelling)
+            assertTrue(
+                encodedBody(op.toOperationBody()).contentEquals(encodedBody(canonical)),
+                "spelling $spelling must reach the wire as the same bytes"
+            )
+            val restored = when (val xdr = op.toOperationBody()) {
+                is OperationBodyXdr.ClaimClaimableBalanceOp ->
+                    ClaimClaimableBalanceOperation.fromXdr(xdr.value)
+                else -> fail("Wrong XDR type")
+            }
+            assertEquals(
+                BALANCE_PADDED_HEX, restored.balanceId,
+                "spelling $spelling must be reported in one form"
+            )
+        }
+    }
+
+    @Test
+    fun testClaimClaimableBalanceRejectsAnIdNamingNoBalance() {
+        for (candidate in BALANCE_REJECTIONS) {
+            val resolver = assertFailsWith<IllegalArgumentException>(
+                "\"$candidate\" must name no balance"
+            ) { ClaimableBalanceId.forId(candidate) }
+            val failure = assertFailsWith<IllegalArgumentException>("\"$candidate\" must be rejected") {
+                ClaimClaimableBalanceOperation(candidate)
+            }
+            assertEquals(
+                resolver.message, failure.message,
+                "\"$candidate\": the operation must reject as the resolver does"
+            )
+        }
+    }
+
+    @Test
+    fun testClaimClaimableBalanceCopyJudgesTheNewId() {
+        // copy() runs the primary constructor, so an id put in this way is held to the same
+        // rules as one given at construction.
+        val op = ClaimClaimableBalanceOperation(BALANCE_PADDED_HEX)
+        for (candidate in BALANCE_REJECTIONS) {
+            assertFailsWith<IllegalArgumentException>("copy to \"$candidate\" must be rejected") {
+                op.copy(balanceId = candidate)
+            }
         }
     }
 
@@ -742,6 +822,53 @@ class OperationsXdrRoundtripTest {
             else -> fail("Wrong XDR type")
         }
         assertEquals(balanceId, restored.balanceId)
+    }
+
+    @Test
+    fun testClawbackClaimableBalanceAcceptsEverySpelling() {
+        val canonical = ClawbackClaimableBalanceOperation(BALANCE_PADDED_HEX).toOperationBody()
+        for (spelling in BALANCE_SPELLINGS) {
+            val op = ClawbackClaimableBalanceOperation(spelling)
+            assertTrue(
+                encodedBody(op.toOperationBody()).contentEquals(encodedBody(canonical)),
+                "spelling $spelling must reach the wire as the same bytes"
+            )
+            val restored = when (val xdr = op.toOperationBody()) {
+                is OperationBodyXdr.ClawbackClaimableBalanceOp ->
+                    ClawbackClaimableBalanceOperation.fromXdr(xdr.value)
+                else -> fail("Wrong XDR type")
+            }
+            assertEquals(
+                BALANCE_PADDED_HEX, restored.balanceId,
+                "spelling $spelling must be reported in one form"
+            )
+        }
+    }
+
+    @Test
+    fun testClawbackClaimableBalanceRejectsAnIdNamingNoBalance() {
+        for (candidate in BALANCE_REJECTIONS) {
+            val resolver = assertFailsWith<IllegalArgumentException>(
+                "\"$candidate\" must name no balance"
+            ) { ClaimableBalanceId.forId(candidate) }
+            val failure = assertFailsWith<IllegalArgumentException>("\"$candidate\" must be rejected") {
+                ClawbackClaimableBalanceOperation(candidate)
+            }
+            assertEquals(
+                resolver.message, failure.message,
+                "\"$candidate\": the operation must reject as the resolver does"
+            )
+        }
+    }
+
+    @Test
+    fun testClawbackClaimableBalanceCopyJudgesTheNewId() {
+        val op = ClawbackClaimableBalanceOperation(BALANCE_PADDED_HEX)
+        for (candidate in BALANCE_REJECTIONS) {
+            assertFailsWith<IllegalArgumentException>("copy to \"$candidate\" must be rejected") {
+                op.copy(balanceId = candidate)
+            }
+        }
     }
 
     // ========== Clawback ==========
@@ -963,7 +1090,62 @@ class OperationsXdrRoundtripTest {
             is OperationBodyXdr.RevokeSponsorshipOp -> RevokeSponsorshipOperation.fromXdr(xdr.value)
             else -> fail("Wrong XDR type")
         }
-        assertTrue(restored.sponsorship is Sponsorship.ClaimableBalance)
+        val sponsorship = restored.sponsorship
+        assertTrue(sponsorship is Sponsorship.ClaimableBalance)
+        assertEquals("00000000" + hash, sponsorship.balanceId)
+    }
+
+    @Test
+    fun testRevokeSponsorshipClaimableBalanceAcceptsEverySpelling() {
+        val canonical =
+            RevokeSponsorshipOperation(Sponsorship.ClaimableBalance(BALANCE_PADDED_HEX))
+                .toOperationBody()
+        for (spelling in BALANCE_SPELLINGS) {
+            val op = RevokeSponsorshipOperation(Sponsorship.ClaimableBalance(spelling))
+            assertTrue(
+                encodedBody(op.toOperationBody()).contentEquals(encodedBody(canonical)),
+                "spelling $spelling must reach the wire as the same bytes"
+            )
+            val restored = when (val xdr = op.toOperationBody()) {
+                is OperationBodyXdr.RevokeSponsorshipOp ->
+                    RevokeSponsorshipOperation.fromXdr(xdr.value)
+                else -> fail("Wrong XDR type")
+            }
+            val sponsorship = restored.sponsorship
+            assertTrue(sponsorship is Sponsorship.ClaimableBalance, "spelling: $spelling")
+            assertEquals(
+                BALANCE_PADDED_HEX, sponsorship.balanceId,
+                "spelling $spelling must be reported in one form"
+            )
+        }
+    }
+
+    @Test
+    fun testRevokeSponsorshipClaimableBalanceRejectsAnIdNamingNoBalance() {
+        // The rejection belongs where the id is given: a ledger key built from an id naming no
+        // balance would otherwise fail only once the transaction is built.
+        for (candidate in BALANCE_REJECTIONS) {
+            val resolver = assertFailsWith<IllegalArgumentException>(
+                "\"$candidate\" must name no balance"
+            ) { ClaimableBalanceId.forId(candidate) }
+            val failure = assertFailsWith<IllegalArgumentException>("\"$candidate\" must be rejected") {
+                Sponsorship.ClaimableBalance(candidate)
+            }
+            assertEquals(
+                resolver.message, failure.message,
+                "\"$candidate\": the sponsorship must reject as the resolver does"
+            )
+        }
+    }
+
+    @Test
+    fun testRevokeSponsorshipClaimableBalanceCopyJudgesTheNewId() {
+        val sponsorship = Sponsorship.ClaimableBalance(BALANCE_PADDED_HEX)
+        for (candidate in BALANCE_REJECTIONS) {
+            assertFailsWith<IllegalArgumentException>("copy to \"$candidate\" must be rejected") {
+                sponsorship.copy(balanceId = candidate)
+            }
+        }
     }
 
     @Test
@@ -1502,14 +1684,7 @@ class OperationsXdrRoundtripTest {
         val exception = assertFailsWith<IllegalArgumentException> {
             ClaimClaimableBalanceOperation(badHex)
         }
-        assertTrue(exception.message!!.contains("valid hex string"))
-    }
-
-    @Test
-    fun testClawbackClaimableBalanceInvalidLengthThrows() {
-        assertFailsWith<IllegalArgumentException> {
-            ClawbackClaimableBalanceOperation("abc")
-        }
+        assertEquals("claimable balance id \"$badHex\" is not hexadecimal", exception.message)
     }
 
     @Test
@@ -1518,7 +1693,7 @@ class OperationsXdrRoundtripTest {
         val exception = assertFailsWith<IllegalArgumentException> {
             ClawbackClaimableBalanceOperation(badHex)
         }
-        assertTrue(exception.message!!.contains("valid hex string"))
+        assertEquals("claimable balance id \"$badHex\" is not hexadecimal", exception.message)
     }
 
     // ========== Clawback source (from) address validation ==========

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/OperationsXdrRoundtripTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/OperationsXdrRoundtripTest.kt
@@ -20,36 +20,23 @@ class OperationsXdrRoundtripTest {
         val ASSET_LONG = AssetTypeCreditAlphaNum12("LONGASSET", ACCOUNT_A)
         val MUXED_B: String = MuxedAccount(ACCOUNT_B, 42UL).address
 
-        /** The 32-byte hash of the claimable balance the spelling vectors name. */
-        const val BALANCE_HASH_HEX =
-            "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
+        const val BALANCE_HASH_HEX = ClaimableBalanceVectors.hashHex
 
         /** That balance in the spelling Horizon reports and the operations report back. */
-        const val BALANCE_PADDED_HEX = "00000000$BALANCE_HASH_HEX"
+        const val BALANCE_PADDED_HEX = ClaimableBalanceVectors.paddedHex
 
-        /** Every spelling of the one balance, the strkey and a case variant among them. */
-        val BALANCE_SPELLINGS = listOf(
-            "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU",
-            BALANCE_HASH_HEX,
-            "00$BALANCE_HASH_HEX",
-            BALANCE_PADDED_HEX,
-            BALANCE_HASH_HEX.uppercase()
-        )
+        val BALANCE_SPELLINGS = ClaimableBalanceVectors.spellings
 
         /**
-         * Ids naming no claimable balance: lengths no spelling has, a discriminant the union
-         * does not declare in either width (among them an XDR form carrying its value only in
-         * the bytes above the last one), and hexadecimal the alphabet does not contain.
+         * Ids naming no claimable balance, beyond [ClaimableBalanceVectors.rejections]: lengths
+         * no spelling has, and an XDR form carrying its discriminant in the last byte.
          */
         val BALANCE_REJECTIONS = listOf(
             "abc",
             BALANCE_HASH_HEX.dropLast(1),
             BALANCE_PADDED_HEX + "0",
-            "01$BALANCE_HASH_HEX",
-            "01000000$BALANCE_HASH_HEX",
-            "00000001$BALANCE_HASH_HEX",
-            "z".repeat(72)
-        )
+            "00000001$BALANCE_HASH_HEX"
+        ) + ClaimableBalanceVectors.rejections
 
         /** The XDR bytes [body] encodes to, which is what equivalent spellings must share. */
         fun encodedBody(body: OperationBodyXdr): ByteArray {

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/SignerKeyTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/SignerKeyTest.kt
@@ -370,42 +370,149 @@ class SignerKeyTest {
 
     // ========== fromEncodedSignerKey: invalid embedded payload length ==========
 
+    /**
+     * Checks that [encoded] is refused as a signed payload for [rejection], the framing rule the
+     * case is written to exercise. [SignerKey.fromEncodedSignerKey] reports every input it cannot
+     * read in the same words, so without this the case would stand on a rejection that names no
+     * reason at all.
+     */
+    private fun assertSignedPayloadFramingRejection(encoded: String, rejection: String) {
+        assertFalse(StrKey.isValidSignedPayload(encoded))
+        val failure = assertFailsWith<IllegalArgumentException> {
+            StrKey.decodeSignedPayload(encoded)
+        }
+        assertEquals(rejection, failure.message, "the rejection must name the rule broken")
+    }
+
     @Test
     fun testFromEncodedSignerKeyInvalidPayloadLengthThrows() {
-        // Craft a signed-payload strkey whose embedded length field (bytes 32-35) does not
-        // describe a valid payload size (must be 1..64), while the overall byte count still
-        // satisfies StrKey's own 40-100 byte range so decoding succeeds up to that point.
-        val raw = ByteArray(40)
-        testPublicKey.copyInto(raw, 0)
-        // Length field = 0, which is outside the valid 1..64 range.
-        raw[32] = 0
-        raw[33] = 0
-        raw[34] = 0
-        raw[35] = 0
-
-        val encoded = StrKey.encodeSignedPayload(raw)
+        // A P... strkey carrying a 32-byte ed25519 public key, a declared payload length of 0 and
+        // four zero bytes. A signed payload declares at least one payload byte, so this string
+        // describes no signer key. It is written out in full because the encoder does not produce
+        // framing its own decoder rejects.
+        val encoded = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAABO6A"
+        assertSignedPayloadFramingRejection(
+            encoded,
+            "Invalid signed payload declared length, expected between 1 and 64 bytes, got 0"
+        )
 
         val exception = assertFailsWith<IllegalArgumentException> {
             SignerKey.fromEncodedSignerKey(encoded)
         }
-        assertTrue(exception.message!!.contains("Invalid payload length"))
+        assertEquals("Invalid encoded signer key: $encoded", exception.message)
     }
 
     @Test
     fun testFromEncodedSignerKeyPayloadLengthExceedsMaxThrows() {
-        val raw = ByteArray(40)
-        testPublicKey.copyInto(raw, 0)
-        // Length field = 1000, which exceeds SIGNED_PAYLOAD_MAX_PAYLOAD_LENGTH (64).
-        raw[32] = 0
-        raw[33] = 0
-        raw[34] = 0x03
-        raw[35] = 0xE8.toByte()
-
-        val encoded = StrKey.encodeSignedPayload(raw)
+        // The same framing declaring 1000 payload bytes, which exceeds the 64 a signed payload
+        // can carry and the 40 bytes this strkey holds.
+        val encoded = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAPUAAAAAACOBO"
+        assertSignedPayloadFramingRejection(
+            encoded,
+            "Invalid signed payload declared length, expected between 1 and 64 bytes, got 1000"
+        )
 
         val exception = assertFailsWith<IllegalArgumentException> {
             SignerKey.fromEncodedSignerKey(encoded)
         }
-        assertTrue(exception.message!!.contains("Invalid payload length"))
+        assertEquals("Invalid encoded signer key: $encoded", exception.message)
+    }
+
+    @Test
+    fun testFromEncodedSignerKeyDeclaredLengthLongerThanThePayloadPresentThrows() {
+        // A 32-byte ed25519 public key, a declared payload length of 64 and four payload bytes.
+        // The declared length is one a signed payload can carry, but these 40 bytes do not carry
+        // it, so the payload the length names ends past the end of the decoded bytes.
+        val encoded = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAQ3PY"
+        assertSignedPayloadFramingRejection(
+            encoded,
+            "Invalid signed payload size, a declared length of 64 requires 100 bytes, got 40"
+        )
+
+        val failure = signerKeyRejection(encoded)
+        assertEquals("Invalid encoded signer key: $encoded", failure.message)
+    }
+
+    @Test
+    fun testFromEncodedSignerKeyReEmitsEveryPayloadLengthUnchanged() {
+        for (payloadLength in 1..SignerKey.SIGNED_PAYLOAD_MAX_PAYLOAD_LENGTH) {
+            val payload = ByteArray(payloadLength) { (it + 1).toByte() }
+            val encoded = SignerKey.ed25519SignedPayload(testPublicKey, payload).encodeSignerKey()
+
+            val decoded = assertIs<SignerKey.Ed25519SignedPayload>(
+                SignerKey.fromEncodedSignerKey(encoded),
+                "payload length $payloadLength: must decode to a signed payload signer"
+            )
+            assertTrue(
+                testPublicKey.contentEquals(decoded.ed25519PublicKey),
+                "payload length $payloadLength: public key"
+            )
+            assertTrue(
+                payload.contentEquals(decoded.payload),
+                "payload length $payloadLength: payload"
+            )
+            assertEquals(
+                encoded, decoded.encodeSignerKey(),
+                "payload length $payloadLength: the re-emitted strkey must be the one decoded"
+            )
+        }
+    }
+
+    @Test
+    fun testFromEncodedSignerKeyRejectsMalformedInputWithoutReadingPastTheDecodedBytes() {
+        val malformed = listOf(
+            // Nothing to decode, and a single character that names a type but carries no key.
+            "",
+            "P",
+            // The three SEP-0023 invalid signed payload vectors: a declared length shorter than
+            // the payload present, one longer than the payload present, and a payload written
+            // without the padding that fills it to a four-byte boundary.
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IAAAAAAAAPM",
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4Z2PQ",
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DXFH6",
+            // A declared length of 0, one of 64 inside 40 bytes, and 29 payload bytes followed by
+            // padding of 0xff.
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAABO6A",
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAQ3PY",
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DX77776K34",
+            // A signed payload strkey cut short, and one carrying a character the base32 alphabet
+            // does not hold.
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAQ",
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAq3PY",
+            // A valid account id with pad characters appended, and a string of pad characters
+            // alone: a strkey is written without padding, so neither is one.
+            "$validAccountId========",
+            "========"
+        )
+
+        for (candidate in malformed) {
+            val failure = signerKeyRejection(candidate)
+            assertEquals(
+                "Invalid encoded signer key: $candidate", failure.message,
+                "the rejection must name the input it refused"
+            )
+        }
+    }
+
+    /**
+     * The failure [SignerKey.fromEncodedSignerKey] raises for [encoded], having checked that it is
+     * the [IllegalArgumentException] the contract documents. A declared payload length the decoded
+     * bytes do not carry is the input that could instead surface as an out-of-bounds read, so that
+     * case is named on its own and a regression in it reports what broke.
+     */
+    private fun signerKeyRejection(encoded: String): IllegalArgumentException {
+        val failure = assertFails { SignerKey.fromEncodedSignerKey(encoded) }
+        assertFalse(
+            failure is IndexOutOfBoundsException,
+            "reading past the end of the decoded bytes escaped for \"$encoded\""
+        )
+        return assertIs<IllegalArgumentException>(
+            failure,
+            "the rejection must be the exception type the contract documents"
+        )
     }
 }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/SignerKeyTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/SignerKeyTest.kt
@@ -454,6 +454,9 @@ class SignerKeyTest {
             // A signed payload strkey cut short: fewer characters than the shortest signed
             // payload has, so it describes no signer key rather than a malformed one.
             "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAQ",
+            // A signed payload strkey run past its end: more characters than the longest signed
+            // payload has, so it describes no signer key rather than a malformed one.
+            "P" + "A".repeat(200),
             // A valid account id with pad characters appended, and a string of pad characters
             // alone: a strkey is written without padding, so neither is one.
             "$validAccountId========",

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/SignerKeyTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/SignerKeyTest.kt
@@ -372,9 +372,8 @@ class SignerKeyTest {
 
     /**
      * Checks that [encoded] is refused as a signed payload for [rejection], the framing rule the
-     * case is written to exercise. [SignerKey.fromEncodedSignerKey] reports every input it cannot
-     * read in the same words, so without this the case would stand on a rejection that names no
-     * reason at all.
+     * case is written to exercise, both by the codec and by [SignerKey.fromEncodedSignerKey],
+     * which reports the rule rather than the refusal it gives a string it cannot place at all.
      */
     private fun assertSignedPayloadFramingRejection(encoded: String, rejection: String) {
         assertFalse(StrKey.isValidSignedPayload(encoded))
@@ -382,6 +381,10 @@ class SignerKeyTest {
             StrKey.decodeSignedPayload(encoded)
         }
         assertEquals(rejection, failure.message, "the rejection must name the rule broken")
+        assertEquals(
+            rejection, signerKeyRejection(encoded).message,
+            "the signer key rejection must name the rule broken"
+        )
     }
 
     @Test
@@ -390,32 +393,20 @@ class SignerKeyTest {
         // four zero bytes. A signed payload declares at least one payload byte, so this string
         // describes no signer key. It is written out in full because the encoder does not produce
         // framing its own decoder rejects.
-        val encoded = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAABO6A"
         assertSignedPayloadFramingRejection(
-            encoded,
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAABO6A",
             "Invalid signed payload declared length, expected between 1 and 64 bytes, got 0"
         )
-
-        val exception = assertFailsWith<IllegalArgumentException> {
-            SignerKey.fromEncodedSignerKey(encoded)
-        }
-        assertEquals("Invalid encoded signer key: $encoded", exception.message)
     }
 
     @Test
     fun testFromEncodedSignerKeyPayloadLengthExceedsMaxThrows() {
         // The same framing declaring 1000 payload bytes, which exceeds the 64 a signed payload
         // can carry and the 40 bytes this strkey holds.
-        val encoded = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAPUAAAAAACOBO"
         assertSignedPayloadFramingRejection(
-            encoded,
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAPUAAAAAACOBO",
             "Invalid signed payload declared length, expected between 1 and 64 bytes, got 1000"
         )
-
-        val exception = assertFailsWith<IllegalArgumentException> {
-            SignerKey.fromEncodedSignerKey(encoded)
-        }
-        assertEquals("Invalid encoded signer key: $encoded", exception.message)
     }
 
     @Test
@@ -423,14 +414,10 @@ class SignerKeyTest {
         // A 32-byte ed25519 public key, a declared payload length of 64 and four payload bytes.
         // The declared length is one a signed payload can carry, but these 40 bytes do not carry
         // it, so the payload the length names ends past the end of the decoded bytes.
-        val encoded = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAQ3PY"
         assertSignedPayloadFramingRejection(
-            encoded,
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAQ3PY",
             "Invalid signed payload size, a declared length of 64 requires 100 bytes, got 40"
         )
-
-        val failure = signerKeyRejection(encoded)
-        assertEquals("Invalid encoded signer key: $encoded", failure.message)
     }
 
     @Test
@@ -459,41 +446,59 @@ class SignerKeyTest {
     }
 
     @Test
-    fun testFromEncodedSignerKeyRejectsMalformedInputWithoutReadingPastTheDecodedBytes() {
-        val malformed = listOf(
+    fun testFromEncodedSignerKeyNamesTheInputItCannotPlace() {
+        val unplaceable = listOf(
             // Nothing to decode, and a single character that names a type but carries no key.
             "",
             "P",
-            // The three SEP-0023 invalid signed payload vectors: a declared length shorter than
-            // the payload present, one longer than the payload present, and a payload written
-            // without the padding that fills it to a four-byte boundary.
-            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQ" +
-                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IAAAAAAAAPM",
-            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
-                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4Z2PQ",
-            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
-                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DXFH6",
-            // A declared length of 0, one of 64 inside 40 bytes, and 29 payload bytes followed by
-            // padding of 0xff.
-            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAABO6A",
-            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAQ3PY",
-            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
-                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DX77776K34",
-            // A signed payload strkey cut short, and one carrying a character the base32 alphabet
-            // does not hold.
+            // A signed payload strkey cut short: fewer characters than the shortest signed
+            // payload has, so it describes no signer key rather than a malformed one.
             "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAQ",
-            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAq3PY",
             // A valid account id with pad characters appended, and a string of pad characters
             // alone: a strkey is written without padding, so neither is one.
             "$validAccountId========",
             "========"
         )
 
-        for (candidate in malformed) {
+        for (candidate in unplaceable) {
             val failure = signerKeyRejection(candidate)
             assertEquals(
                 "Invalid encoded signer key: $candidate", failure.message,
                 "the rejection must name the input it refused"
+            )
+        }
+    }
+
+    @Test
+    fun testFromEncodedSignerKeyNamesTheRuleAMalformedSignedPayloadBroke() {
+        val rejections = mapOf(
+            // The three SEP-0023 invalid signed payload vectors: a declared length shorter than
+            // the payload present, one longer than the payload present, and a payload written
+            // without the padding that fills it to a four-byte boundary.
+            ("PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IAAAAAAAAPM") to
+                "Invalid signed payload size, a declared length of 32 requires 68 bytes, got 72",
+            ("PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4Z2PQ") to
+                "Invalid signed payload size, a declared length of 29 requires 68 bytes, got 64",
+            ("PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DXFH6") to
+                "Invalid signed payload size, a declared length of 29 requires 68 bytes, got 65",
+            // 29 payload bytes followed by padding of 0xff.
+            ("PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DX77776K34") to
+                "Invalid signed payload padding, expected zero at index 65 after a declared " +
+                "length of 29, got 255",
+            // A signed payload strkey carrying a character the base32 alphabet does not hold.
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAq3PY" to
+                "Invalid base32 encoded string"
+        )
+
+        for ((candidate, rejection) in rejections) {
+            val failure = signerKeyRejection(candidate)
+            assertEquals(
+                rejection, failure.message,
+                "the rejection must name the rule broken for \"$candidate\""
             )
         }
     }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/StrKeyTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/StrKeyTest.kt
@@ -302,6 +302,24 @@ class StrKeyTest {
         )
     }
 
+    /**
+     * Asserts that [candidate] is rejected with [rejection] by both [decode] and [isValid].
+     * [label] names the rule the candidate breaks; the strkeys here are too long to read.
+     */
+    private fun assertRejectedByRule(
+        label: String,
+        candidate: String,
+        rejection: String,
+        decode: (String) -> ByteArray,
+        isValid: (String) -> Boolean
+    ) {
+        val failure = assertFailsWith<IllegalArgumentException>("$label: must be rejected") {
+            decode(candidate)
+        }
+        assertEquals(rejection, failure.message, "$label: the rejection must name the rule broken")
+        assertFalse(isValid(candidate), "$label: isValid must agree with decode")
+    }
+
     // Test vectors for invalid public keys
     @Test
     fun testInvalidPublicKeys() {
@@ -653,7 +671,7 @@ class StrKeyTest {
     // that check.
 
     /** The 32-byte hash the SEP-0023 vectors are built around. */
-    private val sep23Hash = "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
+    private val sep23Hash = ClaimableBalanceVectors.hashHex
 
     private val sep23AccountId = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
 
@@ -682,7 +700,7 @@ class StrKeyTest {
 
     private val sep23LiquidityPoolId = "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN"
 
-    private val sep23ClaimableBalanceId = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+    private val sep23ClaimableBalanceId = ClaimableBalanceVectors.strKey
 
     private class Sep23ValidVector(
         val description: String,
@@ -788,7 +806,7 @@ class StrKeyTest {
             Sep23InvalidVector(
                 "the unused trailing bit of the last character must be zero",
                 trailingBitSet,
-                "Unused bits should be set to 0",
+                unusedBitsRejection,
                 m, mValid,
                 evidence = {
                     // Padding is a second way to write the same characters, and it must not turn
@@ -885,7 +903,7 @@ class StrKeyTest {
             Sep23InvalidVector(
                 "the unused trailing two bits of the last character must be zero",
                 "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TV",
-                "Unused bits should be set to 0",
+                unusedBitsRejection,
                 b, bValid
             ),
             Sep23InvalidVector(
@@ -1131,6 +1149,23 @@ class StrKeyTest {
             if (it == -1) encoded.size else it
         }
         return encoded.copyOfRange(0, unpaddedLength).map { it.toInt().toChar() }.joinToString("")
+    }
+
+    /**
+     * The data bytes [strKey] carries, having checked that its checksum matches and that it is
+     * written under [versionByte], the version byte of [type]. A vector that failed either check
+     * would be rejected for that rather than for what it is written to exercise.
+     */
+    private fun checkedData(strKey: String, versionByte: Byte, type: String): ByteArray {
+        val decoded = Base32Codec.decode(strKey.map { it.code.toByte() }.toByteArray())
+        val payload = decoded.copyOfRange(0, decoded.size - 2)
+        val checksum = decoded.copyOfRange(decoded.size - 2, decoded.size)
+        assertTrue(
+            crc16XModem(payload).contentEquals(checksum),
+            "the vector must carry a valid checksum"
+        )
+        assertEquals(versionByte, payload[0], "the vector must be $type")
+        return payload.copyOfRange(1, payload.size)
     }
 
     @Test
@@ -1498,43 +1533,19 @@ class StrKeyTest {
     // alphabet check rejects the pad character, whitespace and every other byte, and reports the
     // same verdict on every platform even though the codec behind it is platform-specific.
 
-    private fun assertRejectedForNonAlphabetCharacter(
-        label: String,
-        candidate: String,
-        check: String,
-        decode: (String) -> ByteArray,
-        isValid: (String) -> Boolean
-    ) {
-        val failure = assertFailsWith<IllegalArgumentException>("$label: must be rejected") {
-            decode(candidate)
-        }
-        assertEquals(
-            nonAlphabetCharacterRejection, failure.message,
-            "$label: rejected by a check other than $check"
-        )
-        assertFalse(isValid(candidate), "$label: isValid must agree with decode")
-    }
-
-    /**
-     * Asserts that [candidate] is turned away by the alphabet check, which every character it
-     * carries reaches: they are all inside the ASCII range, so the guard ahead of that check lets
-     * them through.
-     */
+    /** Asserts that [candidate], every character of which is ASCII, fails the alphabet check. */
     private fun assertRejectedByAlphabet(
         label: String,
         candidate: String,
         decode: (String) -> ByteArray,
         isValid: (String) -> Boolean
     ) {
-        assertRejectedForNonAlphabetCharacter(
-            label, candidate, "the base32 alphabet", decode, isValid
-        )
+        assertRejectedByRule(label, candidate, nonAlphabetCharacterRejection, decode, isValid)
     }
 
     /**
-     * Asserts that [candidate] is turned away by the guard that admits only characters inside the
-     * ASCII range. A character above that range is stopped there rather than by the alphabet
-     * check, because the guard runs ahead of the narrowing that every later check reads.
+     * Asserts that [candidate], which carries a character above the ASCII range, fails the guard
+     * on that range.
      */
     private fun assertRejectedByTheAsciiRangeGuard(
         label: String,
@@ -1542,9 +1553,7 @@ class StrKeyTest {
         decode: (String) -> ByteArray,
         isValid: (String) -> Boolean
     ) {
-        assertRejectedForNonAlphabetCharacter(
-            label, candidate, "the guard on the ASCII range", decode, isValid
-        )
+        assertRejectedByRule(label, candidate, nonAlphabetCharacterRejection, decode, isValid)
     }
 
     @Test
@@ -1593,13 +1602,21 @@ class StrKeyTest {
     @Test
     fun testDecodeRejectsLowercaseAlphabet() {
         // The base32 alphabet is uppercase. Lowercasing keeps the length, so the candidate gets
-        // past the encoded-length check. The last character is left as the vector had it: it is
-        // the one the unused-trailing-bits check reads, and that check runs first, so a lowercase
-        // character there would stop the candidate before it reached the alphabet.
+        // past the encoded-length check. Every character is lowercased, the last one included:
+        // the alphabet check runs ahead of the unused-trailing-bits check, so a string written
+        // in characters no strkey is written in is reported as that, whatever five-bit value a
+        // decoder would otherwise read from its last character.
         for (type in strKeyTypes()) {
-            val lowercased = type.valid.dropLast(1).lowercase() + type.valid.last()
+            val lowercased = type.valid.lowercase()
             assertEquals(type.valid.length, lowercased.length)
             assertNotEquals(type.valid, lowercased)
+            if ((type.valid.length * 5) % 8 > 0) {
+                assertNotEquals(
+                    type.valid.last(), lowercased.last(),
+                    "${type.name}: the vector must end in a letter, so that lowercasing leaves " +
+                        "the unused-trailing-bits check a character it cannot read"
+                )
+            }
             assertRejectedByAlphabet(
                 "${type.name} in lowercase", lowercased, type.decode, type.isValid
             )
@@ -1680,8 +1697,8 @@ class StrKeyTest {
     //
     // Every variant below lengthens the string, so for a type of one fixed encoded length the
     // check that reports it is the encoded-length check rather than the alphabet. For the signed
-    // payload, whose legal lengths form a range, the variant stays inside the range and the check
-    // its resulting length reaches is the one that reports it.
+    // payload, whose legal lengths form a range, the variant stays inside the range and is
+    // reported by the first check it fails.
 
     private class NonCanonicalVariant(
         val description: String,
@@ -1692,12 +1709,19 @@ class StrKeyTest {
 
     private fun nonCanonicalVariants(): List<NonCanonicalVariant> = listOf(
         NonCanonicalVariant("one pad character appended", { "$it=" }, leftoverCharacterRejection),
-        NonCanonicalVariant("three pad characters appended", { "$it===" }, unusedBitsRejection),
-        NonCanonicalVariant("a full pad group appended", { "$it========" }, unusedBitsRejection),
         NonCanonicalVariant(
-            "characters written after a pad character", { "$it=ZZZZZZZ" }, unusedBitsRejection
+            "three pad characters appended", { "$it===" }, nonAlphabetCharacterRejection
         ),
-        NonCanonicalVariant("eight trailing spaces", { "$it        " }, unusedBitsRejection),
+        NonCanonicalVariant(
+            "a full pad group appended", { "$it========" }, nonAlphabetCharacterRejection
+        ),
+        NonCanonicalVariant(
+            "characters written after a pad character", { "$it=ZZZZZZZ" },
+            nonAlphabetCharacterRejection
+        ),
+        NonCanonicalVariant(
+            "eight trailing spaces", { "$it        " }, nonAlphabetCharacterRejection
+        ),
         NonCanonicalVariant(
             "a space inserted mid-string",
             { it.substring(0, 10) + " " + it.substring(10) },
@@ -1762,30 +1786,8 @@ class StrKeyTest {
         return length
     }
 
-    /**
-     * The data bytes [strKey] carries, having checked that it is a signed payload whose checksum
-     * matches. A vector that failed either check would be rejected for that rather than for the
-     * framing it is written to exercise.
-     */
-    private fun checkedSignedPayloadData(strKey: String): ByteArray {
-        val decoded = Base32Codec.decode(strKey.map { it.code.toByte() }.toByteArray())
-        val payload = decoded.copyOfRange(0, decoded.size - 2)
-        val checksum = decoded.copyOfRange(decoded.size - 2, decoded.size)
-        assertTrue(
-            crc16XModem(payload).contentEquals(checksum),
-            "the vector must carry a valid checksum"
-        )
-        assertEquals(signedPayloadVersionByte, payload[0], "the vector must be a signed payload")
-        return payload.copyOfRange(1, payload.size)
-    }
-
-    private fun assertSignedPayloadRejected(label: String, candidate: String, rejection: String) {
-        val failure = assertFailsWith<IllegalArgumentException>("$label: must be rejected") {
-            StrKey.decodeSignedPayload(candidate)
-        }
-        assertEquals(rejection, failure.message, "$label: the rejection must name the rule broken")
-        assertFalse(StrKey.isValidSignedPayload(candidate), "$label: isValid must agree with decode")
-    }
+    private fun checkedSignedPayloadData(strKey: String): ByteArray =
+        checkedData(strKey, signedPayloadVersionByte, "a signed payload")
 
     @Test
     fun testDecodeRejectsSignedPayloadDeclaringALengthItCannotCarry() {
@@ -1795,9 +1797,10 @@ class StrKeyTest {
         val zeroData = checkedSignedPayloadData(declaresZero)
         assertEquals(40, zeroData.size)
         assertEquals(0L, declaredPayloadLength(zeroData))
-        assertSignedPayloadRejected(
+        assertRejectedByRule(
             "a declared length of 0", declaresZero,
-            "$signedPayloadDeclaredLengthRejection, expected between 1 and 64 bytes, got 0"
+            "$signedPayloadDeclaredLengthRejection, expected between 1 and 64 bytes, got 0",
+            { StrKey.decodeSignedPayload(it) }, { StrKey.isValidSignedPayload(it) }
         )
 
         // A 32-byte ed25519 public key, a declared length of 65 and 64 payload bytes: the largest
@@ -1809,9 +1812,10 @@ class StrKeyTest {
         val sixtyFiveData = checkedSignedPayloadData(declaresSixtyFive)
         assertEquals(100, sixtyFiveData.size)
         assertEquals(65L, declaredPayloadLength(sixtyFiveData))
-        assertSignedPayloadRejected(
+        assertRejectedByRule(
             "a declared length of 65", declaresSixtyFive,
-            "$signedPayloadDeclaredLengthRejection, expected between 1 and 64 bytes, got 65"
+            "$signedPayloadDeclaredLengthRejection, expected between 1 and 64 bytes, got 65",
+            { StrKey.decodeSignedPayload(it) }, { StrKey.isValidSignedPayload(it) }
         )
     }
 
@@ -1824,10 +1828,11 @@ class StrKeyTest {
         val data = checkedSignedPayloadData(declaresMoreThanItHolds)
         assertEquals(40, data.size)
         assertEquals(64L, declaredPayloadLength(data))
-        assertSignedPayloadRejected(
+        assertRejectedByRule(
             "a declared length of 64 inside 40 bytes",
             declaresMoreThanItHolds,
-            "$signedPayloadSizeRejection, a declared length of 64 requires 100 bytes, got 40"
+            "$signedPayloadSizeRejection, a declared length of 64 requires 100 bytes, got 40",
+            { StrKey.decodeSignedPayload(it) }, { StrKey.isValidSignedPayload(it) }
         )
     }
 
@@ -1850,10 +1855,11 @@ class StrKeyTest {
             data.copyOfRange(36 + 29, data.size).all { it != 0.toByte() },
             "every padding byte must be non-zero"
         )
-        assertSignedPayloadRejected(
+        assertRejectedByRule(
             "non-zero padding", nonZeroPadding,
             "$signedPayloadPaddingRejection, expected zero at index 65 after a declared length " +
-                "of 29, got 255"
+                "of 29, got 255",
+            { StrKey.decodeSignedPayload(it) }, { StrKey.isValidSignedPayload(it) }
         )
     }
 
@@ -1952,40 +1958,8 @@ class StrKeyTest {
 
     private val claimableBalanceHash = ByteArray(32) { index -> (index * 5 + 1).toByte() }
 
-    /**
-     * The data bytes [strKey] carries, having checked that it is a claimable balance id whose
-     * checksum matches. A vector that failed either check would be rejected for that rather than
-     * for the discriminant it is written to exercise.
-     */
-    private fun checkedClaimableBalanceData(strKey: String): ByteArray {
-        val decoded = Base32Codec.decode(strKey.map { it.code.toByte() }.toByteArray())
-        val payload = decoded.copyOfRange(0, decoded.size - 2)
-        val checksum = decoded.copyOfRange(decoded.size - 2, decoded.size)
-        assertTrue(
-            crc16XModem(payload).contentEquals(checksum),
-            "the vector must carry a valid checksum"
-        )
-        assertEquals(
-            claimableBalanceVersionByte, payload[0],
-            "the vector must be a claimable balance id"
-        )
-        return payload.copyOfRange(1, payload.size)
-    }
-
-    private fun assertClaimableBalanceRejected(
-        label: String,
-        candidate: String,
-        rejection: String
-    ) {
-        val failure = assertFailsWith<IllegalArgumentException>("$label: must be rejected") {
-            StrKey.decodeClaimableBalance(candidate)
-        }
-        assertEquals(rejection, failure.message, "$label: the rejection must name the rule broken")
-        assertFalse(
-            StrKey.isValidClaimableBalance(candidate),
-            "$label: isValid must agree with decode"
-        )
-    }
+    private fun checkedClaimableBalanceData(strKey: String): ByteArray =
+        checkedData(strKey, claimableBalanceVersionByte, "a claimable balance id")
 
     @Test
     fun testDecodeRejectsClaimableBalanceDiscriminantOtherThanTheOneDeclared() {
@@ -2002,9 +1976,10 @@ class StrKeyTest {
                 discriminant, checkedClaimableBalanceData(candidate)[0].toInt() and 0xFF,
                 "discriminant $discriminant: the vector must carry it"
             )
-            assertClaimableBalanceRejected(
+            assertRejectedByRule(
                 "a discriminant of $discriminant", candidate,
-                "$claimableBalanceDiscriminantRejection, expected 0, got $discriminant"
+                "$claimableBalanceDiscriminantRejection, expected 0, got $discriminant",
+                { StrKey.decodeClaimableBalance(it) }, { StrKey.isValidClaimableBalance(it) }
             )
         }
     }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/StrKeyTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/StrKeyTest.kt
@@ -57,26 +57,31 @@ class StrKeyTest {
 
     @Test
     fun testDecodeInvalidChecksum() {
-        // Change last character to make checksum invalid
-        assertFailsWith<IllegalArgumentException> {
+        // The last character carries checksum bits, so changing it leaves a string of the length
+        // and the version byte an account id has whose checksum no longer matches.
+        val failure = assertFailsWith<IllegalArgumentException> {
             StrKey.decodeEd25519PublicKey("GCZHXL5HXQX5ABDM26LHYRCQZ5OJFHLOPLZX47WEBP3V2PF5AVFK2A5X")
         }
+        assertEquals("Checksum invalid", failure.message)
     }
 
     @Test
     fun testDecodeInvalidVersion() {
-        // Try to decode a seed as a public key
-        assertFailsWith<IllegalArgumentException> {
+        // A secret seed read as a public key. The version byte it carries names a type, and not
+        // the one the caller asked for.
+        val failure = assertFailsWith<IllegalArgumentException> {
             StrKey.decodeEd25519PublicKey("SDJHRQF4GCMIIKAAAQ6IHY42X73FQFLHUULAPSKKD4DFDM7UXWWCRHBE")
         }
+        assertEquals("Version byte mismatch", failure.message)
     }
 
     @Test
     fun testEncodeInvalidLength() {
         val tooShort = byteArrayOf(1, 2, 3)
-        assertFailsWith<IllegalArgumentException> {
+        val failure = assertFailsWith<IllegalArgumentException> {
             StrKey.encodeEd25519PublicKey(tooShort)
         }
+        assertEquals("Public key must be 32 bytes, got 3", failure.message)
 
         assertFailsWith<IllegalArgumentException> {
             StrKey.encodeEd25519SecretSeed(tooShort)
@@ -85,16 +90,16 @@ class StrKeyTest {
 
     @Test
     fun testDecodeTooShort() {
-        assertFailsWith<IllegalArgumentException> {
+        val failure = assertFailsWith<IllegalArgumentException> {
             StrKey.decodeEd25519PublicKey("GAAA")
         }
+        assertEquals("Invalid encoded length, expected 56 characters, got 4", failure.message)
     }
 
     // Contract address tests
 
     @Test
     fun testEncodeDecodeContract() {
-        // Test vector from Java SDK: CA2LVQXQLGPWHV2QO5ENVAGWM2TYICRMWXW4UXBPVKV26WLKU2V3UTH5
         val contractAddress = "CA2LVQXQLGPWHV2QO5ENVAGWM2TYICRMWXW4UXBPVKV26WLKU2V3UTH5"
 
         // Decode to get the actual bytes
@@ -112,7 +117,6 @@ class StrKeyTest {
 
     @Test
     fun testEncodeDecodeContractAnotherVector() {
-        // Another test vector from Java SDK: CADEDRPB3MIT2QWLK5DGAFR3JMCIZMTEFT6R4KUGW5ZZYCQKAMPR5WAJ
         val contractAddress = "CADEDRPB3MIT2QWLK5DGAFR3JMCIZMTEFT6R4KUGW5ZZYCQKAMPR5WAJ"
 
         // Decode to get the actual bytes
@@ -147,22 +151,27 @@ class StrKeyTest {
 
     @Test
     fun testDecodeContractInvalidChecksum() {
-        // Change last character to make checksum invalid
-        assertFailsWith<IllegalArgumentException> {
+        // The last character carries checksum bits, so changing it leaves a string of the length
+        // and the version byte a contract address has whose checksum no longer matches.
+        val failure = assertFailsWith<IllegalArgumentException> {
             StrKey.decodeContract("CA2LVQXQLGPWHV2QO5ENVAGWM2TYICRMWXW4UXBPVKV26WLKU2V3UTH4")
         }
+        assertEquals("Checksum invalid", failure.message)
     }
 
     @Test
     fun testDecodeContractInvalidVersion() {
-        // Try to decode an account ID as a contract
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.decodeContract("GCZHXL5HXQX5ABDM26LHYRCQZ5OJFHLOPLZX47WEBP3V2PF5AVFK2A5D")
-        }
-
-        // Try to decode a seed as a contract
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.decodeContract("SDJHRQF4GCMIIKAAAQ6IHY42X73FQFLHUULAPSKKD4DFDM7UXWWCRHBE")
+        // An account id and a secret seed read as a contract address. Each carries a version byte
+        // that names a type, and neither names the one the caller asked for.
+        val others = listOf(
+            "GCZHXL5HXQX5ABDM26LHYRCQZ5OJFHLOPLZX47WEBP3V2PF5AVFK2A5D",
+            "SDJHRQF4GCMIIKAAAQ6IHY42X73FQFLHUULAPSKKD4DFDM7UXWWCRHBE"
+        )
+        for (other in others) {
+            val failure = assertFailsWith<IllegalArgumentException> {
+                StrKey.decodeContract(other)
+            }
+            assertEquals("Version byte mismatch", failure.message, "rejecting $other")
         }
     }
 
@@ -229,22 +238,25 @@ class StrKeyTest {
 
     @Test
     fun testDecodeContractTooShort() {
-        assertFailsWith<IllegalArgumentException> {
+        val failure = assertFailsWith<IllegalArgumentException> {
             StrKey.decodeContract("CAAA")
         }
+        assertEquals("Invalid encoded length, expected 56 characters, got 4", failure.message)
     }
 
     @Test
     fun testDecodeContractInvalidBase32() {
-        // Invalid base32 character (0 and 1 are not in base32 alphabet)
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.decodeContract("C000000000000000000000000000000000000000000000000000000")
+        // '0' is not a base32 character. The string is as long as a contract address, so it gets
+        // past the encoded-length check and the alphabet is what stops it.
+        val candidate = "C" + "0".repeat(55)
+        assertEquals(56, candidate.length)
+        val failure = assertFailsWith<IllegalArgumentException> {
+            StrKey.decodeContract(candidate)
         }
+        assertEquals("Invalid base32 encoded string", failure.message)
     }
 
-    // NEW TESTS FROM FLUTTER SDK
-
-    // Test vectors for valid public keys (from Flutter SDK)
+    // Test vectors for valid public keys
     @Test
     fun testValidPublicKeys() {
         val validKeys = listOf(
@@ -265,28 +277,92 @@ class StrKeyTest {
         }
     }
 
-    // Test vectors for invalid public keys (from Flutter SDK)
+    /**
+     * A strkey that is not one, together with the message the check that rejects it reports.
+     * Naming the check keeps a vector from standing for a defect it never reaches: a string
+     * whose length no strkey of its type has is stopped before anything is decoded, whatever
+     * else is wrong with it.
+     */
+    private class RejectedVector(val strKey: String, val rejection: String)
+
+    private fun assertRejected(
+        vector: RejectedVector,
+        decode: (String) -> ByteArray,
+        isValid: (String) -> Boolean
+    ) {
+        assertFalse(isValid(vector.strKey), "Expected ${vector.strKey} to be invalid")
+        val failure = assertFailsWith<IllegalArgumentException>(
+            "Expected ${vector.strKey} to be rejected"
+        ) {
+            decode(vector.strKey)
+        }
+        assertEquals(
+            vector.rejection, failure.message,
+            "${vector.strKey}: the rejection must name the check that reports it"
+        )
+    }
+
+    // Test vectors for invalid public keys
     @Test
     fun testInvalidPublicKeys() {
         val invalidKeys = listOf(
-            "GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL", // Invalid encoded
-            "GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++", // Invalid chars
-            "GADE5QJ2TY7S5ZB65Q43DFGWYWCPHIYDJ2326KZGAGBN7AE5UY6JVDRRA", // Invalid encoded
-            "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2", // Invalid encoded
-            "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T", // Too long
-            "GDXIIZTKTLVYCBHURXL2UPMTYXOVNI7BRAEFQCP6EZCY4JLKY4VKFNLT", // Invalid checksum
-            "SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDY", // Secret seed, not account
-            "gWRYUerEKuz53tstxEuR3NCkiQDcV4wzFHmvLnZmj7PUqxW2wt", // Invalid format
-            "test", // Invalid
-            "g4VPBPrHZkfE8CsjuG2S4yBQNd455UWmk" // Old network key
+            // '0' is no base32 character.
+            RejectedVector(
+                "GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL",
+                "Invalid base32 encoded string"
+            ),
+            // Two characters too long, and the two are not base32 characters either.
+            RejectedVector(
+                "GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++",
+                "Invalid encoded length, expected 56 characters, got 58"
+            ),
+            // One character too long.
+            RejectedVector(
+                "GADE5QJ2TY7S5ZB65Q43DFGWYWCPHIYDJ2326KZGAGBN7AE5UY6JVDRRA",
+                "Invalid encoded length, expected 56 characters, got 57"
+            ),
+            RejectedVector(
+                "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2",
+                "Invalid encoded length, expected 56 characters, got 57"
+            ),
+            // Two characters too long.
+            RejectedVector(
+                "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T",
+                "Invalid encoded length, expected 56 characters, got 58"
+            ),
+            // The length and the version byte an account id has, and a checksum that does not
+            // match the bytes it covers.
+            RejectedVector(
+                "GDXIIZTKTLVYCBHURXL2UPMTYXOVNI7BRAEFQCP6EZCY4JLKY4VKFNLT",
+                "Checksum invalid"
+            ),
+            // A secret seed: the version byte names a type, and not this one.
+            RejectedVector(
+                "SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDY",
+                "Version byte mismatch"
+            ),
+            // Strings of other lengths entirely: none of them is written the way a strkey is.
+            RejectedVector(
+                "gWRYUerEKuz53tstxEuR3NCkiQDcV4wzFHmvLnZmj7PUqxW2wt",
+                "Invalid encoded length, expected 56 characters, got 50"
+            ),
+            RejectedVector("test", "Invalid encoded length, expected 56 characters, got 4"),
+            RejectedVector(
+                "g4VPBPrHZkfE8CsjuG2S4yBQNd455UWmk",
+                "Invalid encoded length, expected 56 characters, got 33"
+            )
         )
 
         for (key in invalidKeys) {
-            assertFalse(StrKey.isValidEd25519PublicKey(key), "Expected $key to be invalid")
+            assertRejected(
+                key,
+                { StrKey.decodeEd25519PublicKey(it) },
+                { StrKey.isValidEd25519PublicKey(it) }
+            )
         }
     }
 
-    // Test vectors for valid secret seeds (from Flutter SDK)
+    // Test vectors for valid secret seeds
     @Test
     fun testValidSecretSeeds() {
         val validSeeds = listOf(
@@ -303,92 +379,137 @@ class StrKeyTest {
         }
     }
 
-    // Test vectors for invalid secret seeds (from Flutter SDK)
+    // Test vectors for invalid secret seeds
     @Test
     fun testInvalidSecretSeeds() {
         val invalidSeeds = listOf(
-            "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB", // Account ID, not seed
-            "SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDYT", // Too long
-            "SAFGAMN5Z6IHVI3IVEPIILS7ITZDYSCEPLN4FN5Z3IY63DRH4CIYEV", // Too short
-            "SAFGAMN5Z6IHVI3IVEPIILS7ITZDYSCEPLN4FN5Z3IY63DRH4CIYEVIT", // Invalid checksum
-            "test" // Invalid
+            // An account id: the version byte names a type, and not this one.
+            RejectedVector(
+                "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB",
+                "Version byte mismatch"
+            ),
+            // One character too long, and two characters too short.
+            RejectedVector(
+                "SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDYT",
+                "Invalid encoded length, expected 56 characters, got 57"
+            ),
+            RejectedVector(
+                "SAFGAMN5Z6IHVI3IVEPIILS7ITZDYSCEPLN4FN5Z3IY63DRH4CIYEV",
+                "Invalid encoded length, expected 56 characters, got 54"
+            ),
+            // The length and the version byte a secret seed has, and a checksum that does not
+            // match the bytes it covers.
+            RejectedVector(
+                "SAFGAMN5Z6IHVI3IVEPIILS7ITZDYSCEPLN4FN5Z3IY63DRH4CIYEVIT",
+                "Checksum invalid"
+            ),
+            RejectedVector("test", "Invalid encoded length, expected 56 characters, got 4")
         )
 
         for (seed in invalidSeeds) {
-            assertFalse(StrKey.isValidEd25519SecretSeed(seed.toCharArray()), "Expected $seed to be invalid")
+            assertRejected(
+                seed,
+                { StrKey.decodeEd25519SecretSeed(it.toCharArray()) },
+                { StrKey.isValidEd25519SecretSeed(it.toCharArray()) }
+            )
         }
     }
 
-    // Test decode with wrong version byte (from Flutter SDK)
+    // Test decode with wrong version byte
     @Test
     fun testDecodeWithWrongVersionByte() {
-        // Throws an error when the version byte is wrong
-        assertFailsWith<IllegalArgumentException> {
-            // Try to decode a secret seed as account ID
+        // A secret seed read as an account id, and an account id read as a secret seed. Each
+        // carries a version byte that names a type, and neither names the one asked for.
+        val seedFailure = assertFailsWith<IllegalArgumentException> {
             StrKey.decodeEd25519SecretSeed("GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL".toCharArray())
         }
+        assertEquals("Version byte mismatch", seedFailure.message)
 
-        assertFailsWith<IllegalArgumentException> {
-            // Try to decode an account ID as secret seed
+        val publicKeyFailure = assertFailsWith<IllegalArgumentException> {
             StrKey.decodeEd25519PublicKey("SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")
         }
+        assertEquals("Version byte mismatch", publicKeyFailure.message)
     }
 
-    // Test decode with invalid encoded strings (from Flutter SDK)
+    // Test decode with invalid encoded strings
     @Test
     fun testDecodeInvalidEncodedStrings() {
-        // Invalid account ID
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.decodeEd25519PublicKey("GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")
+        val invalidAccountIds = listOf(
+            // '0' is no base32 character.
+            RejectedVector(
+                "GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL",
+                "Invalid base32 encoded string"
+            ),
+            // Two characters too long, once with characters no strkey is written in and once
+            // without.
+            RejectedVector(
+                "GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++",
+                "Invalid encoded length, expected 56 characters, got 58"
+            ),
+            RejectedVector(
+                "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T",
+                "Invalid encoded length, expected 56 characters, got 58"
+            )
+        )
+        for (accountId in invalidAccountIds) {
+            assertRejected(
+                accountId,
+                { StrKey.decodeEd25519PublicKey(it) },
+                { StrKey.isValidEd25519PublicKey(it) }
+            )
         }
 
-        // Invalid account ID with special chars
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.decodeEd25519PublicKey("GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++")
-        }
-
-        // Invalid account ID - too long
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.decodeEd25519PublicKey("GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T")
-        }
-
-        // Invalid secret seeds with various issues
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.decodeEd25519SecretSeed("SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYW".toCharArray())
-        }
-
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.decodeEd25519SecretSeed("SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2".toCharArray())
-        }
-
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.decodeEd25519SecretSeed("SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2T".toCharArray())
-        }
-
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.decodeEd25519SecretSeed("SCMB30FQCIQAWZ4WQTS6SVK37LGMAFJGXOZIHTH2PY6EXLP37G46H6DT".toCharArray())
-        }
-
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.decodeEd25519SecretSeed("SAYC2LQ322EEHZYWNSKBEW6N66IRTDREEBUXXU5HPVZGMAXKLIZNM45H++".toCharArray())
+        val invalidSeeds = listOf(
+            // Six characters too short, one too long and two too long.
+            RejectedVector(
+                "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYW",
+                "Invalid encoded length, expected 56 characters, got 50"
+            ),
+            RejectedVector(
+                "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2",
+                "Invalid encoded length, expected 56 characters, got 57"
+            ),
+            RejectedVector(
+                "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2T",
+                "Invalid encoded length, expected 56 characters, got 58"
+            ),
+            // '0' is no base32 character.
+            RejectedVector(
+                "SCMB30FQCIQAWZ4WQTS6SVK37LGMAFJGXOZIHTH2PY6EXLP37G46H6DT",
+                "Invalid base32 encoded string"
+            ),
+            // Two characters too long, and the two are not base32 characters either.
+            RejectedVector(
+                "SAYC2LQ322EEHZYWNSKBEW6N66IRTDREEBUXXU5HPVZGMAXKLIZNM45H++",
+                "Invalid encoded length, expected 56 characters, got 58"
+            )
+        )
+        for (seed in invalidSeeds) {
+            assertRejected(
+                seed,
+                { StrKey.decodeEd25519SecretSeed(it.toCharArray()) },
+                { StrKey.isValidEd25519SecretSeed(it.toCharArray()) }
+            )
         }
     }
 
-    // Test decode with wrong checksum (from Flutter SDK)
+    // Test decode with wrong checksum
     @Test
     fun testDecodeWrongChecksum() {
-        // Invalid account ID checksum
-        assertFailsWith<IllegalArgumentException> {
+        // An account id and a secret seed, each of the length and with the version byte its type
+        // has, and each carrying a checksum that does not match the bytes it covers.
+        val accountIdFailure = assertFailsWith<IllegalArgumentException> {
             StrKey.decodeEd25519PublicKey("GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVT")
         }
+        assertEquals("Checksum invalid", accountIdFailure.message)
 
-        // Invalid secret seed checksum
-        assertFailsWith<IllegalArgumentException> {
+        val seedFailure = assertFailsWith<IllegalArgumentException> {
             StrKey.decodeEd25519SecretSeed("SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCX".toCharArray())
         }
+        assertEquals("Checksum invalid", seedFailure.message)
     }
 
-    // Test encode with proper prefix (from Flutter SDK)
+    // Test encode with proper prefix
     @Test
     fun testEncodePrefixes() {
         // Create test data
@@ -411,11 +532,13 @@ class StrKeyTest {
         assertTrue(sha256Hash.startsWith("X"))
     }
 
-    // Test muxed accounts (from Flutter SDK)
+    // Test muxed accounts
     @Test
     fun testMuxedAccounts() {
-        val muxedAddress = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK"
-        val rawMuxedKey = hexToBytes("3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a8000000000000000")
+        // The SEP-0023 valid vector whose id exceeds the largest signed 64-bit integer;
+        // sep23ValidVectors() carries the id-0 vector.
+        val muxedAddress = sep23MaxIdMuxedAccountId
+        val rawMuxedKey = hexToBytes(sep23Hash + "8000000000000000")
 
         // Encodes & decodes M... addresses correctly
         assertEquals(muxedAddress, StrKey.encodeMed25519PublicKey(rawMuxedKey))
@@ -425,9 +548,9 @@ class StrKeyTest {
         assertTrue(StrKey.isValidMed25519PublicKey(muxedAddress))
     }
 
-    // Test contracts (from Flutter SDK)
+    // Test contracts
     @Test
-    fun testContractsFromFlutterSDK() {
+    fun testContractIdDecodesToItsHash() {
         val contractId = "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE"
         val asHex = "363eaa3867841fbad0f4ed88c779e4fe66e56a2470dc98c0ec9c073d05c7b103"
 
@@ -439,11 +562,11 @@ class StrKeyTest {
         assertFalse(StrKey.isValidContract("GA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE"))
     }
 
-    // Test liquidity pools (from Flutter SDK)
+    // Test liquidity pools
     @Test
     fun testLiquidityPools() {
-        val liquidityPoolId = "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN"
-        val asHex = "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
+        val liquidityPoolId = sep23LiquidityPoolId
+        val asHex = sep23Hash
 
         val decoded = StrKey.decodeLiquidityPool(liquidityPoolId)
         assertEquals(asHex, bytesToHex(decoded))
@@ -453,11 +576,11 @@ class StrKeyTest {
         assertFalse(StrKey.isValidLiquidityPool("LB7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN"))
     }
 
-    // Test claimable balances (from Flutter SDK)
+    // Test claimable balances
     @Test
     fun testClaimableBalances() {
-        val claimableBalanceId = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
-        val asHex = "003f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
+        val claimableBalanceId = sep23ClaimableBalanceId
+        val asHex = "00" + sep23Hash
 
         val decoded = StrKey.decodeClaimableBalance(claimableBalanceId)
         assertEquals(asHex, bytesToHex(decoded))
@@ -466,31 +589,47 @@ class StrKeyTest {
         assertTrue(StrKey.isValidClaimableBalance(claimableBalanceId))
         assertFalse(StrKey.isValidClaimableBalance("BBAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"))
 
-        // Test with 32-byte input (hash only) - SDK should automatically prepend V0 discriminant (0x00)
-        val hashOnly = "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
+        // A 32-byte input is the hash on its own, which is written under the discriminant the
+        // XDR union declares.
+        val hashOnly = sep23Hash
         val encoded32Byte = StrKey.encodeClaimableBalance(hexToBytes(hashOnly))
         assertEquals(claimableBalanceId, encoded32Byte)
 
-        // Test with 33-byte input (type + hash) - SDK should use as-is
+        // A 33-byte input carries that discriminant itself, followed by the hash.
         val fullBytes = "00" + hashOnly
         val encoded33Byte = StrKey.encodeClaimableBalance(hexToBytes(fullBytes))
         assertEquals(claimableBalanceId, encoded33Byte)
 
-        // Both 32-byte and 33-byte inputs should produce the same result
+        // A 36-byte input is the XDR wire form: the discriminant across four big-endian bytes,
+        // followed by the hash. It is the shape Horizon reports.
+        val xdrBytes = "00000000" + hashOnly
+        val encoded36Byte = StrKey.encodeClaimableBalance(hexToBytes(xdrBytes))
+        assertEquals(claimableBalanceId, encoded36Byte)
+
+        // All three widths name the same balance, so they spell one strkey
         assertEquals(encoded32Byte, encoded33Byte)
+        assertEquals(encoded32Byte, encoded36Byte)
     }
 
     @Test
     fun testEncodeClaimableBalanceInvalidLength() {
-        // Test with invalid input sizes (not 32 or 33 bytes)
+        // Test with invalid input sizes (not 32, 33 or 36 bytes)
         val tooShort = byteArrayOf(1, 2, 3)
         assertFailsWith<IllegalArgumentException> {
             StrKey.encodeClaimableBalance(tooShort)
         }
 
-        val tooLong = ByteArray(34) { it.toByte() }
-        assertFailsWith<IllegalArgumentException> {
-            StrKey.encodeClaimableBalance(tooLong)
+        // The widths between the strkey body and the XDR form, and the one past it: accepting
+        // any of them would mean a width is being padded or truncated to a shape it is not.
+        for (size in listOf(34, 35, 37)) {
+            val failure = assertFailsWith<IllegalArgumentException>("a $size byte id must be rejected") {
+                StrKey.encodeClaimableBalance(ByteArray(size) { it.toByte() })
+            }
+            assertEquals(
+                "Claimable balance ID must be 32 bytes (hash only), 33 bytes (type + hash) or " +
+                    "36 bytes (XDR form), got $size bytes",
+                failure.message
+            )
         }
 
         val empty = byteArrayOf()
@@ -504,53 +643,294 @@ class StrKeyTest {
         }
     }
 
-    // Test invalid str keys (from Flutter SDK - comprehensive edge cases)
+    // ========== SEP-0023 test vectors ==========
+    //
+    // The strkey vectors SEP-0023 publishes, transcribed from the specification. Every invalid
+    // one is listed with the reason the specification gives and with the message the check that
+    // rejects it reports. The two need not describe the same check: a string whose length no
+    // strkey of its type has is stopped before anything is decoded, whatever else is wrong with
+    // it, and a vector that stood only for the check its reason names would prove nothing about
+    // that check.
+
+    /** The 32-byte hash the SEP-0023 vectors are built around. */
+    private val sep23Hash = "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
+
+    private val sep23AccountId = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+
+    /** The SEP-0023 valid multiplexed account vector, whose id is 0. */
+    private val sep23MuxedAccountId =
+        "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ"
+
+    /**
+     * The SEP-0023 valid multiplexed account vector whose id exceeds the largest signed
+     * 64-bit integer.
+     */
+    private val sep23MaxIdMuxedAccountId =
+        "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK"
+
+    /** The SEP-0023 valid signed payload vector, whose payload is 32 bytes and needs no padding. */
+    private val sep23SignedPayload =
+        "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQ" +
+            "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IBZGM"
+
+    /** The SEP-0023 valid signed payload vector whose 29-byte payload is zero padded. */
+    private val sep23PaddedSignedPayload =
+        "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+            "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUAAAAFGBU"
+
+    private val sep23ContractId = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
+
+    private val sep23LiquidityPoolId = "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN"
+
+    private val sep23ClaimableBalanceId = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+
+    private class Sep23ValidVector(
+        val description: String,
+        val strKey: String,
+        val dataHex: String,
+        val decode: (String) -> ByteArray,
+        val isValid: (String) -> Boolean
+    )
+
+    /**
+     * The SEP-0023 valid vectors whose key no other test in this file reads back. The multiplexed
+     * account whose id exceeds the largest signed 64-bit integer, the liquidity pool and the
+     * claimable balance are read back by [testMuxedAccounts], [testLiquidityPools] and
+     * [testClaimableBalances].
+     */
+    private fun sep23ValidVectors(): List<Sep23ValidVector> = listOf(
+        Sep23ValidVector(
+            "non-multiplexed account", sep23AccountId, sep23Hash,
+            { StrKey.decodeEd25519PublicKey(it) }, { StrKey.isValidEd25519PublicKey(it) }
+        ),
+        Sep23ValidVector(
+            // A multiplexed account holds the ed25519 public key followed by the id, and this
+            // vector's id is 0.
+            "multiplexed account", sep23MuxedAccountId, sep23Hash + "0000000000000000",
+            { StrKey.decodeMed25519PublicKey(it) }, { StrKey.isValidMed25519PublicKey(it) }
+        ),
+        Sep23ValidVector(
+            // A signed payload holds the ed25519 public key, the declared payload length as a
+            // big-endian four-byte value, and the payload. 32 bytes need no padding.
+            "signed payload with a 32-byte payload", sep23SignedPayload,
+            sep23Hash + "00000020" + "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+            { StrKey.decodeSignedPayload(it) }, { StrKey.isValidSignedPayload(it) }
+        ),
+        Sep23ValidVector(
+            // 29 payload bytes are padded with three zero bytes to the four-byte boundary.
+            "signed payload with a 29-byte payload", sep23PaddedSignedPayload,
+            sep23Hash + "0000001d" + "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d" +
+                "000000",
+            { StrKey.decodeSignedPayload(it) }, { StrKey.isValidSignedPayload(it) }
+        ),
+        Sep23ValidVector(
+            "contract", sep23ContractId, sep23Hash,
+            { StrKey.decodeContract(it) }, { StrKey.isValidContract(it) }
+        )
+    )
+
     @Test
-    fun testInvalidStrKeys() {
-        // The unused trailing bit must be zero in the encoding of the last three
-        // bytes (24 bits) as five base-32 symbols (25 bits)
-        var strKey = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUR"
-        assertFalse(StrKey.isValidMed25519PublicKey(strKey))
+    fun testSep23ValidVectorsDecodeToTheKeysTheySpell() {
+        for (vector in sep23ValidVectors()) {
+            assertTrue(vector.isValid(vector.strKey), "${vector.description}: must be valid")
+            assertEquals(
+                vector.dataHex, bytesToHex(vector.decode(vector.strKey)),
+                "${vector.description}: must decode to the key it spells"
+            )
+        }
+    }
 
-        // Invalid length (congruent to 1 mod 8)
-        strKey = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA"
-        assertFalse(StrKey.isValidEd25519PublicKey(strKey))
+    private class Sep23InvalidVector(
+        /** The reason SEP-0023 gives for listing the vector as invalid. */
+        val reason: String,
+        val strKey: String,
+        /** The message the check that rejects the vector reports. */
+        val rejection: String,
+        val decode: (String) -> ByteArray,
+        val isValid: (String) -> Boolean,
+        /** What the vector carries, where that is what makes its reason provable. */
+        val evidence: (() -> Unit)? = null
+    )
 
-        // Invalid algorithm (low 3 bits of version byte are 7)
-        strKey = "G47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVP2I"
-        assertFalse(StrKey.isValidEd25519PublicKey(strKey))
+    /**
+     * The fifteen invalid vectors SEP-0023 publishes, in the order the specification lists them.
+     */
+    private fun sep23InvalidVectors(): List<Sep23InvalidVector> {
+        val g: (String) -> ByteArray = { StrKey.decodeEd25519PublicKey(it) }
+        val gValid: (String) -> Boolean = { StrKey.isValidEd25519PublicKey(it) }
+        val m: (String) -> ByteArray = { StrKey.decodeMed25519PublicKey(it) }
+        val mValid: (String) -> Boolean = { StrKey.isValidMed25519PublicKey(it) }
+        val p: (String) -> ByteArray = { StrKey.decodeSignedPayload(it) }
+        val pValid: (String) -> Boolean = { StrKey.isValidSignedPayload(it) }
+        val b: (String) -> ByteArray = { StrKey.decodeClaimableBalance(it) }
+        val bValid: (String) -> Boolean = { StrKey.isValidClaimableBalance(it) }
 
-        // Invalid length (congruent to 6 mod 8)
-        strKey = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLKA"
-        assertFalse(StrKey.isValidMed25519PublicKey(strKey))
+        val trailingBitSet = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUR"
+        val padded = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUK==="
+        val declaredShorterThanPayload =
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IAAAAAAAAPM"
+        val declaredLongerThanPayload =
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4Z2PQ"
+        val withoutZeroPadding =
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DXFH6"
+        val undeclaredClaimableBalanceType = "BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA"
 
-        // Invalid algorithm (low 3 bits of version byte are 7)
-        strKey = "M47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ"
-        assertFalse(StrKey.isValidMed25519PublicKey(strKey))
+        return listOf(
+            Sep23InvalidVector(
+                "invalid length: an ed25519 public key is 32 bytes, not 5",
+                "GAAAAAAAACGC6",
+                "Invalid encoded length, expected 56 characters, got 13",
+                g, gValid
+            ),
+            Sep23InvalidVector(
+                "the unused trailing bit of the last character must be zero",
+                trailingBitSet,
+                "Unused bits should be set to 0",
+                m, mValid,
+                evidence = {
+                    // Padding is a second way to write the same characters, and it must not turn
+                    // a rejected encoding into an accepted one.
+                    assertFalse(
+                        StrKey.isValidMed25519PublicKey("$trailingBitSet==="),
+                        "padding must not rescue an encoding that leaves a trailing bit set"
+                    )
+                }
+            ),
+            Sep23InvalidVector(
+                "invalid length: congruent to 1 mod 8",
+                "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA",
+                "Invalid encoded length, expected 56 characters, got 57",
+                g, gValid
+            ),
+            Sep23InvalidVector(
+                "invalid length: base-32 decoding yields 36 bytes, not 35",
+                "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUACUSI",
+                "Invalid encoded length, expected 56 characters, got 58",
+                g, gValid
+            ),
+            Sep23InvalidVector(
+                "invalid algorithm: the low three bits of the version byte are 7",
+                "G47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVP2I",
+                "Version byte is invalid",
+                g, gValid
+            ),
+            Sep23InvalidVector(
+                "invalid length: congruent to 6 mod 8",
+                "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLKA",
+                "Invalid encoded length, expected 69 characters, got 70",
+                m, mValid
+            ),
+            Sep23InvalidVector(
+                "invalid length: base-32 decoding yields 44 bytes, not 43",
+                "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAAV75I",
+                "Invalid encoded length, expected 69 characters, got 71",
+                m, mValid
+            ),
+            Sep23InvalidVector(
+                "invalid algorithm: the low three bits of the version byte are 7",
+                "M47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ",
+                "Version byte is invalid",
+                m, mValid
+            ),
+            Sep23InvalidVector(
+                "padding characters are not allowed",
+                padded,
+                "Invalid encoded length, expected 69 characters, got 72",
+                m, mValid,
+                evidence = {
+                    // With the padding taken off the string is the length a multiplexed account
+                    // has and its checksum does not match, so the checksum is never what rejects
+                    // the padded form.
+                    val stripped = padded.removeSuffix("===")
+                    assertEquals(69, stripped.length)
+                    val failure = assertFailsWith<IllegalArgumentException> {
+                        StrKey.decodeMed25519PublicKey(stripped)
+                    }
+                    assertEquals("Checksum invalid", failure.message)
+                }
+            ),
+            Sep23InvalidVector(
+                "invalid checksum",
+                "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUO",
+                "Checksum invalid",
+                m, mValid
+            ),
+            Sep23InvalidVector(
+                "the declared length is shorter than the payload present",
+                declaredShorterThanPayload,
+                "$signedPayloadSizeRejection, a declared length of 32 requires 68 bytes, got 72",
+                p, pValid,
+                evidence = { assertSignedPayloadFraming(declaredShorterThanPayload, 32L, 72) }
+            ),
+            Sep23InvalidVector(
+                "the declared length is longer than the payload present",
+                declaredLongerThanPayload,
+                "$signedPayloadSizeRejection, a declared length of 29 requires 68 bytes, got 64",
+                p, pValid,
+                evidence = { assertSignedPayloadFraming(declaredLongerThanPayload, 29L, 64) }
+            ),
+            Sep23InvalidVector(
+                // The declared length names 29 payload bytes inside 65 data bytes, a size no
+                // padding of a 29-byte payload produces, so the exact-fit rule is what reports it
+                // and the padding bytes are never read.
+                "no zero padding in the signed payload",
+                withoutZeroPadding,
+                "$signedPayloadSizeRejection, a declared length of 29 requires 68 bytes, got 65",
+                p, pValid,
+                evidence = { assertSignedPayloadFraming(withoutZeroPadding, 29L, 65) }
+            ),
+            Sep23InvalidVector(
+                "the unused trailing two bits of the last character must be zero",
+                "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TV",
+                "Unused bits should be set to 0",
+                b, bValid
+            ),
+            Sep23InvalidVector(
+                "invalid claimable balance type: the first byte of the binary key is not 0",
+                undeclaredClaimableBalanceType,
+                "$claimableBalanceDiscriminantRejection, expected 0, got 1",
+                b, bValid,
+                evidence = {
+                    val data = checkedClaimableBalanceData(undeclaredClaimableBalanceType)
+                    assertEquals(58, undeclaredClaimableBalanceType.length, "encoded length")
+                    assertEquals(33, data.size, "the vector must carry the payload the type admits")
+                    assertEquals(1, data[0].toInt(), "the discriminant the vector is written for")
+                }
+            )
+        )
+    }
 
-        // Padding bytes are not allowed
-        strKey = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUK==="
-        assertFalse(StrKey.isValidMed25519PublicKey(strKey))
+    /**
+     * Reads the framing of the signed payload [strKey] carries and checks that it declares
+     * [declaredLength] inside [dataSize] data bytes. A vector whose checksum or version byte did
+     * not hold would be rejected for that rather than for the framing it is listed under.
+     */
+    private fun assertSignedPayloadFraming(strKey: String, declaredLength: Long, dataSize: Int) {
+        val data = checkedSignedPayloadData(strKey)
+        assertEquals(dataSize, data.size, "data size")
+        assertEquals(declaredLength, declaredPayloadLength(data), "declared payload length")
+    }
 
-        // Invalid checksum
-        strKey = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUO"
-        assertFalse(StrKey.isValidMed25519PublicKey(strKey))
+    @Test
+    fun testSep23InvalidVectorsAreRejected() {
+        val vectors = sep23InvalidVectors()
+        assertEquals(15, vectors.size, "SEP-0023 publishes fifteen invalid vectors")
 
-        // Trailing bits should be zeroes
-        strKey = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TV"
-        assertFalse(StrKey.isValidClaimableBalance(strKey))
-
-        // Invalid length (Ed25519 should be 32 bytes, not 5)
-        strKey = "GAAAAAAAACGC6"
-        assertFalse(StrKey.isValidEd25519PublicKey(strKey))
-
-        // Invalid length (base-32 decoding should yield 35 bytes, not 36)
-        strKey = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUACUSI"
-        assertFalse(StrKey.isValidEd25519PublicKey(strKey))
-
-        // Invalid length (base-32 decoding should yield 43 bytes, not 44)
-        strKey = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAAV75I"
-        assertFalse(StrKey.isValidMed25519PublicKey(strKey))
+        for (vector in vectors) {
+            val label = "${vector.strKey} (${vector.reason})"
+            assertFalse(vector.isValid(vector.strKey), "$label: must be invalid")
+            val failure = assertFailsWith<IllegalArgumentException>("$label: must be rejected") {
+                vector.decode(vector.strKey)
+            }
+            assertEquals(
+                vector.rejection, failure.message,
+                "$label: the rejection must name the check that reports it"
+            )
+            vector.evidence?.invoke()
+        }
     }
 
     // Test pre-auth transaction hashes
@@ -584,15 +964,17 @@ class StrKeyTest {
     // Test signed payload encoding/decoding
     @Test
     fun testSignedPayloadEncodeDecode() {
-        // Test with minimum size (40 bytes: 32 + 4 + 4)
-        val minPayload = ByteArray(40) { it.toByte() }
+        // Test with minimum size (40 bytes: 32 + 4 + a single payload byte padded to 4)
+        val minPayload = signedPayloadData(1)
+        assertEquals(40, minPayload.size)
         val encodedMin = StrKey.encodeSignedPayload(minPayload)
         assertTrue(encodedMin.startsWith("P"))
         val decodedMin = StrKey.decodeSignedPayload(encodedMin)
         assertTrue(minPayload.contentEquals(decodedMin))
 
-        // Test with maximum size (100 bytes: 32 + 4 + 64)
-        val maxPayload = ByteArray(100) { it.toByte() }
+        // Test with maximum size (100 bytes: 32 + 4 + 64 payload bytes)
+        val maxPayload = signedPayloadData(64)
+        assertEquals(100, maxPayload.size)
         val encodedMax = StrKey.encodeSignedPayload(maxPayload)
         assertTrue(encodedMax.startsWith("P"))
         val decodedMax = StrKey.decodeSignedPayload(encodedMax)
@@ -603,14 +985,16 @@ class StrKeyTest {
         assertTrue(StrKey.isValidSignedPayload(encodedMax))
 
         // Test invalid size (too small)
-        assertFailsWith<IllegalArgumentException> {
+        val tooSmall = assertFailsWith<IllegalArgumentException> {
             StrKey.encodeSignedPayload(ByteArray(39))
         }
+        assertEquals("Signed payload must be between 40 and 100 bytes, got 39", tooSmall.message)
 
         // Test invalid size (too large)
-        assertFailsWith<IllegalArgumentException> {
+        val tooLarge = assertFailsWith<IllegalArgumentException> {
             StrKey.encodeSignedPayload(ByteArray(101))
         }
+        assertEquals("Signed payload must be between 40 and 100 bytes, got 101", tooLarge.message)
     }
 
     // Test round-trip for all key types
@@ -619,7 +1003,8 @@ class StrKeyTest {
         val data32 = ByteArray(32) { i -> (i * 3).toByte() }
         val data33 = ByteArray(33) { i -> (i * 3).toByte() }
         val data40 = ByteArray(40) { i -> (i * 3).toByte() }
-        val data50 = ByteArray(50) { i -> (i * 3).toByte() }
+        // A signed payload frames its bytes, so this one carries a 14-byte payload padded to 16.
+        val signedPayloadRaw = signedPayloadData(14)
 
         // Ed25519 Public Key (G)
         val publicKey = StrKey.encodeEd25519PublicKey(data32)
@@ -642,8 +1027,8 @@ class StrKeyTest {
         assertTrue(data32.contentEquals(StrKey.decodeSha256Hash(sha256Hash)))
 
         // Signed Payload (P)
-        val signedPayload = StrKey.encodeSignedPayload(data50)
-        assertTrue(data50.contentEquals(StrKey.decodeSignedPayload(signedPayload)))
+        val signedPayload = StrKey.encodeSignedPayload(signedPayloadRaw)
+        assertTrue(signedPayloadRaw.contentEquals(StrKey.decodeSignedPayload(signedPayload)))
 
         // Contract (C)
         val contract = StrKey.encodeContract(data32)
@@ -706,14 +1091,18 @@ class StrKeyTest {
 
     // ========== Decode: payload-length validation ==========
     //
-    // These length constraints cannot be reached through the SDK's own encoders, which
-    // validate the raw payload before base32-encoding it. The strkeys below are hand-crafted
-    // with a correct CRC16-XModem checksum but an out-of-range payload, standing in for a
-    // malicious or corrupted strkey that a decoder must still reject.
+    // Two checks bound the payload, and they read the type from different places. The encoded
+    // length is fixed by the type the caller asked for, so a string that could not hold that type's
+    // payload is turned away before it is decoded. The decoded payload is then held against the
+    // type the version byte inside it names, which need not be the type the caller asked for: a
+    // string can have the length the requested type has and still carry a payload size the type it
+    // names does not admit, and that is what the decoded-length check catches. The strkeys below
+    // are hand-crafted with a correct CRC16-XModem checksum, standing in for a malicious or
+    // corrupted strkey.
 
-    // CLAIM_PREDICATE and other version byte constants are internal implementation
-    // detail of StrKey; the raw version byte values below are the public strkey
-    // protocol constants (see SEP-0023 / CAP-0027), not implementation-specific.
+    // The version byte values a strkey is written under are protocol constants (see SEP-0023 /
+    // CAP-0027). StrKey keeps its own enum of them private, so they are spelled out here.
+    private val accountIdVersionByte: Byte = (6 shl 3).toByte()
     private val claimableBalanceVersionByte: Byte = (1 shl 3).toByte()
     private val signedPayloadVersionByte: Byte = (15 shl 3).toByte()
 
@@ -745,24 +1134,952 @@ class StrKeyTest {
     }
 
     @Test
-    fun testDecodeClaimableBalanceWrongDataLengthThrows() {
-        // A validly checksummed B... strkey whose payload is neither 32 nor 33 bytes
-        // must still be rejected on decode, not just on encode.
+    fun testDecodeClaimableBalanceRejectsAPayloadSizeItsEncodedLengthCannotHold() {
+        // A validly checksummed B... strkey carrying 20 payload bytes. 20 bytes are written in 37
+        // characters, and no claimable balance id is 37 characters long.
         val badKey = craftStrKey(claimableBalanceVersionByte, ByteArray(20))
-        assertFailsWith<IllegalArgumentException> {
+        assertEquals(37, badKey.length)
+        val failure = assertFailsWith<IllegalArgumentException> {
             StrKey.decodeClaimableBalance(badKey)
         }
+        assertEquals(
+            "$encodedLengthRejection, expected 58 characters, got 37", failure.message,
+            "the rejection must name the check that reports it"
+        )
         assertFalse(StrKey.isValidClaimableBalance(badKey))
     }
 
     @Test
-    fun testDecodeSignedPayloadWrongDataLengthThrows() {
-        // A validly checksummed P... strkey whose payload is outside [40, 100] bytes
-        // must still be rejected on decode.
+    fun testDecodeSignedPayloadRejectsAPayloadSizeItsEncodedLengthCannotHold() {
+        // A validly checksummed P... strkey carrying 30 payload bytes, which is below the 40 the
+        // type admits. 30 bytes are written in 53 characters, and the shortest signed payload is
+        // 69 characters long.
         val badKey = craftStrKey(signedPayloadVersionByte, ByteArray(30))
-        assertFailsWith<IllegalArgumentException> {
+        assertEquals(53, badKey.length)
+        val failure = assertFailsWith<IllegalArgumentException> {
             StrKey.decodeSignedPayload(badKey)
         }
+        assertEquals(
+            "$encodedLengthRejection, expected between 69 and 165 characters, got 53",
+            failure.message,
+            "the rejection must name the check that reports it"
+        )
         assertFalse(StrKey.isValidSignedPayload(badKey))
+    }
+
+    private class DecodedLengthCase(
+        val description: String,
+        val strKey: String,
+        val rejection: String,
+        val decode: (String) -> ByteArray,
+        val isValid: (String) -> Boolean
+    )
+
+    @Test
+    fun testDecodeRejectsPayloadSizeTheVersionByteInsideItDoesNotAdmit() {
+        // Each strkey below has the encoded length the caller's type requires, so the
+        // encoded-length check passes it, and carries a version byte naming a different type whose
+        // payload sizes it does not fit. The decoded-length check reads that version byte, so it is
+        // the check that reports these, and it runs ahead of the version-byte comparison so that
+        // the framing a type defines is only ever read from a payload of a size that type admits.
+        val cases = listOf(
+            DecodedLengthCase(
+                "a 58-character strkey naming the signed payload type",
+                craftStrKey(signedPayloadVersionByte, ByteArray(33)),
+                "Invalid data length, expected between 40 and 100 bytes, got 33",
+                { StrKey.decodeClaimableBalance(it) },
+                { StrKey.isValidClaimableBalance(it) }
+            ),
+            DecodedLengthCase(
+                "a 58-character strkey naming the ed25519 public key type",
+                craftStrKey(accountIdVersionByte, ByteArray(33)),
+                "Invalid data length, expected 32 bytes, got 33",
+                { StrKey.decodeClaimableBalance(it) },
+                { StrKey.isValidClaimableBalance(it) }
+            ),
+            DecodedLengthCase(
+                "a 69-character strkey naming the ed25519 public key type, read as a muxed account",
+                craftStrKey(accountIdVersionByte, ByteArray(40)),
+                "Invalid data length, expected 32 bytes, got 40",
+                { StrKey.decodeMed25519PublicKey(it) },
+                { StrKey.isValidMed25519PublicKey(it) }
+            ),
+            DecodedLengthCase(
+                // 69 characters is the shortest a signed payload can be, so the range the
+                // encoded-length check holds this type to admits the string as well.
+                "a 69-character strkey naming the ed25519 public key type, read as a signed payload",
+                craftStrKey(accountIdVersionByte, ByteArray(40)),
+                "Invalid data length, expected 32 bytes, got 40",
+                { StrKey.decodeSignedPayload(it) },
+                { StrKey.isValidSignedPayload(it) }
+            )
+        )
+
+        for (case in cases) {
+            val failure = assertFailsWith<IllegalArgumentException>(
+                "${case.description}: must be rejected"
+            ) {
+                case.decode(case.strKey)
+            }
+            assertEquals(
+                case.rejection, failure.message,
+                "${case.description}: the rejection must name the check that reports it"
+            )
+            assertFalse(
+                case.isValid(case.strKey),
+                "${case.description}: isValid must agree with decode"
+            )
+        }
+    }
+
+    // ========== Decode: encoded-string length ==========
+    //
+    // A strkey type fixes the number of characters its encoded form has, so a string of any
+    // other length is not a strkey of that type and is rejected before anything is decoded.
+
+    /**
+     * The checks a string passes before its bytes stand for a key. Naming them lets a test state
+     * which one it exercises instead of settling for a rejection.
+     *
+     * [nonAlphabetCharacterRejection] is reported by two of them: the guard that admits only
+     * characters inside the ASCII range, and the alphabet check. Both answer the same question -
+     * whether the string is written in the characters a strkey is written in - so they say so in
+     * the same words, and a message alone does not tell them apart.
+     */
+    private val encodedLengthRejection = "Invalid encoded length"
+    private val leftoverCharacterRejection = "Encoded char array has leftover character"
+    private val unusedBitsRejection = "Unused bits should be set to 0"
+    private val nonAlphabetCharacterRejection = "Invalid base32 encoded string"
+
+    /**
+     * A strkey type, the entry points that read it and one valid strkey of that type. Every test
+     * that needs a genuinely valid strkey per type takes it from here, so the types a check is
+     * exercised against cannot drift apart between tests.
+     */
+    private class StrKeyType(
+        val name: String,
+        val valid: String,
+        val dataLength: Int,
+        /**
+         * Characters an encoded strkey of this type has, or null for a type whose encoded lengths
+         * form a range. A signed payload carries a variable payload, so its length follows from
+         * the payload rather than from the type.
+         */
+        val fixedEncodedLength: Int?,
+        val decode: (String) -> ByteArray,
+        val isValid: (String) -> Boolean
+    )
+
+    private fun strKeyTypes(): List<StrKeyType> {
+        val sample32 = ByteArray(32) { i -> (i * 5 + 1).toByte() }
+        return listOf(
+            StrKeyType(
+                "ed25519 public key", sep23AccountId, 32, 56,
+                { StrKey.decodeEd25519PublicKey(it) },
+                { StrKey.isValidEd25519PublicKey(it) }
+            ),
+            StrKeyType(
+                "ed25519 secret seed",
+                "SDJHRQF4GCMIIKAAAQ6IHY42X73FQFLHUULAPSKKD4DFDM7UXWWCRHBE", 32, 56,
+                { StrKey.decodeEd25519SecretSeed(it.toCharArray()) },
+                { StrKey.isValidEd25519SecretSeed(it.toCharArray()) }
+            ),
+            StrKeyType(
+                "pre-auth transaction", StrKey.encodePreAuthTx(sample32), 32, 56,
+                { StrKey.decodePreAuthTx(it) },
+                { StrKey.isValidPreAuthTx(it) }
+            ),
+            StrKeyType(
+                "sha256 hash", StrKey.encodeSha256Hash(sample32), 32, 56,
+                { StrKey.decodeSha256Hash(it) },
+                { StrKey.isValidSha256Hash(it) }
+            ),
+            StrKeyType(
+                "contract", sep23ContractId, 32, 56,
+                { StrKey.decodeContract(it) },
+                { StrKey.isValidContract(it) }
+            ),
+            StrKeyType(
+                "liquidity pool", sep23LiquidityPoolId, 32, 56,
+                { StrKey.decodeLiquidityPool(it) },
+                { StrKey.isValidLiquidityPool(it) }
+            ),
+            StrKeyType(
+                "claimable balance", sep23ClaimableBalanceId, 33, 58,
+                { StrKey.decodeClaimableBalance(it) },
+                { StrKey.isValidClaimableBalance(it) }
+            ),
+            StrKeyType(
+                "muxed ed25519 public key", sep23MuxedAccountId, 40, 69,
+                { StrKey.decodeMed25519PublicKey(it) },
+                { StrKey.isValidMed25519PublicKey(it) }
+            ),
+            StrKeyType(
+                "signed payload", sep23SignedPayload, 68, null,
+                { StrKey.decodeSignedPayload(it) },
+                { StrKey.isValidSignedPayload(it) }
+            )
+        )
+    }
+
+    private fun assertRejectedForEncodedLength(
+        label: String,
+        candidate: String,
+        expectation: String,
+        decode: (String) -> ByteArray,
+        isValid: (String) -> Boolean
+    ) {
+        val failure = assertFailsWith<IllegalArgumentException>(
+            "$label: a ${candidate.length} character string must be rejected"
+        ) {
+            decode(candidate)
+        }
+        val message = failure.message.orEmpty()
+        assertTrue(
+            message.contains(encodedLengthRejection),
+            "$label: rejected for a reason other than its length: $message"
+        )
+        assertTrue(
+            message.contains(expectation) && message.contains(candidate.length.toString()),
+            "$label: message must name the expected and the actual length: $message"
+        )
+        assertFalse(isValid(candidate), "$label: isValid must agree with decode")
+    }
+
+    @Test
+    fun testDecodeRejectsEncodedLengthThatDoesNotMatchType() {
+        // The signed payload is left out: its legal encoded lengths form a range, so a string one
+        // character longer than a valid one can still be inside it. Its bounds are checked by
+        // testSignedPayloadEncodedLengthBounds.
+        val fixedLengthTypes = strKeyTypes().filter { it.fixedEncodedLength != null }
+        assertEquals(8, fixedLengthTypes.size, "every type but the signed payload has one length")
+
+        for (type in fixedLengthTypes) {
+            val encodedLength = type.fixedEncodedLength!!
+            assertEquals(encodedLength, type.valid.length, "${type.name}: test vector length")
+            assertTrue(type.isValid(type.valid), "${type.name}: a valid strkey must be accepted")
+            assertEquals(
+                type.dataLength, type.decode(type.valid).size,
+                "${type.name}: a valid strkey must decode to its payload"
+            )
+
+            assertRejectedForEncodedLength(
+                type.name,
+                type.valid.substring(0, type.valid.length - 1),
+                encodedLength.toString(),
+                type.decode,
+                type.isValid
+            )
+            assertRejectedForEncodedLength(
+                type.name,
+                type.valid + "A",
+                encodedLength.toString(),
+                type.decode,
+                type.isValid
+            )
+        }
+    }
+
+    /**
+     * Builds well-formed signed payload data: a 32-byte ed25519 public key, the declared
+     * payload length as a big-endian four-byte value, and the payload zero-padded to a
+     * four-byte boundary.
+     */
+    private fun signedPayloadData(payloadLength: Int): ByteArray {
+        val paddedPayloadLength = (payloadLength + 3) / 4 * 4
+        val data = ByteArray(32 + 4 + paddedPayloadLength)
+        for (i in 0 until 32) {
+            data[i] = (i + 1).toByte()
+        }
+        data[32] = ((payloadLength ushr 24) and 0xFF).toByte()
+        data[33] = ((payloadLength ushr 16) and 0xFF).toByte()
+        data[34] = ((payloadLength ushr 8) and 0xFF).toByte()
+        data[35] = (payloadLength and 0xFF).toByte()
+        for (i in 0 until payloadLength) {
+            data[36 + i] = (i + 1).toByte()
+        }
+        return data
+    }
+
+    @Test
+    fun testSignedPayloadEncodedLengthBounds() {
+        // The smallest and the largest signed payload a P... strkey can carry pin the range
+        // of encoded lengths the type admits.
+        val shortest = StrKey.encodeSignedPayload(signedPayloadData(1))
+        assertEquals(69, shortest.length)
+        assertTrue(StrKey.isValidSignedPayload(shortest))
+
+        val longest = StrKey.encodeSignedPayload(signedPayloadData(64))
+        assertEquals(165, longest.length)
+        assertTrue(StrKey.isValidSignedPayload(longest))
+
+        val tooShort = shortest.substring(0, shortest.length - 1)
+        assertEquals(68, tooShort.length)
+        assertRejectedForEncodedLength(
+            "signed payload", tooShort, "69",
+            { StrKey.decodeSignedPayload(it) }, { StrKey.isValidSignedPayload(it) }
+        )
+
+        val tooLong = longest + "A"
+        assertEquals(166, tooLong.length)
+        assertRejectedForEncodedLength(
+            "signed payload", tooLong, "165",
+            { StrKey.decodeSignedPayload(it) }, { StrKey.isValidSignedPayload(it) }
+        )
+    }
+
+    @Test
+    fun testDecodeRejectsMultiMegabyteInput() {
+        // (length * 5) % 8 is below 5 for this length, so the leftover-character check accepts
+        // it: the rejection can only come from the encoded-length check, and it happens before
+        // the string is decoded.
+        val length = 2_000_000
+        assertTrue((length * 5) % 8 < 5, "the length must survive the leftover-character check")
+        val huge = "A".repeat(length)
+
+        assertRejectedForEncodedLength(
+            "ed25519 public key", huge, "56",
+            { StrKey.decodeEd25519PublicKey(it) }, { StrKey.isValidEd25519PublicKey(it) }
+        )
+        assertRejectedForEncodedLength(
+            "claimable balance", huge, "58",
+            { StrKey.decodeClaimableBalance(it) }, { StrKey.isValidClaimableBalance(it) }
+        )
+        assertRejectedForEncodedLength(
+            "signed payload", huge, "165",
+            { StrKey.decodeSignedPayload(it) }, { StrKey.isValidSignedPayload(it) }
+        )
+    }
+
+    private class DecodeEntryPoint(val name: String, val decode: (String) -> ByteArray)
+
+    private fun decodeEntryPoints(): List<DecodeEntryPoint> = listOf(
+        DecodeEntryPoint("decodeEd25519PublicKey") { StrKey.decodeEd25519PublicKey(it) },
+        DecodeEntryPoint("decodeEd25519SecretSeed") { StrKey.decodeEd25519SecretSeed(it.toCharArray()) },
+        DecodeEntryPoint("decodeMed25519PublicKey") { StrKey.decodeMed25519PublicKey(it) },
+        DecodeEntryPoint("decodePreAuthTx") { StrKey.decodePreAuthTx(it) },
+        DecodeEntryPoint("decodeSha256Hash") { StrKey.decodeSha256Hash(it) },
+        DecodeEntryPoint("decodeSignedPayload") { StrKey.decodeSignedPayload(it) },
+        DecodeEntryPoint("decodeContract") { StrKey.decodeContract(it) },
+        DecodeEntryPoint("decodeLiquidityPool") { StrKey.decodeLiquidityPool(it) },
+        DecodeEntryPoint("decodeClaimableBalance") { StrKey.decodeClaimableBalance(it) }
+    )
+
+    @Test
+    fun testDecodeRejectsDegenerateInputsWithIllegalArgumentException() {
+        // Short and degenerate inputs are invalid arguments on every entry point. Nothing from
+        // the IndexOutOfBoundsException family may escape, on any target: assertFailsWith
+        // accepts only IllegalArgumentException and its subtypes.
+        val degenerateInputs = listOf(
+            "",
+            "=",
+            "A",
+            "G",
+            "GA",
+            "GAAA",
+            "========",
+            "GAAAAAAAACGC6",
+            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJ"
+        )
+        for (entryPoint in decodeEntryPoints()) {
+            for (input in degenerateInputs) {
+                assertFailsWith<IllegalArgumentException>(
+                    "${entryPoint.name} must reject \"$input\" with IllegalArgumentException"
+                ) {
+                    entryPoint.decode(input)
+                }
+            }
+        }
+    }
+
+    // ========== Decode: base32 alphabet ==========
+    //
+    // A strkey is written in the 32 characters of the base32 alphabet and in nothing else. The
+    // alphabet check rejects the pad character, whitespace and every other byte, and reports the
+    // same verdict on every platform even though the codec behind it is platform-specific.
+
+    private fun assertRejectedForNonAlphabetCharacter(
+        label: String,
+        candidate: String,
+        check: String,
+        decode: (String) -> ByteArray,
+        isValid: (String) -> Boolean
+    ) {
+        val failure = assertFailsWith<IllegalArgumentException>("$label: must be rejected") {
+            decode(candidate)
+        }
+        assertEquals(
+            nonAlphabetCharacterRejection, failure.message,
+            "$label: rejected by a check other than $check"
+        )
+        assertFalse(isValid(candidate), "$label: isValid must agree with decode")
+    }
+
+    /**
+     * Asserts that [candidate] is turned away by the alphabet check, which every character it
+     * carries reaches: they are all inside the ASCII range, so the guard ahead of that check lets
+     * them through.
+     */
+    private fun assertRejectedByAlphabet(
+        label: String,
+        candidate: String,
+        decode: (String) -> ByteArray,
+        isValid: (String) -> Boolean
+    ) {
+        assertRejectedForNonAlphabetCharacter(
+            label, candidate, "the base32 alphabet", decode, isValid
+        )
+    }
+
+    /**
+     * Asserts that [candidate] is turned away by the guard that admits only characters inside the
+     * ASCII range. A character above that range is stopped there rather than by the alphabet
+     * check, because the guard runs ahead of the narrowing that every later check reads.
+     */
+    private fun assertRejectedByTheAsciiRangeGuard(
+        label: String,
+        candidate: String,
+        decode: (String) -> ByteArray,
+        isValid: (String) -> Boolean
+    ) {
+        assertRejectedForNonAlphabetCharacter(
+            label, candidate, "the guard on the ASCII range", decode, isValid
+        )
+    }
+
+    @Test
+    fun testDecodeRejectsCharacterOutsideTheBase32Alphabet() {
+        // Substituting rather than appending keeps the string at the length its type requires,
+        // so it passes the encoded-length check and reaches the alphabet check. The substituted
+        // position is in the middle, which leaves the last character - the only one the
+        // unused-trailing-bits check reads - as the valid vector had it.
+        val substitutes = listOf("a pad character" to '=', "a space" to ' ', "a tab" to '\t')
+        for (type in strKeyTypes()) {
+            assertTrue(type.isValid(type.valid), "${type.name}: the vector must be valid")
+            for ((description, replacement) in substitutes) {
+                val middle = type.valid.length / 2
+                val candidate =
+                    type.valid.substring(0, middle) + replacement + type.valid.substring(middle + 1)
+                assertEquals(
+                    type.valid.length, candidate.length,
+                    "${type.name}: the substitution must not change the length"
+                )
+                assertRejectedByAlphabet(
+                    "${type.name} carrying $description", candidate, type.decode, type.isValid
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testDecodeRejectsInputOfWhitespaceOrPaddingAlone() {
+        // Both strings are as long as an ed25519 public key strkey, so they pass the
+        // encoded-length check and reach the alphabet check. Neither carries a version byte, so
+        // a decoder that let them through would read past the end of an empty decode result;
+        // assertFailsWith accepts IllegalArgumentException alone, and nothing from the
+        // IndexOutOfBoundsException family is one.
+        val candidates = listOf(
+            "spaces alone" to " ".repeat(56),
+            "pad characters alone" to "=".repeat(56)
+        )
+        for ((description, candidate) in candidates) {
+            assertRejectedByAlphabet(
+                "ed25519 public key of $description", candidate,
+                { StrKey.decodeEd25519PublicKey(it) }, { StrKey.isValidEd25519PublicKey(it) }
+            )
+        }
+    }
+
+    @Test
+    fun testDecodeRejectsLowercaseAlphabet() {
+        // The base32 alphabet is uppercase. Lowercasing keeps the length, so the candidate gets
+        // past the encoded-length check. The last character is left as the vector had it: it is
+        // the one the unused-trailing-bits check reads, and that check runs first, so a lowercase
+        // character there would stop the candidate before it reached the alphabet.
+        for (type in strKeyTypes()) {
+            val lowercased = type.valid.dropLast(1).lowercase() + type.valid.last()
+            assertEquals(type.valid.length, lowercased.length)
+            assertNotEquals(type.valid, lowercased)
+            assertRejectedByAlphabet(
+                "${type.name} in lowercase", lowercased, type.decode, type.isValid
+            )
+        }
+    }
+
+    /**
+     * The character whose low byte spells [spelled], which is the form a decoder narrowing
+     * characters to bytes would mistake for [spelled] itself.
+     */
+    private fun aliasing(spelled: Char): Char = (spelled.code + 0x100).toChar()
+
+    private fun labelFor(char: Char): String =
+        "U+" + char.code.toString(16).uppercase().padStart(4, '0')
+
+    @Test
+    fun testDecodeRejectsCharacterOutsideTheAsciiRange() {
+        // A character above the ASCII range whose low byte spells an alphabet character is the
+        // one input a byte-level alphabet check cannot see for itself. Each candidate replaces
+        // exactly the character its low byte spells, so a decoder that narrowed characters to
+        // their low bytes would read the candidate as the vector and hand back one key for two
+        // different strings.
+        val vector = "GCZHXL5HXQX5ABDM26LHYRCQZ5OJFHLOPLZX47WEBP3V2PF5AVFK2A5D"
+        assertTrue(StrKey.isValidEd25519PublicKey(vector))
+
+        for (spelled in listOf('A', '2', '5')) {
+            val at = vector.indexOf(spelled)
+            assertTrue(at >= 0, "the vector must contain '$spelled' for this candidate to alias onto it")
+            val char = aliasing(spelled)
+            assertEquals(spelled, (char.code and 0xFF).toChar(), "${labelFor(char)} must alias onto '$spelled'")
+
+            val candidate = vector.substring(0, at) + char + vector.substring(at + 1)
+            assertEquals(vector.length, candidate.length)
+            assertNotEquals(vector, candidate)
+            assertRejectedByTheAsciiRangeGuard(
+                "ed25519 public key carrying ${labelFor(char)}", candidate,
+                { StrKey.decodeEd25519PublicKey(it) }, { StrKey.isValidEd25519PublicKey(it) }
+            )
+        }
+
+        // A character in 128..255 keeps its value when narrowed and is no alphabet character
+        // in either form, so unlike the aliasing cases above this one cannot tell the guard
+        // from the alphabet check; it documents the rejection either way.
+        val at = vector.indexOf('A')
+        val latin1 = vector.substring(0, at) + 'Á' + vector.substring(at + 1)
+        assertEquals(vector.length, latin1.length)
+        assertRejectedByTheAsciiRangeGuard(
+            "ed25519 public key carrying U+00C1", latin1,
+            { StrKey.decodeEd25519PublicKey(it) }, { StrKey.isValidEd25519PublicKey(it) }
+        )
+    }
+
+    @Test
+    fun testDecodeRejectsAliasingCharacterInTheLastPosition() {
+        // The last character is the one the unused-trailing-bits check reads, and it reads the
+        // narrowed byte. An aliasing character there has to be rejected before the narrowing,
+        // or that check judges a character the string does not contain.
+        val vector = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ"
+        assertTrue(StrKey.isValidMed25519PublicKey(vector))
+        assertEquals(1, (vector.length * 5) % 8, "the type must leave unused bits in its last character")
+
+        val char = aliasing(vector.last())
+        assertEquals(vector.last(), (char.code and 0xFF).toChar())
+        val candidate = vector.substring(0, vector.length - 1) + char
+        assertEquals(vector.length, candidate.length)
+        assertRejectedByTheAsciiRangeGuard(
+            "muxed ed25519 public key ending in ${labelFor(char)}", candidate,
+            { StrKey.decodeMed25519PublicKey(it) }, { StrKey.isValidMed25519PublicKey(it) }
+        )
+    }
+
+    // ========== Decode: canonical encoding ==========
+    //
+    // A key has exactly one strkey. Padding, characters written after padding and whitespace all
+    // produce a string no encoder emits, and every type rejects every one of them. These cases run
+    // from common code, so each target answers for the codec it carries and all of them have to
+    // give the same answer.
+    //
+    // Every variant below lengthens the string, so for a type of one fixed encoded length the
+    // check that reports it is the encoded-length check rather than the alphabet. For the signed
+    // payload, whose legal lengths form a range, the variant stays inside the range and the check
+    // its resulting length reaches is the one that reports it.
+
+    private class NonCanonicalVariant(
+        val description: String,
+        val build: (String) -> String,
+        /** The check that reports the variant for a type whose encoded lengths form a range. */
+        val rangeTypeRejection: String
+    )
+
+    private fun nonCanonicalVariants(): List<NonCanonicalVariant> = listOf(
+        NonCanonicalVariant("one pad character appended", { "$it=" }, leftoverCharacterRejection),
+        NonCanonicalVariant("three pad characters appended", { "$it===" }, unusedBitsRejection),
+        NonCanonicalVariant("a full pad group appended", { "$it========" }, unusedBitsRejection),
+        NonCanonicalVariant(
+            "characters written after a pad character", { "$it=ZZZZZZZ" }, unusedBitsRejection
+        ),
+        NonCanonicalVariant("eight trailing spaces", { "$it        " }, unusedBitsRejection),
+        NonCanonicalVariant(
+            "a space inserted mid-string",
+            { it.substring(0, 10) + " " + it.substring(10) },
+            leftoverCharacterRejection
+        ),
+        NonCanonicalVariant(
+            "a tab inserted mid-string",
+            { it.substring(0, 10) + "\t" + it.substring(10) },
+            leftoverCharacterRejection
+        )
+    )
+
+    @Test
+    fun testDecodeRejectsNonCanonicalVariantsOfAValidStrKey() {
+        for (type in strKeyTypes()) {
+            assertTrue(type.isValid(type.valid), "${type.name}: the vector must be valid")
+            for (variant in nonCanonicalVariants()) {
+                val candidate = variant.build(type.valid)
+                val label = "${type.name} with ${variant.description}"
+                assertTrue(candidate.length > type.valid.length, "$label: must lengthen the string")
+
+                val failure = assertFailsWith<IllegalArgumentException>("$label: must be rejected") {
+                    type.decode(candidate)
+                }
+                val expected = if (type.fixedEncodedLength != null) {
+                    "$encodedLengthRejection, expected ${type.fixedEncodedLength} characters, " +
+                        "got ${candidate.length}"
+                } else {
+                    variant.rangeTypeRejection
+                }
+                assertEquals(
+                    expected, failure.message,
+                    "$label: the rejection must name the check that reports it"
+                )
+                assertFalse(type.isValid(candidate), "$label: isValid must agree with decode")
+            }
+        }
+    }
+
+    // ========== Decode and encode: signed payload framing ==========
+    //
+    // A signed payload frames its bytes the way the XDR wire form does: a 32-byte ed25519 public
+    // key, the declared payload length written as a big-endian four-byte value, and the payload
+    // padded with zeros to a four-byte boundary. The declared length has to name a payload the
+    // type can carry, the data size has to fit that length exactly, and the padding after the
+    // payload has to be zero. Each rejection below names the rule it exercises, so no case can
+    // pass on the strength of a different check.
+
+    private val signedPayloadDeclaredLengthRejection = "Invalid signed payload declared length"
+    private val signedPayloadSizeRejection = "Invalid signed payload size"
+    private val signedPayloadPaddingRejection = "Invalid signed payload padding"
+
+    /**
+     * The declared payload length a signed payload's data carries, read big-endian from the four
+     * bytes that follow the ed25519 public key.
+     */
+    private fun declaredPayloadLength(data: ByteArray): Long {
+        var length = 0L
+        for (index in 32 until 36) {
+            length = (length shl 8) or (data[index].toLong() and 0xFF)
+        }
+        return length
+    }
+
+    /**
+     * The data bytes [strKey] carries, having checked that it is a signed payload whose checksum
+     * matches. A vector that failed either check would be rejected for that rather than for the
+     * framing it is written to exercise.
+     */
+    private fun checkedSignedPayloadData(strKey: String): ByteArray {
+        val decoded = Base32Codec.decode(strKey.map { it.code.toByte() }.toByteArray())
+        val payload = decoded.copyOfRange(0, decoded.size - 2)
+        val checksum = decoded.copyOfRange(decoded.size - 2, decoded.size)
+        assertTrue(
+            crc16XModem(payload).contentEquals(checksum),
+            "the vector must carry a valid checksum"
+        )
+        assertEquals(signedPayloadVersionByte, payload[0], "the vector must be a signed payload")
+        return payload.copyOfRange(1, payload.size)
+    }
+
+    private fun assertSignedPayloadRejected(label: String, candidate: String, rejection: String) {
+        val failure = assertFailsWith<IllegalArgumentException>("$label: must be rejected") {
+            StrKey.decodeSignedPayload(candidate)
+        }
+        assertEquals(rejection, failure.message, "$label: the rejection must name the rule broken")
+        assertFalse(StrKey.isValidSignedPayload(candidate), "$label: isValid must agree with decode")
+    }
+
+    @Test
+    fun testDecodeRejectsSignedPayloadDeclaringALengthItCannotCarry() {
+        // A 32-byte ed25519 public key, a declared length of 0 and four zero bytes. A signed
+        // payload names at least one payload byte, so 0 is not a length it can declare.
+        val declaresZero = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAABO6A"
+        val zeroData = checkedSignedPayloadData(declaresZero)
+        assertEquals(40, zeroData.size)
+        assertEquals(0L, declaredPayloadLength(zeroData))
+        assertSignedPayloadRejected(
+            "a declared length of 0", declaresZero,
+            "$signedPayloadDeclaredLengthRejection, expected between 1 and 64 bytes, got 0"
+        )
+
+        // A 32-byte ed25519 public key, a declared length of 65 and 64 payload bytes: the largest
+        // data a P... strkey can carry, declaring one byte more than the type admits.
+        val declaresSixtyFive =
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAQCAQDAQCQMBYIBEFAWD" +
+                "ANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IBBEIRSIJJGE4UCSKRLFQWS4LZQGEZDGNBVGY3TQOJ2H" +
+                "M6D2PR7ICJ4E"
+        val sixtyFiveData = checkedSignedPayloadData(declaresSixtyFive)
+        assertEquals(100, sixtyFiveData.size)
+        assertEquals(65L, declaredPayloadLength(sixtyFiveData))
+        assertSignedPayloadRejected(
+            "a declared length of 65", declaresSixtyFive,
+            "$signedPayloadDeclaredLengthRejection, expected between 1 and 64 bytes, got 65"
+        )
+    }
+
+    @Test
+    fun testDecodeRejectsSignedPayloadDeclaringMoreThanThePayloadPresent() {
+        // A 32-byte ed25519 public key, a declared length of 64 and four payload bytes. The
+        // declared length is one a signed payload can carry, but not one these 40 bytes hold.
+        val declaresMoreThanItHolds =
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAQ3PY"
+        val data = checkedSignedPayloadData(declaresMoreThanItHolds)
+        assertEquals(40, data.size)
+        assertEquals(64L, declaredPayloadLength(data))
+        assertSignedPayloadRejected(
+            "a declared length of 64 inside 40 bytes",
+            declaresMoreThanItHolds,
+            "$signedPayloadSizeRejection, a declared length of 64 requires 100 bytes, got 40"
+        )
+    }
+
+    @Test
+    fun testDecodeRejectsSignedPayloadWithNonZeroPadding() {
+        // A 32-byte ed25519 public key, a declared length of 29, 29 payload bytes and three
+        // padding bytes of 0xff. The data size fits the declared length exactly, so the padding
+        // is the only thing wrong with it and the only rule that can reject it.
+        val nonZeroPadding =
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+                "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DX77776K34"
+        val data = checkedSignedPayloadData(nonZeroPadding)
+        assertEquals(68, data.size)
+        assertEquals(29L, declaredPayloadLength(data))
+        assertEquals(
+            data.size, 36 + (29 + 3) / 4 * 4,
+            "the data size must fit the declared length exactly"
+        )
+        assertTrue(
+            data.copyOfRange(36 + 29, data.size).all { it != 0.toByte() },
+            "every padding byte must be non-zero"
+        )
+        assertSignedPayloadRejected(
+            "non-zero padding", nonZeroPadding,
+            "$signedPayloadPaddingRejection, expected zero at index 65 after a declared length " +
+                "of 29, got 255"
+        )
+    }
+
+    @Test
+    fun testSignedPayloadAcceptsEveryLegalPayloadLength() {
+        for (payloadLength in 1..64) {
+            val data = signedPayloadData(payloadLength)
+            assertEquals(
+                36 + (payloadLength + 3) / 4 * 4, data.size,
+                "payload length $payloadLength: framed size"
+            )
+
+            val encoded = StrKey.encodeSignedPayload(data)
+            assertTrue(encoded.startsWith("P"), "payload length $payloadLength: must encode to a P... strkey")
+            assertTrue(
+                StrKey.isValidSignedPayload(encoded),
+                "payload length $payloadLength: must be valid"
+            )
+            assertTrue(
+                data.contentEquals(StrKey.decodeSignedPayload(encoded)),
+                "payload length $payloadLength: must round-trip"
+            )
+        }
+    }
+
+    /**
+     * Signed payload data of [dataSize] bytes whose declared length field holds [declaredLength],
+     * whether or not the two agree.
+     */
+    private fun signedPayloadDataDeclaring(declaredLength: Int, dataSize: Int): ByteArray {
+        val data = ByteArray(dataSize)
+        for (i in 0 until 32) {
+            data[i] = (i + 1).toByte()
+        }
+        data[32] = ((declaredLength ushr 24) and 0xFF).toByte()
+        data[33] = ((declaredLength ushr 16) and 0xFF).toByte()
+        data[34] = ((declaredLength ushr 8) and 0xFF).toByte()
+        data[35] = (declaredLength and 0xFF).toByte()
+        return data
+    }
+
+    @Test
+    fun testEncodeSignedPayloadRejectsFramingItsDecoderRejects() {
+        val wellFramed = signedPayloadData(29)
+        assertTrue(
+            StrKey.isValidSignedPayload(StrKey.encodeSignedPayload(wellFramed)),
+            "what the encoder emits must be what the decoder accepts"
+        )
+
+        val nonZeroPadding = signedPayloadData(29)
+        nonZeroPadding[nonZeroPadding.size - 1] = 0xFF.toByte()
+
+        val cases = listOf(
+            Triple(
+                "a declared length of 0",
+                signedPayloadDataDeclaring(0, 40),
+                "$signedPayloadDeclaredLengthRejection, expected between 1 and 64 bytes, got 0"
+            ),
+            Triple(
+                "a declared length of 65",
+                signedPayloadDataDeclaring(65, 100),
+                "$signedPayloadDeclaredLengthRejection, expected between 1 and 64 bytes, got 65"
+            ),
+            Triple(
+                "a declared length of 64 inside 40 bytes",
+                signedPayloadDataDeclaring(64, 40),
+                "$signedPayloadSizeRejection, a declared length of 64 requires 100 bytes, got 40"
+            ),
+            Triple(
+                "non-zero padding",
+                nonZeroPadding,
+                "$signedPayloadPaddingRejection, expected zero at index 67 after a declared " +
+                    "length of 29, got 255"
+            )
+        )
+
+        for ((description, data, rejection) in cases) {
+            val failure = assertFailsWith<IllegalArgumentException>("$description: must be rejected") {
+                StrKey.encodeSignedPayload(data)
+            }
+            assertEquals(
+                rejection, failure.message,
+                "$description: the rejection must name the rule broken"
+            )
+        }
+    }
+
+    // ========== Decode and encode: claimable balance discriminant ==========
+    //
+    // A claimable balance id is the one case its XDR union declares: a type discriminant of 0
+    // followed by a 32-byte hash. Any other discriminant names a type the union does not
+    // declare, so neither end of the codec handles it. Each rejection below names the rule it
+    // exercises, so no case can pass on the strength of a different check.
+
+    private val claimableBalanceDiscriminantRejection = "Invalid claimable balance discriminant"
+
+    private val claimableBalanceHash = ByteArray(32) { index -> (index * 5 + 1).toByte() }
+
+    /**
+     * The data bytes [strKey] carries, having checked that it is a claimable balance id whose
+     * checksum matches. A vector that failed either check would be rejected for that rather than
+     * for the discriminant it is written to exercise.
+     */
+    private fun checkedClaimableBalanceData(strKey: String): ByteArray {
+        val decoded = Base32Codec.decode(strKey.map { it.code.toByte() }.toByteArray())
+        val payload = decoded.copyOfRange(0, decoded.size - 2)
+        val checksum = decoded.copyOfRange(decoded.size - 2, decoded.size)
+        assertTrue(
+            crc16XModem(payload).contentEquals(checksum),
+            "the vector must carry a valid checksum"
+        )
+        assertEquals(
+            claimableBalanceVersionByte, payload[0],
+            "the vector must be a claimable balance id"
+        )
+        return payload.copyOfRange(1, payload.size)
+    }
+
+    private fun assertClaimableBalanceRejected(
+        label: String,
+        candidate: String,
+        rejection: String
+    ) {
+        val failure = assertFailsWith<IllegalArgumentException>("$label: must be rejected") {
+            StrKey.decodeClaimableBalance(candidate)
+        }
+        assertEquals(rejection, failure.message, "$label: the rejection must name the rule broken")
+        assertFalse(
+            StrKey.isValidClaimableBalance(candidate),
+            "$label: isValid must agree with decode"
+        )
+    }
+
+    @Test
+    fun testDecodeRejectsClaimableBalanceDiscriminantOtherThanTheOneDeclared() {
+        // Both ends of the values a discriminant byte can hold beyond the one the union
+        // declares. Each strkey is built with a valid checksum and the length its type requires,
+        // so the discriminant is the only check left that can reject it.
+        for (discriminant in listOf(1, 255)) {
+            val candidate = craftStrKey(
+                claimableBalanceVersionByte,
+                byteArrayOf(discriminant.toByte()) + claimableBalanceHash
+            )
+            assertEquals(58, candidate.length, "discriminant $discriminant: encoded length")
+            assertEquals(
+                discriminant, checkedClaimableBalanceData(candidate)[0].toInt() and 0xFF,
+                "discriminant $discriminant: the vector must carry it"
+            )
+            assertClaimableBalanceRejected(
+                "a discriminant of $discriminant", candidate,
+                "$claimableBalanceDiscriminantRejection, expected 0, got $discriminant"
+            )
+        }
+    }
+
+    @Test
+    fun testClaimableBalanceRoundTripsUnderTheDiscriminantTheUnionDeclares() {
+        val data = byteArrayOf(0) + claimableBalanceHash
+
+        val encoded = StrKey.encodeClaimableBalance(data)
+        assertTrue(encoded.startsWith("B"), "must encode to a B... strkey")
+        assertEquals(58, encoded.length, "encoded length")
+        assertTrue(StrKey.isValidClaimableBalance(encoded), "must be valid")
+        assertTrue(data.contentEquals(StrKey.decodeClaimableBalance(encoded)), "must round-trip")
+
+        // The hash on its own names no type and is written under the same discriminant, so the
+        // two forms of the same claimable balance id spell one strkey.
+        assertEquals(encoded, StrKey.encodeClaimableBalance(claimableBalanceHash))
+    }
+
+    @Test
+    fun testEncodeClaimableBalanceRejectsADiscriminantItsDecoderRejects() {
+        for (discriminant in listOf(1, 255)) {
+            val failure = assertFailsWith<IllegalArgumentException>(
+                "a discriminant of $discriminant: must be rejected"
+            ) {
+                StrKey.encodeClaimableBalance(
+                    byteArrayOf(discriminant.toByte()) + claimableBalanceHash
+                )
+            }
+            assertEquals(
+                "$claimableBalanceDiscriminantRejection, expected 0, got $discriminant",
+                failure.message,
+                "a discriminant of $discriminant: the rejection must name the rule broken"
+            )
+        }
+    }
+
+    @Test
+    fun testEncodeClaimableBalanceReadsTheXdrFormUnderTheDiscriminantTheUnionDeclares() {
+        val xdrForm = ByteArray(4) + claimableBalanceHash
+
+        val encoded = StrKey.encodeClaimableBalance(xdrForm)
+        assertEquals(
+            StrKey.encodeClaimableBalance(claimableBalanceHash), encoded,
+            "the XDR form and the bare hash name one balance"
+        )
+        assertTrue(
+            (byteArrayOf(0) + claimableBalanceHash)
+                .contentEquals(StrKey.decodeClaimableBalance(encoded)),
+            "the XDR form must reach the strkey body the decoder hands back"
+        )
+    }
+
+    @Test
+    fun testEncodeClaimableBalanceRejectsAnXdrFormDiscriminantTheUnionDoesNotDeclare() {
+        // Every byte of the wider discriminant is read. The first three carry a value only
+        // above the last byte, which a check reading that byte alone would let through.
+        val carriedByPrefix = mapOf(
+            "01000000" to "0x1000000",
+            "00010000" to "0x10000",
+            "00000100" to "0x100",
+            "00000001" to "0x1",
+            "ffffffff" to "0xffffffff"
+        )
+        for ((prefix, carried) in carriedByPrefix) {
+            val failure = assertFailsWith<IllegalArgumentException>(
+                "the XDR form prefixed $prefix: must be rejected"
+            ) {
+                StrKey.encodeClaimableBalance(hexToBytes(prefix) + claimableBalanceHash)
+            }
+            assertEquals(
+                "$claimableBalanceDiscriminantRejection, expected 0, got $carried",
+                failure.message,
+                "the XDR form prefixed $prefix: the rejection must name the rule broken"
+            )
+        }
     }
 }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/StrKeyTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/StrKeyTest.kt
@@ -1107,6 +1107,58 @@ class StrKeyTest {
         }
     }
 
+    @Test
+    fun testEncodeRefusesAPayloadOnEitherSideOfTheLengthItsTypeAdmits() {
+        // A payload is read on both sides of the length its type admits: one byte short and one
+        // byte long are each refused, and the refusal names the length the type has. A check that
+        // only bounded the payload from below would write a key carrying more bytes than its type
+        // holds.
+        val encoders = listOf(
+            Triple("Public key", 32) { data: ByteArray -> StrKey.encodeEd25519PublicKey(data) },
+            Triple("Secret seed", 32) { data: ByteArray -> StrKey.encodeEd25519SecretSeed(data) },
+            Triple("Muxed public key", 40) { data: ByteArray ->
+                StrKey.encodeMed25519PublicKey(data)
+            },
+            Triple("Pre-auth transaction hash", 32) { data: ByteArray ->
+                StrKey.encodePreAuthTx(data)
+            },
+            Triple("SHA-256 hash", 32) { data: ByteArray -> StrKey.encodeSha256Hash(data) },
+            Triple("Contract address", 32) { data: ByteArray -> StrKey.encodeContract(data) },
+            Triple("Liquidity pool ID", 32) { data: ByteArray -> StrKey.encodeLiquidityPool(data) }
+        )
+
+        for ((name, size, encode) in encoders) {
+            for (given in listOf(size - 1, size + 1)) {
+                val failure = assertFailsWith<IllegalArgumentException>(
+                    "$name: $given bytes must be refused"
+                ) {
+                    encode(ByteArray(given))
+                }
+                assertEquals(
+                    "$name must be $size bytes, got $given", failure.message,
+                    "$name: the refusal must name the length the type has"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testTheCodecRefusesABytePastItsAlphabet() {
+        // The alphabet gate is the precondition the codec decodes under. A codec that dropped
+        // the byte instead would hand back a result the input does not spell.
+        for (outside in listOf('1', '0', '8', '9', 'a', 'z', '=', ' ')) {
+            val failure = assertFailsWith<IllegalArgumentException>(
+                "\"$outside\" must be refused"
+            ) {
+                Base32Codec.decode(byteArrayOf('A'.code.toByte(), outside.code.toByte()))
+            }
+            assertEquals(
+                INVALID_BASE32_MESSAGE, failure.message,
+                "\"$outside\": the refusal must name the rule broken"
+            )
+        }
+    }
+
     // ========== Decode: payload-length validation ==========
     //
     // Two checks bound the payload, and they read the type from different places. The encoded

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/UtilTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/UtilTest.kt
@@ -174,6 +174,95 @@ class UtilTest {
         assertEquals("TESTASSET", Util.paddedByteArrayToString(padded12))
     }
 
+    // ========== hexToBytes: strict ASCII hex alphabet ==========
+
+    @Test
+    fun testHexToBytesRoundTrip() {
+        val bytes = ByteArray(32) { it.toByte() }
+        assertContentEquals(bytes, Util.hexToBytes(Util.bytesToHex(bytes)))
+    }
+
+    @Test
+    fun testHexToBytesAcceptsMixedCase() {
+        // The documented contract is case-insensitive: mixed-case valid hex must parse
+        // to the same bytes as its lowercase form.
+        val mixed = "0A1b2C3d4E5f6789AbCdEf0123456789abcdef0123456789ABCDEF0123456789"
+        assertContentEquals(Util.hexToBytes(mixed.lowercase()), Util.hexToBytes(mixed))
+        assertEquals(32, Util.hexToBytes(mixed).size)
+    }
+
+    @Test
+    fun testHexToBytesEmptyStringYieldsEmptyArray() {
+        assertContentEquals(ByteArray(0), Util.hexToBytes(""))
+    }
+
+    @Test
+    fun testHexToBytesRejectsOddLength() {
+        val exception = assertFailsWith<IllegalArgumentException> { Util.hexToBytes("abc") }
+        assertTrue(
+            exception.message?.contains("even length") ?: false,
+            "Unexpected message: ${exception.message}"
+        )
+    }
+
+    @Test
+    fun testHexToBytesRejectsNegativeSignPairs() {
+        // A per-pair radix parse reads "-1" as -1 and truncates it to 0xff, so a 64-character
+        // string of sign pairs would decode to a full 32-byte id that the caller never wrote.
+        val exception = assertFailsWith<IllegalArgumentException> {
+            Util.hexToBytes("-1".repeat(32))
+        }
+        assertTrue(
+            exception.message?.contains("0-9 and a-f") ?: false,
+            "Unexpected message: ${exception.message}"
+        )
+    }
+
+    @Test
+    fun testHexToBytesRejectsPositiveSignPairs() {
+        assertFailsWith<IllegalArgumentException> { Util.hexToBytes("+1".repeat(32)) }
+    }
+
+    @Test
+    fun testHexToBytesRejectsArabicIndicDigits() {
+        // U+0661 U+0662 are Unicode decimal digits that a radix parse accepts as 1 and 2.
+        assertFailsWith<IllegalArgumentException> { Util.hexToBytes("١٢") }
+    }
+
+    @Test
+    fun testHexToBytesRejectsFullwidthDigits() {
+        // U+FF11 U+FF12 are the fullwidth forms of 1 and 2.
+        assertFailsWith<IllegalArgumentException> { Util.hexToBytes("１２") }
+    }
+
+    @Test
+    fun testHexToBytesRejectsFullwidthLetters() {
+        // Fullwidth letters lowercase to fullwidth letters, so case folding alone does not
+        // map U+FF21 U+FF22 onto the ASCII alphabet.
+        assertFailsWith<IllegalArgumentException> { Util.hexToBytes("ＡＢ") }
+    }
+
+    @Test
+    fun testHexToBytesRejectsNonHexLetters() {
+        assertFailsWith<IllegalArgumentException> { Util.hexToBytes("0g") }
+        assertFailsWith<IllegalArgumentException> { Util.hexToBytes("zz") }
+    }
+
+    @Test
+    fun testHexToBytesRejectsWhitespaceAndPrefix() {
+        assertFailsWith<IllegalArgumentException> { Util.hexToBytes("01 02") }
+        assertFailsWith<IllegalArgumentException> { Util.hexToBytes("0x0102") }
+    }
+
+    @Test
+    fun testHexToBytesErrorNamesTheOffendingCharacter() {
+        val exception = assertFailsWith<IllegalArgumentException> { Util.hexToBytes("00zz") }
+        assertTrue(
+            exception.message?.contains("'z'") ?: false,
+            "Message should name the offending character: ${exception.message}"
+        )
+    }
+
     @Test
     fun testIsFatal_cancellationException_isFatal() {
         assertTrue(isFatal(CancellationException("cancelled")))

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/contract/ContractSpecTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/contract/ContractSpecTest.kt
@@ -2476,6 +2476,55 @@ class ContractSpecTest {
         }
     }
 
+    // ========== hexToBytes: strict hex alphabet ==========
+
+    @Test
+    fun testBytesConversionFromSignedHexPairsThrows() {
+        // "-1" pairs parse as -1 per pair under a bare radix parse and would truncate to 0xff,
+        // producing bytes that do not correspond to the supplied string.
+        val spec = ContractSpec(emptyList())
+        val typeDef = createTypeDef(SCSpecTypeXdr.SC_SPEC_TYPE_BYTES)
+        assertFailsWith<ContractSpecException> { spec.nativeToXdrSCVal("-1-1-1-1", typeDef) }
+        assertFailsWith<ContractSpecException> { spec.nativeToXdrSCVal("0x+1+1", typeDef) }
+    }
+
+    @Test
+    fun testBytesConversionFromUnicodeDigitHexThrows() {
+        val spec = ContractSpec(emptyList())
+        val typeDef = createTypeDef(SCSpecTypeXdr.SC_SPEC_TYPE_BYTES)
+        assertFailsWith<ContractSpecException> { spec.nativeToXdrSCVal("１２", typeDef) }
+        assertFailsWith<ContractSpecException> { spec.nativeToXdrSCVal("١٢", typeDef) }
+    }
+
+    @Test
+    fun testBytesConversionFromSpacedHexThrows() {
+        val spec = ContractSpec(emptyList())
+        val typeDef = createTypeDef(SCSpecTypeXdr.SC_SPEC_TYPE_BYTES)
+        assertFailsWith<ContractSpecException> { spec.nativeToXdrSCVal("01 02 03", typeDef) }
+    }
+
+    @Test
+    fun testBytesConversionFromMixedCaseHex() {
+        // The hex input is case-insensitive, with or without the "0x" prefix.
+        val spec = ContractSpec(emptyList())
+        val typeDef = createTypeDef(SCSpecTypeXdr.SC_SPEC_TYPE_BYTES)
+
+        val prefixed = spec.nativeToXdrSCVal("0xAbCdEf", typeDef)
+        assertTrue(prefixed is SCValXdr.Bytes)
+        assertContentEquals(byteArrayOf(0xAB.toByte(), 0xCD.toByte(), 0xEF.toByte()), prefixed.value.value)
+
+        val bare = spec.nativeToXdrSCVal("aBcDeF", typeDef)
+        assertTrue(bare is SCValXdr.Bytes)
+        assertContentEquals(byteArrayOf(0xAB.toByte(), 0xCD.toByte(), 0xEF.toByte()), bare.value.value)
+    }
+
+    @Test
+    fun testBytesNConversionFromSignedHexPairsThrows() {
+        val spec = ContractSpec(emptyList())
+        val typeDef = SCSpecTypeDefXdr.BytesN(SCSpecTypeBytesNXdr(Uint32Xdr(3u)))
+        assertFailsWith<ContractSpecException> { spec.nativeToXdrSCVal("-1-1-1", typeDef) }
+    }
+
     // ========== handleResultType: non-null "ok" value with a VOID ok type ==========
 
     @Test

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/requests/ClaimableBalanceRoutingTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/requests/ClaimableBalanceRoutingTest.kt
@@ -1,6 +1,7 @@
 package com.soneso.stellar.sdk.unitTests.horizon.requests
 
 import com.soneso.stellar.sdk.horizon.HorizonServer
+import com.soneso.stellar.sdk.unitTests.ClaimableBalanceVectors
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -27,29 +28,21 @@ class ClaimableBalanceRoutingTest {
 
     private val serverUrl = "https://horizon-testnet.stellar.org"
 
-    /** The 32-byte balance hash the vectors are built around. */
-    private val hashHex = "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
-
-    private val strKey = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+    private val strKey = ClaimableBalanceVectors.strKey
 
     /** The spelling Horizon serves: the hexadecimal of the XDR form. */
-    private val horizonHex = "00000000$hashHex"
+    private val horizonHex = ClaimableBalanceVectors.paddedHex
 
-    /** Every spelling of the one balance, the strkey and a case variant among them. */
-    private val spellings = listOf(strKey, hashHex, "00$hashHex", horizonHex, hashHex.uppercase())
+    private val spellings = ClaimableBalanceVectors.spellings
 
     /**
-     * Ids naming no claimable balance: a length no spelling has, the legacy 63-character id,
-     * a discriminant the union does not declare in either width - the second carries it only
-     * above the last byte - and hexadecimal the alphabet does not contain.
+     * Ids naming no claimable balance, beyond [ClaimableBalanceVectors.rejections]: a length no
+     * spelling has, and the legacy 63-character id.
      */
     private val rejected = listOf(
         "not a claimable balance id",
-        "BAAAAAAAJXMXZMNAXINW4GQYRNE55L523HRUZAHCO7BXEX4BLR2XYLIF3X7IL2Y",
-        "01$hashHex",
-        "01000000$hashHex",
-        "z".repeat(72)
-    )
+        "BAAAAAAAJXMXZMNAXINW4GQYRNE55L523HRUZAHCO7BXEX4BLR2XYLIF3X7IL2Y"
+    ) + ClaimableBalanceVectors.rejections
 
     private val claimableBalanceJson = """
         {

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/requests/ClaimableBalanceRoutingTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/requests/ClaimableBalanceRoutingTest.kt
@@ -1,0 +1,238 @@
+package com.soneso.stellar.sdk.unitTests.horizon.requests
+
+import com.soneso.stellar.sdk.horizon.HorizonServer
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * The route and the claimable balance id spelling the request builders put on the wire.
+ *
+ * Horizon serves a claimable balance under one spelling of its id, the hexadecimal of the XDR
+ * form. Every spelling a caller may hold has to reach that route, and an id naming no balance
+ * has to be reported before a request is sent.
+ */
+class ClaimableBalanceRoutingTest {
+
+    private val serverUrl = "https://horizon-testnet.stellar.org"
+
+    /** The 32-byte balance hash the vectors are built around. */
+    private val hashHex = "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
+
+    private val strKey = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+
+    /** The spelling Horizon serves: the hexadecimal of the XDR form. */
+    private val horizonHex = "00000000$hashHex"
+
+    /** Every spelling of the one balance, the strkey and a case variant among them. */
+    private val spellings = listOf(strKey, hashHex, "00$hashHex", horizonHex, hashHex.uppercase())
+
+    /**
+     * Ids naming no claimable balance: a length no spelling has, the legacy 63-character id,
+     * a discriminant the union does not declare in either width - the second carries it only
+     * above the last byte - and hexadecimal the alphabet does not contain.
+     */
+    private val rejected = listOf(
+        "not a claimable balance id",
+        "BAAAAAAAJXMXZMNAXINW4GQYRNE55L523HRUZAHCO7BXEX4BLR2XYLIF3X7IL2Y",
+        "01$hashHex",
+        "01000000$hashHex",
+        "z".repeat(72)
+    )
+
+    private val claimableBalanceJson = """
+        {
+            "id": "$horizonHex",
+            "asset": "native",
+            "amount": "12.3000000",
+            "sponsor": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "last_modified_ledger": 7877447,
+            "last_modified_time": "2021-11-18T03:47:47Z",
+            "paging_token": "12884905984-$horizonHex",
+            "claimants": [
+                {
+                    "destination": "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
+                    "predicate": {"unconditional": true}
+                }
+            ],
+            "_links": {
+                "self": {"href": "$serverUrl/claimable_balances/$horizonHex"}
+            }
+        }
+    """.trimIndent()
+
+    private val emptyPageJson = """
+        {
+            "_links": {"self": {"href": "$serverUrl/claimable_balances"}},
+            "_embedded": {"records": []}
+        }
+    """.trimIndent()
+
+    /**
+     * A client serving [body] for every request, recording the path of each one it is asked
+     * for. The mock matches every path, so a request for a route the SDK should never build is
+     * recorded here rather than escaping to the network.
+     */
+    private fun recordingClient(body: String, recorded: MutableList<String>): HttpClient {
+        val engine = MockEngine { request ->
+            recorded.add(request.url.encodedPath)
+            respond(
+                content = body,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        return HttpClient(engine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true; isLenient = true })
+            }
+        }
+    }
+
+    // ========== The id every claimable balance route carries ==========
+
+    @Test
+    fun testClaimableBalanceAsksForTheHorizonHexOfEverySpelling() = runTest {
+        for (spelling in spellings) {
+            val recorded = mutableListOf<String>()
+            val server = HorizonServer(
+                serverUrl,
+                httpClient = recordingClient(claimableBalanceJson, recorded)
+            )
+
+            val balance = server.claimableBalances().claimableBalance(spelling)
+
+            assertEquals(horizonHex, balance.id, "spelling: $spelling")
+            assertEquals(listOf("/claimable_balances/$horizonHex"), recorded, "spelling: $spelling")
+            server.close()
+        }
+    }
+
+    @Test
+    fun testOperationsForClaimableBalanceAsksForTheHorizonHexOfEverySpelling() = runTest {
+        for (spelling in spellings) {
+            val recorded = mutableListOf<String>()
+            val server =
+                HorizonServer(serverUrl, httpClient = recordingClient(emptyPageJson, recorded))
+
+            val builder = server.operations().forClaimableBalance(spelling)
+            assertEquals(
+                "/claimable_balances/$horizonHex/operations", builder.buildUrl().encodedPath,
+                "spelling: $spelling"
+            )
+
+            builder.execute()
+            assertEquals(
+                listOf("/claimable_balances/$horizonHex/operations"), recorded,
+                "spelling: $spelling"
+            )
+            server.close()
+        }
+    }
+
+    @Test
+    fun testTransactionsForClaimableBalanceAsksForTheHorizonHexOfEverySpelling() = runTest {
+        for (spelling in spellings) {
+            val recorded = mutableListOf<String>()
+            val server =
+                HorizonServer(serverUrl, httpClient = recordingClient(emptyPageJson, recorded))
+
+            val builder = server.transactions().forClaimableBalance(spelling)
+            assertEquals(
+                "/claimable_balances/$horizonHex/transactions", builder.buildUrl().encodedPath,
+                "spelling: $spelling"
+            )
+
+            builder.execute()
+            assertEquals(
+                listOf("/claimable_balances/$horizonHex/transactions"), recorded,
+                "spelling: $spelling"
+            )
+            server.close()
+        }
+    }
+
+    @Test
+    fun testTheRouteCarriesTheCursorAndTheHorizonHexTogether() {
+        val server = HorizonServer(serverUrl)
+        val url = server.transactions().forClaimableBalance(strKey).cursor("now").buildUrl()
+        assertEquals("/claimable_balances/$horizonHex/transactions", url.encodedPath)
+        assertEquals("now", url.parameters["cursor"])
+        server.close()
+    }
+
+    // ========== An id naming no claimable balance ==========
+
+    @Test
+    fun testClaimableBalanceRejectsAnIdNamingNoBalanceBeforeAnyRequest() = runTest {
+        for (candidate in rejected) {
+            val recorded = mutableListOf<String>()
+            val server = HorizonServer(
+                serverUrl,
+                httpClient = recordingClient(claimableBalanceJson, recorded)
+            )
+
+            assertFailsWith<IllegalArgumentException>("\"$candidate\" must be rejected") {
+                server.claimableBalances().claimableBalance(candidate)
+            }
+            assertTrue(recorded.isEmpty(), "\"$candidate\": no request may be sent")
+            server.close()
+        }
+    }
+
+    @Test
+    fun testOperationsForClaimableBalanceRejectsAnIdNamingNoBalanceBeforeAnyRequest() = runTest {
+        for (candidate in rejected) {
+            val recorded = mutableListOf<String>()
+            val server =
+                HorizonServer(serverUrl, httpClient = recordingClient(emptyPageJson, recorded))
+
+            assertFailsWith<IllegalArgumentException>("\"$candidate\" must be rejected") {
+                server.operations().forClaimableBalance(candidate)
+            }
+            assertTrue(recorded.isEmpty(), "\"$candidate\": no request may be sent")
+            server.close()
+        }
+    }
+
+    @Test
+    fun testTransactionsForClaimableBalanceRejectsAnIdNamingNoBalanceBeforeAnyRequest() = runTest {
+        for (candidate in rejected) {
+            val recorded = mutableListOf<String>()
+            val server =
+                HorizonServer(serverUrl, httpClient = recordingClient(emptyPageJson, recorded))
+
+            assertFailsWith<IllegalArgumentException>("\"$candidate\" must be rejected") {
+                server.transactions().forClaimableBalance(candidate)
+            }
+            assertTrue(recorded.isEmpty(), "\"$candidate\": no request may be sent")
+            server.close()
+        }
+    }
+
+    @Test
+    fun testTheRejectionNamesTheAcceptedSpellings() {
+        val server = HorizonServer(serverUrl)
+        val failure = assertFailsWith<IllegalArgumentException> {
+            server.operations().forClaimableBalance("not a claimable balance id")
+        }
+        assertEquals(
+            "claimable balance id must be a 58 character strkey (B...), or hex of the bare id " +
+                "(64 characters), which a discriminant may prefix to 66 or 72 characters; " +
+                "26 characters given",
+            failure.message
+        )
+        server.close()
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/requests/EffectsRequestBuilderTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/requests/EffectsRequestBuilderTest.kt
@@ -64,16 +64,6 @@ class EffectsRequestBuilderTest {
     }
 
     @Test
-    fun testForClaimableBalance() {
-        val server = HorizonServer("https://horizon-testnet.stellar.org")
-        val balanceId = "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be"
-        val builder = server.effects().forClaimableBalance(balanceId)
-        val url = builder.buildUrl().toString()
-        assertTrue(url.contains("claimable_balances/$balanceId/effects"))
-        server.close()
-    }
-
-    @Test
     fun testCursor() {
         val server = HorizonServer("https://horizon-testnet.stellar.org")
         val builder = server.effects().cursor("cursor123")

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/responses/CreatedClaimableBalanceIdTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/responses/CreatedClaimableBalanceIdTest.kt
@@ -1,0 +1,160 @@
+package com.soneso.stellar.sdk.unitTests.horizon.responses
+
+import com.soneso.stellar.sdk.horizon.responses.TransactionResponse
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The claimable balance id a submitted transaction reports for its CreateClaimableBalance
+ * operations.
+ */
+class CreatedClaimableBalanceIdTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Two CreateClaimableBalance operations, one at each index. */
+    private val twoCreates =
+        "AAAAAAAAAMgAAAAAAAAAAgAAAAAAAAAOAAAAAAAAAAA/DDS/k60NmXHQTMyQ9wVRHIOKrZc0pKL7DXo" +
+            "D/H/omgAAAAAAAAAOAAAAAAAAAAD16n+z3hja6fEq+WzwdQdJAW+8umvwnpAqaeVFaHcdggAAAAA="
+
+    /** A payment at index 0, a CreateClaimableBalance at index 1. */
+    private val paymentThenCreate =
+        "AAAAAAAAAMgAAAAAAAAAAgAAAAAAAAABAAAAAAAAAAAAAAAOAAAAAAAAAAD16n+z3hja6fEq+WzwdQd" +
+            "JAW+8umvwnpAqaeVFaHcdggAAAAA="
+
+    /** A fee bump wrapping a transaction whose only operation creates a claimable balance. */
+    private val feeBump =
+        "AAAAAAAAAZAAAAABMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMAAAAAAAAAyAAAAAAAAAA" +
+            "BAAAAAAAAAA4AAAAAAAAAAPXqf7PeGNrp8Sr5bPB1B0kBb7y6a/CekCpp5UVodx2CAAAAAAAAAAA="
+
+    /**
+     * A transaction rejected before any operation ran: txBAD_SEQ carries no operation results
+     * at all.
+     */
+    private val badSeq = "AAAAAAAAAGT////7AAAAAA=="
+
+    /**
+     * A transaction that failed after its first operation had already created a balance: the
+     * CreateClaimableBalance at index 0 succeeded and carries an id, the payment at index 1
+     * found no destination. A ledger that failed applies none of it, so no balance exists and
+     * the result code is the only thing that says so.
+     */
+    private val failedAfterCreate =
+        "AAAAAAAAAMj/////AAAAAgAAAAAAAAAOAAAAAAAAAAD16n+z3hja6fEq+WzwdQdJAW+8umvwnpAqaeV" +
+            "FaHcdggAAAAAAAAAB////+wAAAAA="
+
+    /**
+     * A fee bump whose inner transaction failed after its only operation had created a balance.
+     * The outer result reads txFEE_BUMP_INNER_FAILED and the inner one txFAILED, so either code
+     * on its own is enough to say no balance exists.
+     */
+    private val feeBumpInnerFailed =
+        "AAAAAAAAAZD////zMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMAAAAAAAAAyP////8AAAA" +
+            "BAAAAAAAAAA4AAAAAAAAAAPXqf7PeGNrp8Sr5bPB1B0kBb7y6a/CekCpp5UVodx2CAAAAAAAAAAA="
+
+    private val firstBalanceId = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+    private val secondBalanceId = "BAAPL2T7WPPBRWXJ6EVPS3HQOUDUSALPXS5GX4E6SAVGTZKFNB3R3ATZWM"
+
+    /**
+     * A transaction response carrying [resultXdr]. Every other field holds what Horizon serves;
+     * only the result is read for the balance id.
+     */
+    private fun response(resultXdr: String?, successful: Boolean = true): TransactionResponse {
+        val result = if (resultXdr == null) "" else "\"result_xdr\": \"$resultXdr\","
+        return json.decodeFromString(
+            """
+            {
+                "id": "tx1",
+                "paging_token": "123",
+                "successful": $successful,
+                "hash": "tx1",
+                "ledger": 123,
+                "created_at": "2022-01-01T00:00:00Z",
+                "source_account": "GAJNSTFWKUKRXAHMPWG6BM4ACWNIS57S47KQZZQGQCM6H4WTM7VQUFMN",
+                "source_account_sequence": 123,
+                "fee_account": "GAJNSTFWKUKRXAHMPWG6BM4ACWNIS57S47KQZZQGQCM6H4WTM7VQUFMN",
+                "fee_charged": 100,
+                "max_fee": 1000,
+                "operation_count": 1,
+                $result
+                "memo_type": "none",
+                "signatures": ["sig1"],
+                "_links": {
+                    "self": {"href": "https://horizon-testnet.stellar.org/transactions/tx1"},
+                    "account": {"href": "https://horizon-testnet.stellar.org/accounts/GAJNSTFWKUKRXAHMPWG6BM4ACWNIS57S47KQZZQGQCM6H4WTM7VQUFMN"},
+                    "ledger": {"href": "https://horizon-testnet.stellar.org/ledgers/123"},
+                    "operations": {"href": "https://horizon-testnet.stellar.org/transactions/tx1/operations"},
+                    "effects": {"href": "https://horizon-testnet.stellar.org/transactions/tx1/effects"},
+                    "precedes": {"href": "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=123"},
+                    "succeeds": {"href": "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=123"}
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testReportsTheBalanceIdOfEachOperation() {
+        val response = response(twoCreates)
+        assertEquals(firstBalanceId, response.getCreatedClaimableBalanceId())
+        assertEquals(firstBalanceId, response.getCreatedClaimableBalanceId(operationIndex = 0))
+        assertEquals(secondBalanceId, response.getCreatedClaimableBalanceId(operationIndex = 1))
+    }
+
+    @Test
+    fun testAnswersNullForAnOperationThatCreatesNoBalance() {
+        val response = response(paymentThenCreate)
+        assertNull(response.getCreatedClaimableBalanceId())
+        assertEquals(secondBalanceId, response.getCreatedClaimableBalanceId(operationIndex = 1))
+    }
+
+    @Test
+    fun testAnswersNullForAnIndexNoOperationSitsAt() {
+        val response = response(twoCreates)
+        assertNull(response.getCreatedClaimableBalanceId(operationIndex = 2))
+        assertNull(response.getCreatedClaimableBalanceId(operationIndex = Int.MAX_VALUE))
+        assertNull(response.getCreatedClaimableBalanceId(operationIndex = -1))
+        assertNull(response.getCreatedClaimableBalanceId(operationIndex = Int.MIN_VALUE))
+    }
+
+    @Test
+    fun testReadsTheInnerOperationsOfAFeeBump() {
+        val response = response(feeBump)
+        assertEquals(secondBalanceId, response.getCreatedClaimableBalanceId())
+        assertNull(response.getCreatedClaimableBalanceId(operationIndex = 1))
+    }
+
+    @Test
+    fun testAnswersNullForAResultCarryingNoOperationResults() {
+        assertNull(response(badSeq, successful = false).getCreatedClaimableBalanceId())
+    }
+
+    @Test
+    fun testAnswersNullForABalanceCreatedByATransactionThatThenFailed() {
+        // The operation result at index 0 carries a balance id, so reading the operation
+        // results without judging the transaction result code would report one for a
+        // transaction the ledger never applied.
+        val response = response(failedAfterCreate, successful = false)
+        assertNull(response.getCreatedClaimableBalanceId())
+        assertNull(response.getCreatedClaimableBalanceId(operationIndex = 0))
+        assertNull(response.getCreatedClaimableBalanceId(operationIndex = 1))
+    }
+
+    @Test
+    fun testAnswersNullForABalanceCreatedByAFeeBumpThatThenFailed() {
+        val response = response(feeBumpInnerFailed, successful = false)
+        assertNull(response.getCreatedClaimableBalanceId())
+        assertNull(response.getCreatedClaimableBalanceId(operationIndex = 0))
+    }
+
+    @Test
+    fun testAnswersNullWhenTheResultCannotBeRead() {
+        assertNull(response(null).getCreatedClaimableBalanceId())
+        assertNull(response("").getCreatedClaimableBalanceId())
+        assertNull(response("not base64 at all !!").getCreatedClaimableBalanceId())
+        // Valid base64 whose bytes are no transaction result.
+        assertNull(response("AAAAAQ==").getCreatedClaimableBalanceId())
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/responses/CreatedClaimableBalanceIdTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/responses/CreatedClaimableBalanceIdTest.kt
@@ -81,6 +81,28 @@ class CreatedClaimableBalanceIdTest {
         "AAAAAAAAAZAAAAABMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMAAAAAAAAAyP////8AAAA" +
             "BAAAAAAAAAA4AAAAAAAAAAPXqf7PeGNrp8Sr5bPB1B0kBb7y6a/CekCpp5UVodx2CAAAAAAAAAAA="
 
+    /**
+     * A succeeded transaction whose only operation was turned away before it ran: the operation
+     * result carries the code opBAD_AUTH and no inner result at all.
+     */
+    private val operationWithoutAnInnerResult = "AAAAAAAAAMgAAAAAAAAAAf////8AAAAA"
+
+    /**
+     * A succeeded transaction whose only operation is a CreateClaimableBalance the ledger
+     * refused: the result carries CREATE_CLAIMABLE_BALANCE_MALFORMED, so it names the operation
+     * but holds no balance id.
+     */
+    private val createRefused = "AAAAAAAAAMgAAAAAAAAAAQAAAAAAAAAO/////wAAAAA="
+
+    /**
+     * A fee bump whose outer result reads txFEE_BUMP_INNER_SUCCESS while the inner one reads
+     * txBAD_SEQ, a code that carries no operation results. The two codes disagree, so no ledger
+     * produces this result; a response that carried it would otherwise be read for operation
+     * results the inner transaction does not have.
+     */
+    private val feeBumpInnerCarriesNoResults =
+        "AAAAAAAAAZAAAAABMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMAAAAAAAAAyP////sAAAAAAAAAAA=="
+
     private val firstBalanceId = ClaimableBalanceVectors.strKey
     private val secondBalanceId = "BAAPL2T7WPPBRWXJ6EVPS3HQOUDUSALPXS5GX4E6SAVGTZKFNB3R3ATZWM"
 
@@ -228,6 +250,37 @@ class CreatedClaimableBalanceIdTest {
         val response = response(outerSuccessInnerFailed, successful = true)
         assertNull(response.getCreatedClaimableBalanceId())
         assertNull(response.getCreatedClaimableBalanceId(operationIndex = 0))
+    }
+
+    @Test
+    fun testAnswersNullForAnOperationResultCarryingNoInnerResult() {
+        assertNull(response(operationWithoutAnInnerResult).getCreatedClaimableBalanceId())
+    }
+
+    @Test
+    fun testAnswersNullForACreateClaimableBalanceTheLedgerRefused() {
+        assertNull(response(createRefused).getCreatedClaimableBalanceId())
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    @Test
+    fun testAnswersNullWhenTheInnerResultOfASucceededFeeBumpCarriesNoOperationResults() {
+        val result = TransactionResultXdr.decode(
+            XdrReader(Base64.decode(feeBumpInnerCarriesNoResults))
+        )
+        val outerResult = assertIs<TransactionResultResultXdr.InnerResultPair>(
+            result.result, "the fixture must carry a fee bump result"
+        )
+        assertEquals(
+            TransactionResultCodeXdr.txFEE_BUMP_INNER_SUCCESS, outerResult.discriminant,
+            "the outer result code"
+        )
+        assertIs<InnerTransactionResultResultXdr.Void>(
+            outerResult.value.result.result,
+            "the inner result must carry no operation results"
+        )
+
+        assertNull(response(feeBumpInnerCarriesNoResults).getCreatedClaimableBalanceId())
     }
 
     @Test

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/responses/CreatedClaimableBalanceIdTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/responses/CreatedClaimableBalanceIdTest.kt
@@ -1,9 +1,18 @@
 package com.soneso.stellar.sdk.unitTests.horizon.responses
 
 import com.soneso.stellar.sdk.horizon.responses.TransactionResponse
+import com.soneso.stellar.sdk.unitTests.ClaimableBalanceVectors
+import com.soneso.stellar.sdk.xdr.InnerTransactionResultResultXdr
+import com.soneso.stellar.sdk.xdr.TransactionResultCodeXdr
+import com.soneso.stellar.sdk.xdr.TransactionResultResultXdr
+import com.soneso.stellar.sdk.xdr.TransactionResultXdr
+import com.soneso.stellar.sdk.xdr.XdrReader
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 
 /**
@@ -54,7 +63,25 @@ class CreatedClaimableBalanceIdTest {
         "AAAAAAAAAZD////zMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMAAAAAAAAAyP////8AAAA" +
             "BAAAAAAAAAA4AAAAAAAAAAPXqf7PeGNrp8Sr5bPB1B0kBb7y6a/CekCpp5UVodx2CAAAAAAAAAAA="
 
-    private val firstBalanceId = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+    /**
+     * A fee bump only the outer result says failed: it reads txFEE_BUMP_INNER_FAILED while the
+     * inner one reads txSUCCESS and carries the balance the operation created. The outer code is
+     * the only thing between that id and a caller.
+     */
+    private val outerFailedInnerSuccess =
+        "AAAAAAAAAZD////zMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMAAAAAAAAAyAAAAAAAAAA" +
+            "BAAAAAAAAAA4AAAAAAAAAAPXqf7PeGNrp8Sr5bPB1B0kBb7y6a/CekCpp5UVodx2CAAAAAAAAAAA="
+
+    /**
+     * A fee bump only the inner result says failed: the outer result reads
+     * txFEE_BUMP_INNER_SUCCESS while the inner one reads txFAILED. The inner code is the only
+     * thing between the balance the operation result carries and a caller.
+     */
+    private val outerSuccessInnerFailed =
+        "AAAAAAAAAZAAAAABMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMAAAAAAAAAyP////8AAAA" +
+            "BAAAAAAAAAA4AAAAAAAAAAPXqf7PeGNrp8Sr5bPB1B0kBb7y6a/CekCpp5UVodx2CAAAAAAAAAAA="
+
+    private val firstBalanceId = ClaimableBalanceVectors.strKey
     private val secondBalanceId = "BAAPL2T7WPPBRWXJ6EVPS3HQOUDUSALPXS5GX4E6SAVGTZKFNB3R3ATZWM"
 
     /**
@@ -93,6 +120,29 @@ class CreatedClaimableBalanceIdTest {
             }
             """.trimIndent()
         )
+    }
+
+    /**
+     * Checks that [resultXdr] carries [outer] as its transaction result code and [inner] as the
+     * result code of its inner transaction. Each fee bump case turns on one of the two codes, so
+     * a fixture that came to spell another pair would leave its case green while the other code
+     * did the rejecting.
+     */
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun assertFeeBumpResultCodes(
+        resultXdr: String,
+        outer: TransactionResultCodeXdr,
+        inner: TransactionResultCodeXdr
+    ) {
+        val result = TransactionResultXdr.decode(XdrReader(Base64.decode(resultXdr)))
+        val outerResult = assertIs<TransactionResultResultXdr.InnerResultPair>(
+            result.result, "the fixture must carry a fee bump result"
+        )
+        assertEquals(outer, outerResult.discriminant, "the outer result code")
+        val innerResult = assertIs<InnerTransactionResultResultXdr.Results>(
+            outerResult.value.result.result, "the inner result must carry operation results"
+        )
+        assertEquals(inner, innerResult.discriminant, "the inner result code")
     }
 
     @Test
@@ -144,7 +194,38 @@ class CreatedClaimableBalanceIdTest {
 
     @Test
     fun testAnswersNullForABalanceCreatedByAFeeBumpThatThenFailed() {
+        assertFeeBumpResultCodes(
+            feeBumpInnerFailed,
+            outer = TransactionResultCodeXdr.txFEE_BUMP_INNER_FAILED,
+            inner = TransactionResultCodeXdr.txFAILED
+        )
         val response = response(feeBumpInnerFailed, successful = false)
+        assertNull(response.getCreatedClaimableBalanceId())
+        assertNull(response.getCreatedClaimableBalanceId(operationIndex = 0))
+    }
+
+    @Test
+    fun testAnswersNullWhenOnlyTheOuterResultOfAFeeBumpSaysItFailed() {
+        assertFeeBumpResultCodes(
+            outerFailedInnerSuccess,
+            outer = TransactionResultCodeXdr.txFEE_BUMP_INNER_FAILED,
+            inner = TransactionResultCodeXdr.txSUCCESS
+        )
+        val response = response(outerFailedInnerSuccess, successful = false)
+        assertNull(response.getCreatedClaimableBalanceId())
+        assertNull(response.getCreatedClaimableBalanceId(operationIndex = 0))
+    }
+
+    @Test
+    fun testAnswersNullWhenOnlyTheInnerResultOfAFeeBumpSaysItFailed() {
+        assertFeeBumpResultCodes(
+            outerSuccessInnerFailed,
+            outer = TransactionResultCodeXdr.txFEE_BUMP_INNER_SUCCESS,
+            inner = TransactionResultCodeXdr.txFAILED
+        )
+        // The outer result reads as a success, so Horizon reports the transaction as one. The
+        // result code, not that flag, is what says the ledger applied no operation.
+        val response = response(outerSuccessInnerFailed, successful = true)
         assertNull(response.getCreatedClaimableBalanceId())
         assertNull(response.getCreatedClaimableBalanceId(operationIndex = 0))
     }

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/responses/operations/InvokeHostFunctionOperationResponseTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/responses/operations/InvokeHostFunctionOperationResponseTest.kt
@@ -68,6 +68,31 @@ class InvokeHostFunctionOperationResponseTest {
         assertNull(response.assetBalanceChanges!![0].destinationMuxedId)
     }
 
+    /**
+     * Horizon omits "from" on a mint balance change and "to" on a burn or clawback, so both
+     * fields read as null rather than failing the whole operation page.
+     */
+    @Test
+    fun testDeserializesMintAndBurnBalanceChanges() {
+        val mint = json.decodeFromString<AssetContractBalanceChange>(
+            """{"asset_type":"credit_alphanum4","asset_code":"USD",""" +
+                """"asset_issuer":"${OperationTestHelpers.TEST_ACCOUNT_2}",""" +
+                """"type":"mint","to":"${OperationTestHelpers.TEST_ACCOUNT}","amount":"100.0000000"}"""
+        )
+        assertEquals("mint", mint.type)
+        assertNull(mint.from)
+        assertEquals(OperationTestHelpers.TEST_ACCOUNT, mint.to)
+
+        val burn = json.decodeFromString<AssetContractBalanceChange>(
+            """{"asset_type":"credit_alphanum4","asset_code":"USD",""" +
+                """"asset_issuer":"${OperationTestHelpers.TEST_ACCOUNT_2}",""" +
+                """"type":"burn","from":"${OperationTestHelpers.TEST_SOURCE_ACCOUNT}","amount":"100.0000000"}"""
+        )
+        assertEquals("burn", burn.type)
+        assertNull(burn.to)
+        assertEquals(OperationTestHelpers.TEST_SOURCE_ACCOUNT, burn.from)
+    }
+
     @Test
     fun testAllNullOptionals() {
         val response = createResponse(

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/rpc/SorobanServerTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/rpc/SorobanServerTest.kt
@@ -1471,6 +1471,61 @@ class SorobanServerTest {
     }
 
     @Test
+    fun testLoadContractCodeForWasmId_wrongLength_rejectsBeforeRequest() = runTest {
+        // Given: A WASM ID that is not a 32-byte hash. Without the length check the failure
+        // still happens, but only once the fixed-opaque writer rejects the short hash, so the
+        // message must name the WASM ID rather than the XDR field.
+        val requests = mutableListOf<String>()
+        createSequencedMockServer(GET_LEDGER_ENTRIES_RESPONSE, capturedRequests = requests).use { server ->
+            // When: Loading the code
+            val exception = assertFailsWith<IllegalArgumentException> {
+                server.loadContractCodeForWasmId("abc123")
+            }
+
+            // Then: The length is named and no request went out
+            assertTrue(
+                exception.message?.contains("WASM ID must be 64 hex characters, got 6") ?: false,
+                "Unexpected message: ${exception.message}"
+            )
+            assertTrue(requests.isEmpty(), "No request should be issued for an invalid WASM ID")
+        }
+    }
+
+    @Test
+    fun testLoadContractCodeForWasmId_nonHexId_rejectsBeforeRequest() = runTest {
+        // Given: A 64-character WASM ID made of sign pairs, which a radix parse would
+        // silently decode to a 32-byte hash of 0xff bytes and query the wrong ledger key
+        val requests = mutableListOf<String>()
+        createSequencedMockServer(GET_LEDGER_ENTRIES_RESPONSE, capturedRequests = requests).use { server ->
+            val exception = assertFailsWith<IllegalArgumentException> {
+                server.loadContractCodeForWasmId("-1".repeat(32))
+            }
+
+            assertTrue(
+                exception.message?.contains("0-9 and a-f") ?: false,
+                "Unexpected message: ${exception.message}"
+            )
+            assertTrue(requests.isEmpty(), "No request should be issued for an invalid WASM ID")
+        }
+    }
+
+    @Test
+    fun testLoadContractInfoForWasmId_wrongLength_rejectsBeforeRequest() = runTest {
+        // The info path delegates to the code path, so it inherits the same check.
+        val requests = mutableListOf<String>()
+        createSequencedMockServer(GET_LEDGER_ENTRIES_RESPONSE, capturedRequests = requests).use { server ->
+            val exception = assertFailsWith<IllegalArgumentException> {
+                server.loadContractInfoForWasmId("abc123")
+            }
+            assertTrue(
+                exception.message?.contains("WASM ID must be 64 hex characters, got 6") ?: false,
+                "Unexpected message: ${exception.message}"
+            )
+            assertTrue(requests.isEmpty(), "No request should be issued for an invalid WASM ID")
+        }
+    }
+
+    @Test
     fun testLoadContractCodeForWasmId_noEntries_returnsNull() = runTest {
         createMockServer(GET_LEDGER_ENTRIES_RESPONSE).use { server ->
             assertNull(server.loadContractCodeForWasmId(TEST_WASM_ID))

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/sep/sep01/StellarTomlTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/sep/sep01/StellarTomlTest.kt
@@ -869,6 +869,17 @@ class StellarTomlTest {
     }
 
     @Test
+    fun fromDomain_non200Response_reportsTheStatusCode() = runTest {
+        val engine = MockEngine {
+            respond(content = "", status = HttpStatusCode.InternalServerError)
+        }
+        val e = assertFailsWith<IllegalStateException> {
+            StellarToml.fromDomain("anchor.example.org", HttpClient(engine))
+        }
+        assertEquals("Stellar toml not found, response status code 500", e.message)
+    }
+
+    @Test
     fun fromDomain_uppercaseLocalhost_usesHttp() = runTest {
         // Host comparison must be case-insensitive.
         val (client, captured) = captureTomlFetchUrl()

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/sep/sep51/Sep51StellarTypesTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/sep/sep51/Sep51StellarTypesTest.kt
@@ -855,12 +855,20 @@ class Sep51StellarTypesTest {
         assertTrue(error.message!!.contains("expects a G, T, X or P strkey"), error.message!!)
     }
 
-    /** A B strkey carries a leading type byte; only the one type the XDR declares is readable. */
+    /**
+     * A B strkey carries a leading type byte; only the one type the XDR declares is readable.
+     *
+     * The strkey below is the SEP-0023 invalid claimable balance type vector: its checksum holds
+     * and its leading byte is 1, a type the union does not declare, so it is not a B strkey.
+     */
     @Test
     fun aClaimableBalanceIdRejectsALeadingTypeByteThatNamesNoType() {
-        val strkey = StrKey.encodeClaimableBalance(byteArrayOf(0x01) + filled(0x55))
+        val strkey = "BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA"
         val error = rejects { ClaimableBalanceIDXdr.fromXdrJsonElement(JsonPrimitive(strkey)) }
-        assertEquals("ClaimableBalanceIDXdr: has no type numbered 1", error.message)
+        assertEquals(
+            "ClaimableBalanceIDXdr: expects a B strkey, got \"$strkey\"",
+            error.message
+        )
     }
 
     @Test

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/oz/StorageAdapterTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/smartaccount/oz/StorageAdapterTest.kt
@@ -1259,10 +1259,12 @@ class StorageAdapterTest {
             createdAt = 1700000000000L
         )
 
-        // NumberFormatException is an IllegalArgumentException, which is what
-        // toStoredCredential documents for malformed hex. The message is left unasserted:
-        // the stdlib supplies none on Kotlin/Native.
-        assertFailsWith<NumberFormatException> { dto.toStoredCredential() }
+        // IllegalArgumentException is what toStoredCredential documents for malformed hex.
+        val ex = assertFailsWith<IllegalArgumentException> { dto.toStoredCredential() }
+        assertTrue(
+            ex.message?.contains("0-9 and a-f") ?: false,
+            "The failure must name the hex alphabet; got: ${ex.message}"
+        )
 
         // The same DTO with the two offending digits corrected decodes, so the rejection
         // above is attributable to them and not to anything else in the fixture.

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/json/XdrJsonHelperTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/xdr/json/XdrJsonHelperTest.kt
@@ -1,5 +1,6 @@
 package com.soneso.stellar.sdk.unitTests.xdr.json
 
+import com.soneso.stellar.sdk.xdr.SignerKeyEd25519SignedPayloadXdr
 import com.soneso.stellar.sdk.xdr.XdrJson
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -1549,6 +1550,63 @@ class XdrJsonHelperTest {
         key[35] = 9
         val error = rejects { XdrJson.signedPayload(key, type) }
         assertTrue(error.message!!.contains("does not fit"))
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Signed payload framing through the document path
+    // -------------------------------------------------------------------------------------
+    //
+    // A P strkey names its payload through a declared length, and the bytes it carries have to
+    // agree with that length: the size fits it exactly and the padding after the payload is
+    // zero. The strkey codec is what enforces this, and a document reaches the codec through
+    // [XdrJson.strkey], which reports a rejection in the vocabulary of the XDR-JSON contract
+    // rather than passing the codec's own message on. The cases below read a document rather
+    // than a byte array, so they cover the framing on the path a document actually takes.
+
+    private val signedPayloadType = "SignerKeyEd25519SignedPayloadXdr"
+
+    private fun signedPayloadDocument(strKey: String): String = "\"$strKey\""
+
+    @Test
+    fun signedPayloadDocumentReadsAWellFramedStrkey() {
+        // 29 payload bytes, padded with three zeros to the four-byte boundary the framing sets.
+        val strKey = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+            "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUAAAAFGBU"
+        val decoded = SignerKeyEd25519SignedPayloadXdr.fromXdrJson(signedPayloadDocument(strKey))
+
+        assertEquals(
+            (1..29).map { it.toByte() }, decoded.payload.toList(),
+            "the payload the strkey declares must be the payload read back"
+        )
+        assertEquals(strKey, text(decoded.toXdrJsonElement()))
+    }
+
+    @Test
+    fun signedPayloadDocumentRejectsNonZeroPadding() {
+        // 29 payload bytes followed by padding of 0xff, where the framing requires zeros. The
+        // preview the message carries is truncated, as it is for any value past the limit.
+        val strKey = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQ" +
+            "CQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DX77776K34"
+        val error = rejects { SignerKeyEd25519SignedPayloadXdr.fromXdrJson(signedPayloadDocument(strKey)) }
+
+        assertEquals(
+            "$signedPayloadType: expects a P strkey, got " +
+                "\"PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDA...",
+            error.message
+        )
+    }
+
+    @Test
+    fun signedPayloadDocumentRejectsADeclaredLengthTheBytesDoNotCarry() {
+        // A declared payload length of 64 inside 40 bytes, which names a payload that ends past
+        // the end of the bytes the strkey carries.
+        val strKey = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAACAQDAQ3PY"
+        val error = rejects { SignerKeyEd25519SignedPayloadXdr.fromXdrJson(signedPayloadDocument(strKey)) }
+
+        assertEquals(
+            "$signedPayloadType: expects a P strkey, got \"$strKey\"",
+            error.message
+        )
     }
 
     // -------------------------------------------------------------------------------------

--- a/stellar-sdk/src/jsMain/kotlin/com/soneso/stellar/sdk/StrKey.js.kt
+++ b/stellar-sdk/src/jsMain/kotlin/com/soneso/stellar/sdk/StrKey.js.kt
@@ -1,18 +1,16 @@
 package com.soneso.stellar.sdk
 
 /**
- * JavaScript implementation of Base32 encoding/decoding.
+ * JavaScript base32 codec.
  *
- * This is a pure Kotlin implementation that works in both browser and Node.js environments.
- * It's suitable for JavaScript because:
- * - Base32 encoding is not security-critical (just data transformation)
- * - No native JS Base32 library in browsers
- * - Small implementation, well-tested
+ * A pure Kotlin implementation, used in both browser and Node.js environments, that carries the
+ * same strictness as the codecs on the other platforms: the 32 alphabet characters are the only
+ * input it accepts, so the pad character, whitespace and every other byte are rejected.
  */
 internal actual object Base32Codec {
-    private const val BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+    private val NOT_IN_ALPHABET: Byte = 0xff.toByte()
 
-    private val decodingTable: ByteArray = ByteArray(256) { 0xff.toByte() }.apply {
+    private val decodingTable: ByteArray = ByteArray(256) { NOT_IN_ALPHABET }.apply {
         BASE32_ALPHABET.forEachIndexed { index, char ->
             this[char.code] = index.toByte()
         }
@@ -49,16 +47,24 @@ internal actual object Base32Codec {
         return output.toByteArray()
     }
 
+    /**
+     * Decodes [data], which must have passed [isInAlphabet].
+     *
+     * A byte outside the alphabet carries no five-bit value, so decoding it would either
+     * corrupt the result or cut it short. Such a byte is reported instead.
+     *
+     * @throws IllegalArgumentException if [data] holds a byte outside the base32 alphabet
+     */
     actual fun decode(data: ByteArray): ByteArray {
         val output = mutableListOf<Byte>()
         var buffer = 0
         var bitsLeft = 0
 
         for (byte in data) {
-            if (byte == '='.code.toByte()) break
+            val value = decodingTable[byte.toInt() and 0xFF]
+            require(value != NOT_IN_ALPHABET) { "Invalid base32 encoded string" }
 
-            val value = decodingTable[byte.toInt() and 0xFF].toInt() and 0xFF
-            buffer = (buffer shl 5) or value
+            buffer = (buffer shl 5) or value.toInt()
             bitsLeft += 5
 
             if (bitsLeft >= 8) {
@@ -70,11 +76,15 @@ internal actual object Base32Codec {
         return output.toByteArray()
     }
 
+    /**
+     * Reports whether every byte of [data] is one of the 32 base32 alphabet characters.
+     *
+     * The pad character and whitespace are not among them: a strkey is written without padding,
+     * and accepting either would let one key be written as more than one string.
+     */
     actual fun isInAlphabet(data: ByteArray): Boolean {
         for (byte in data) {
-            if (byte == '='.code.toByte()) continue
-            val index = byte.toInt() and 0xFF
-            if (index >= decodingTable.size || decodingTable[index] == 0xff.toByte()) {
+            if (decodingTable[byte.toInt() and 0xFF] == NOT_IN_ALPHABET) {
                 return false
             }
         }

--- a/stellar-sdk/src/jsMain/kotlin/com/soneso/stellar/sdk/StrKey.js.kt
+++ b/stellar-sdk/src/jsMain/kotlin/com/soneso/stellar/sdk/StrKey.js.kt
@@ -62,7 +62,7 @@ internal actual object Base32Codec {
 
         for (byte in data) {
             val value = decodingTable[byte.toInt() and 0xFF]
-            require(value != NOT_IN_ALPHABET) { "Invalid base32 encoded string" }
+            require(value != NOT_IN_ALPHABET) { INVALID_BASE32_MESSAGE }
 
             buffer = (buffer shl 5) or value.toInt()
             bitsLeft += 5

--- a/stellar-sdk/src/jvmMain/kotlin/com/soneso/stellar/sdk/StrKey.jvm.kt
+++ b/stellar-sdk/src/jvmMain/kotlin/com/soneso/stellar/sdk/StrKey.jvm.kt
@@ -26,7 +26,7 @@ internal actual object Base32Codec {
      * @throws IllegalArgumentException if [data] holds a byte outside the base32 alphabet
      */
     actual fun decode(data: ByteArray): ByteArray {
-        require(isInAlphabet(data)) { "Invalid base32 encoded string" }
+        require(isInAlphabet(data)) { INVALID_BASE32_MESSAGE }
         return codec.decode(data)
     }
 

--- a/stellar-sdk/src/jvmMain/kotlin/com/soneso/stellar/sdk/StrKey.jvm.kt
+++ b/stellar-sdk/src/jvmMain/kotlin/com/soneso/stellar/sdk/StrKey.jvm.kt
@@ -3,20 +3,46 @@ package com.soneso.stellar.sdk
 import org.apache.commons.codec.binary.Base32
 
 /**
- * JVM-specific base32 encoding/decoding using Apache Commons Codec.
+ * JVM base32 codec, backed by Apache Commons Codec.
  */
 internal actual object Base32Codec {
     private val codec = Base32()
+
+    private val inAlphabet: BooleanArray = BooleanArray(256).apply {
+        BASE32_ALPHABET.forEach { char -> this[char.code] = true }
+    }
 
     actual fun encode(data: ByteArray): ByteArray {
         return codec.encode(data)
     }
 
+    /**
+     * Decodes [data], which must have passed [isInAlphabet].
+     *
+     * The underlying codec drops bytes it does not recognise instead of reporting them, and
+     * bytes dropped that way would yield a result the input does not spell, so the alphabet is
+     * enforced before the codec runs.
+     *
+     * @throws IllegalArgumentException if [data] holds a byte outside the base32 alphabet
+     */
     actual fun decode(data: ByteArray): ByteArray {
+        require(isInAlphabet(data)) { "Invalid base32 encoded string" }
         return codec.decode(data)
     }
 
+    /**
+     * Reports whether every byte of [data] is one of the 32 base32 alphabet characters.
+     *
+     * Membership is tested against that alphabet rather than against the underlying codec,
+     * which also maps the lowercase letters and the pad character and would therefore admit
+     * spellings of a key that no encoder produces.
+     */
     actual fun isInAlphabet(data: ByteArray): Boolean {
-        return codec.isInAlphabet(data, true)
+        for (byte in data) {
+            if (!inAlphabet[byte.toInt() and 0xFF]) {
+                return false
+            }
+        }
+        return true
     }
 }

--- a/stellar-sdk/src/jvmTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/requests/SSEStreamTest.kt
+++ b/stellar-sdk/src/jvmTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/requests/SSEStreamTest.kt
@@ -21,6 +21,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -408,7 +409,60 @@ class SSEStreamTest {
         }
     }
 
+    @Test
+    fun testClaimableBalanceStreamAsksForTheHorizonHexOfEverySpelling() {
+        // A stream builds its URL from the request builder's path segments, so the spelling the
+        // builder normalizes an id to is the one every reconnect carries.
+        for (spelling in CLAIMABLE_BALANCE_SPELLINGS) {
+            val (engine, requests) = engineServing(sseEvent("1", record("a", "1", "x")))
+            val listener = RecordingListener()
+            val stream = HorizonServer(SERVER_URI, sseClient(engine))
+                .transactions()
+                .forClaimableBalance(spelling)
+                .stream(StreamedRecord.serializer(), listener, 30_000.milliseconds)
+            try {
+                awaitUntil(description = "the stream connects for spelling $spelling") {
+                    requests.isNotEmpty()
+                }
+                assertEquals(
+                    "/claimable_balances/$CLAIMABLE_BALANCE_HORIZON_HEX/transactions",
+                    requests[0].url.encodedPath,
+                    "spelling: $spelling"
+                )
+            } finally {
+                stream.close()
+            }
+        }
+    }
+
+    @Test
+    fun testClaimableBalanceStreamReportsAnIdNamingNoBalanceBeforeConnecting() {
+        val (engine, requests) = engineServing("")
+        assertFailsWith<IllegalArgumentException> {
+            HorizonServer(SERVER_URI, sseClient(engine))
+                .transactions()
+                .forClaimableBalance("not a claimable balance id")
+        }
+        assertTrue(requests.isEmpty(), "no request may be sent for an id naming no balance")
+    }
+
     companion object {
         private const val SERVER_URI = "https://horizon-testnet.stellar.org"
+
+        /** The 32-byte hash of the claimable balance the spelling vectors name. */
+        private const val CLAIMABLE_BALANCE_HASH_HEX =
+            "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
+
+        /** The spelling Horizon serves: the hexadecimal of the XDR form. */
+        private const val CLAIMABLE_BALANCE_HORIZON_HEX = "00000000$CLAIMABLE_BALANCE_HASH_HEX"
+
+        /** Every spelling of the one balance, the strkey and a case variant among them. */
+        private val CLAIMABLE_BALANCE_SPELLINGS = listOf(
+            "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU",
+            CLAIMABLE_BALANCE_HASH_HEX,
+            "00$CLAIMABLE_BALANCE_HASH_HEX",
+            CLAIMABLE_BALANCE_HORIZON_HEX,
+            CLAIMABLE_BALANCE_HASH_HEX.uppercase()
+        )
     }
 }

--- a/stellar-sdk/src/jvmTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/requests/SSEStreamTest.kt
+++ b/stellar-sdk/src/jvmTest/kotlin/com/soneso/stellar/sdk/unitTests/horizon/requests/SSEStreamTest.kt
@@ -6,6 +6,7 @@ import com.soneso.stellar.sdk.horizon.requests.RequestBuilder
 import com.soneso.stellar.sdk.horizon.requests.SSEStream
 import com.soneso.stellar.sdk.horizon.responses.Pageable
 import com.soneso.stellar.sdk.horizon.responses.Response
+import com.soneso.stellar.sdk.unitTests.ClaimableBalanceVectors
 import io.ktor.client.*
 import io.ktor.client.engine.mock.*
 import io.ktor.client.plugins.*
@@ -449,20 +450,9 @@ class SSEStreamTest {
     companion object {
         private const val SERVER_URI = "https://horizon-testnet.stellar.org"
 
-        /** The 32-byte hash of the claimable balance the spelling vectors name. */
-        private const val CLAIMABLE_BALANCE_HASH_HEX =
-            "3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a"
-
         /** The spelling Horizon serves: the hexadecimal of the XDR form. */
-        private const val CLAIMABLE_BALANCE_HORIZON_HEX = "00000000$CLAIMABLE_BALANCE_HASH_HEX"
+        private const val CLAIMABLE_BALANCE_HORIZON_HEX = ClaimableBalanceVectors.paddedHex
 
-        /** Every spelling of the one balance, the strkey and a case variant among them. */
-        private val CLAIMABLE_BALANCE_SPELLINGS = listOf(
-            "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU",
-            CLAIMABLE_BALANCE_HASH_HEX,
-            "00$CLAIMABLE_BALANCE_HASH_HEX",
-            CLAIMABLE_BALANCE_HORIZON_HEX,
-            CLAIMABLE_BALANCE_HASH_HEX.uppercase()
-        )
+        private val CLAIMABLE_BALANCE_SPELLINGS = ClaimableBalanceVectors.spellings
     }
 }

--- a/stellar-sdk/src/nativeMain/kotlin/com/soneso/stellar/sdk/StrKey.native.kt
+++ b/stellar-sdk/src/nativeMain/kotlin/com/soneso/stellar/sdk/StrKey.native.kt
@@ -1,16 +1,16 @@
 package com.soneso.stellar.sdk
 
 /**
- * Native (iOS/macOS) base32 encoding/decoding implementation.
+ * Native (iOS/macOS) base32 codec.
  *
- * This is a basic implementation. For production use, consider using:
- * - A Kotlin/Native library like libsodium bindings
- * - Swift interop with Apple's Security framework
+ * A pure Kotlin implementation that carries the same strictness as the codecs on the other
+ * platforms: the 32 alphabet characters are the only input it accepts, so the pad character,
+ * whitespace and every other byte are rejected.
  */
 internal actual object Base32Codec {
-    private const val BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+    private val NOT_IN_ALPHABET: Byte = 0xff.toByte()
 
-    private val decodingTable: ByteArray = ByteArray(256) { 0xff.toByte() }.apply {
+    private val decodingTable: ByteArray = ByteArray(256) { NOT_IN_ALPHABET }.apply {
         BASE32_ALPHABET.forEachIndexed { index, char ->
             this[char.code] = index.toByte()
         }
@@ -47,16 +47,24 @@ internal actual object Base32Codec {
         return output.toByteArray()
     }
 
+    /**
+     * Decodes [data], which must have passed [isInAlphabet].
+     *
+     * A byte outside the alphabet carries no five-bit value, so decoding it would either
+     * corrupt the result or cut it short. Such a byte is reported instead.
+     *
+     * @throws IllegalArgumentException if [data] holds a byte outside the base32 alphabet
+     */
     actual fun decode(data: ByteArray): ByteArray {
         val output = mutableListOf<Byte>()
         var buffer = 0
         var bitsLeft = 0
 
         for (byte in data) {
-            if (byte == '='.code.toByte()) break
+            val value = decodingTable[byte.toInt() and 0xFF]
+            require(value != NOT_IN_ALPHABET) { "Invalid base32 encoded string" }
 
-            val value = decodingTable[byte.toInt() and 0xFF].toInt() and 0xFF
-            buffer = (buffer shl 5) or value
+            buffer = (buffer shl 5) or value.toInt()
             bitsLeft += 5
 
             if (bitsLeft >= 8) {
@@ -68,11 +76,15 @@ internal actual object Base32Codec {
         return output.toByteArray()
     }
 
+    /**
+     * Reports whether every byte of [data] is one of the 32 base32 alphabet characters.
+     *
+     * The pad character and whitespace are not among them: a strkey is written without padding,
+     * and accepting either would let one key be written as more than one string.
+     */
     actual fun isInAlphabet(data: ByteArray): Boolean {
         for (byte in data) {
-            if (byte == '='.code.toByte()) continue
-            val index = byte.toInt() and 0xFF
-            if (index >= decodingTable.size || decodingTable[index] == 0xff.toByte()) {
+            if (decodingTable[byte.toInt() and 0xFF] == NOT_IN_ALPHABET) {
                 return false
             }
         }

--- a/stellar-sdk/src/nativeMain/kotlin/com/soneso/stellar/sdk/StrKey.native.kt
+++ b/stellar-sdk/src/nativeMain/kotlin/com/soneso/stellar/sdk/StrKey.native.kt
@@ -62,7 +62,7 @@ internal actual object Base32Codec {
 
         for (byte in data) {
             val value = decodingTable[byte.toInt() and 0xFF]
-            require(value != NOT_IN_ALPHABET) { "Invalid base32 encoded string" }
+            require(value != NOT_IN_ALPHABET) { INVALID_BASE32_MESSAGE }
 
             buffer = (buffer shl 5) or value.toInt()
             bitsLeft += 5


### PR DESCRIPTION
Aligns strkey decoding and encoding with SEP-23, matching the validation level js-stellar-sdk v17 ships (currently a release candidate). These are behavior changes: input that previously slipped through now throws. CHANGELOG.md lists every change.

- Decoding accepts canonical strkeys only, identically on JVM, Android, JS and Native: the encoded length is checked against the type before base32 runs; `=` padding, whitespace, lowercase and non-ASCII characters are rejected; and `IndexOutOfBoundsException` escapes no decode entry point. Lowercase input was previously accepted on the JVM and Android alone, and a non-ASCII character could alias onto a legal one, giving one key more than one spelling
- Signed payload (P...) framing enforced on encode and decode: declared length 1 to 64, exact fit, zero padding. `SignerKey.fromEncodedSignerKey` names the rule a malformed signed payload broke
- Claimable balance (B...) ids must carry the V0 discriminant and are accepted in every spelling: strkey, bare hash hex, tagged hex, and the 36-byte XDR form Horizon reports; the new `ClaimableBalanceId` resolver is the single entry point, with `toPaddedHex()` reporting the id as Horizon spells it. An `Address` over a `B...` strkey carrying another discriminant now fails at construction rather than at `toSCAddress()`
- The claim, clawback and revoke-sponsorship operations accept every spelling with identical XDR and validate at construction; an operation read back from XDR reports the 72-character form, where the revoke-sponsorship read-back reported the bare hash before. The request builders and their streams resolve every spelling to that form and reject anything else with `IllegalArgumentException` before any request
- Hexadecimal ids and hashes are held to the ASCII hex alphabet: the per-pair parse previously accepted signed pairs and non-ASCII digits, silently building a different pool id, wasm hash, memo hash, contract spec argument or stored credential key than the characters spell. `SorobanServer.loadContractCodeForWasmId` requires a 64-character wasm id before querying
- `EffectsRequestBuilder.forClaimableBalance` is removed: Horizon serves no such route, so every call it made returned 404
- New: `getCreatedClaimableBalanceId(operationIndex)` on the transaction response returns the created balance id as a `B...` strkey, reading a fee bump's inner operations
- The Android unit-test compilation is fixed (`androidUnitTest` inherits `jvmTest`) and runs the full JVM suite
- The SEP-01 stellar.toml network-error tests were tightened alongside: the flaky live 500 test is now a deterministic mock unit test and a duplicate DNS test is removed
- Rode along from the integration run: mint, burn and clawback asset balance changes on invoke host function operations deserialize; Horizon omits `from` on a mint and `to` on a burn, which the response model previously required, failing the whole operations page

No strkey these rules reject stands for a value stellar-core would have accepted.

The branch also adds authoring rules to the documentation strategy; user-facing documentation for these changes is on the release-docs branch and merges during release preparation.

Testing: 10,303 JVM, 10,318 JS, 10,368 native macOS and 10,303 Android unit tests with 0 failures, covering all SEP-23 test vectors. Integration suite run against testnet: 201 of 202 tests pass; the one failure is the pre-existing timing-sensitive duplicate-submission assertion in `TransactionAsyncIntegrationTest`, which this branch does not touch and which is tracked separately.
