### PR TITLE
Resolve CAP-85 external reference executables when loading contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   XDR is absent or unreadable, when no operation sits at the index, or when the
   operation there creates no balance. Fee bump transactions are read through to
   the inner transaction's results.
+- `SorobanServer.getExternalRefWasmHash(ref)` resolves a CAP-85 external
+  reference (Protocol 28) to the 32-byte WASM hash it names: the reference's
+  owner contract holds a persistent contract data entry keyed by the tag whose
+  value is the hash, and the entry is read without invoking the owner.
+  `loadContractCodeForContractId` and `loadContractInfoForContractId` apply the
+  resolution when an instance carries an external reference executable, and
+  `ContractClient.forContract` builds clients for such contracts, where all
+  three previously answered null or "Contract spec not found". An external
+  reference that cannot be resolved now throws rather than returning null; a
+  null from the loaders still means the instance or its code was not found, or
+  the contract is a Stellar Asset Contract, which has no WASM on-chain. A
+  missing, wrongly typed or wrong-length tag entry raises
+  `IllegalStateException` naming the owner and tag, which
+  `ContractClient.forContract` passes through unwrapped; a reference
+  whose owner is not a contract address raises `IllegalArgumentException`,
+  which `forContract` wraps as `IllegalStateException("Failed to load contract
+  spec for ...")` with the cause preserved. A tag that is not valid UTF-8
+  cannot be resolved: XDR strings decode into Kotlin strings with replacement
+  characters, so the lookup key would name a different entry, and such a tag
+  surfaces as a missing tag entry. `ContractSpec.scValToNative` converts an
+  `SCV_EXECUTABLE_TAG` value to its tag string; it previously failed the
+  conversion.
 
 ### Changed
 - `ClaimClaimableBalanceOperation`, `ClawbackClaimableBalanceOperation` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ The SDK is **production-ready** with comprehensive functionality implemented:
 - **Assets**: Native (XLM), AlphaNum4, AlphaNum12, SAC contract ID derivation
 - **Accounts**: Account management, muxed accounts, sequence numbers
 - **Horizon Client**: Full REST API coverage, SSE streaming, request builders
-- **Soroban RPC**: Contract calls, simulation, state restoration, polling
+- **Soroban RPC**: Contract calls, simulation, state restoration, polling, CAP-85 external reference resolution
 - **High-Level API**: ContractClient, AssembledTransaction with full lifecycle
 - **XDR**: Complete XDR type system and serialization
 - **SEP Support**: SEP-1 (Stellar TOML), SEP-2 (Federation Protocol), SEP-5 (Key Derivation), SEP-6 (Deposit and Withdrawal API), SEP-8 (Regulated Assets), SEP-9/12 (KYC), SEP-10 (Web Authentication), SEP-24 (Hosted Deposit/Withdrawal), SEP-30 (Account Recovery), SEP-31 (Cross-Border Payments), SEP-38 (Anchor RFQ), SEP-45 (Web Authentication for Contract Accounts), SEP-46 (Contract Meta), SEP-47 (Contract Interface Discovery), SEP-48 (Contract Interface Specification), SEP-51 (XDR-JSON), SEP-53 (Sign and Verify Messages)

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/contract/ContractSpec.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/contract/ContractSpec.kt
@@ -298,6 +298,7 @@ class ContractSpec(private val entries: List<SCSpecEntryXdr>) {
      * - **UDT (enum)** → UInt
      * - **Error** → SCErrorXdr
      * - **ContractInstance** → SCContractInstanceXdr
+     * - **ExecutableTag** → String
      *
      * @param scVal The XDR value to convert
      * @param typeDef The type specification (nullable for direct type inference)
@@ -453,6 +454,11 @@ class ContractSpec(private val entries: List<SCSpecEntryXdr>) {
                 }
                 // Return the SCContractInstanceXdr directly
                 scVal.value
+            }
+
+            SCValTypeXdr.SCV_EXECUTABLE_TAG -> {
+                require(scVal is SCValXdr.ExecutableTag) { "Expected SCValXdr.ExecutableTag for SCV_EXECUTABLE_TAG" }
+                scVal.value.value
             }
 
             else -> {

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/rpc/SorobanServer.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/rpc/SorobanServer.kt
@@ -1006,10 +1006,81 @@ class SorobanServer(
     }
 
     /**
+     * Resolves a CAP-85 external reference to the 32-byte WASM hash it names.
+     *
+     * A contract created from an external reference does not carry its own code hash.
+     * The reference names an owner contract and a tag, and the owner holds a persistent
+     * contract data entry keyed by that tag whose value is the 32-byte hash of an
+     * already uploaded WASM. This method reads that entry off the ledger; the owner
+     * contract is never invoked. The tag is passed through exactly as the reference
+     * carries it, so the ledger key matches the entry the owner wrote. A tag that is
+     * not valid UTF-8 cannot be resolved: XDR strings decode into Kotlin strings with
+     * replacement characters, so such a tag builds a key for a different entry and
+     * surfaces as a missing tag entry.
+     *
+     * @param ref The external reference naming the owner contract and the tag
+     * @return The 32-byte WASM hash the tag entry holds
+     * @throws IllegalArgumentException If the owner is not a contract address; only a
+     * contract can hold the executable tag entry, so no request is issued
+     * @throws IllegalStateException If the owner has no entry under the tag (missing or
+     * archived), if the entry is not a contract data entry, or if the entry value does
+     * not hold exactly 32 bytes
+     * @throws SorobanRpcException If the RPC request fails
+     *
+     * @see loadContractCodeForContractId
+     */
+    suspend fun getExternalRefWasmHash(ref: ContractExecutableExternalRefXdr): ByteArray {
+        val owner = Address.fromSCAddress(ref.executableOwner).getEncodedAddress()
+        if (ref.executableOwner !is SCAddressXdr.ContractId) {
+            throw IllegalArgumentException(
+                "External reference owner $owner is not a contract address; " +
+                    "only a contract can hold the executable tag entry"
+            )
+        }
+        val tag = ref.tag.value
+
+        val entry = getContractData(
+            owner,
+            SCValXdr.ExecutableTag(ref.tag),
+            Durability.PERSISTENT
+        ) ?: throw IllegalStateException(
+            "No executable tag entry found on owner contract $owner for tag \"$tag\""
+        )
+
+        val ledgerEntryData = entry.parseXdr()
+        val contractData = when (ledgerEntryData) {
+            is LedgerEntryDataXdr.ContractData -> ledgerEntryData.value
+            else -> throw IllegalStateException(
+                "Executable tag entry on owner contract $owner for tag \"$tag\" is not " +
+                    "a contract data entry, got ${ledgerEntryData.discriminant}"
+            )
+        }
+
+        val value = contractData.`val`
+        val wasmHash = when (value) {
+            is SCValXdr.Bytes -> value.value.value
+            else -> throw IllegalStateException(
+                "Executable tag entry on owner contract $owner for tag \"$tag\" does " +
+                    "not hold a 32-byte WASM hash, got ${value.discriminant}"
+            )
+        }
+        if (wasmHash.size != 32) {
+            throw IllegalStateException(
+                "Executable tag entry on owner contract $owner for tag \"$tag\" does " +
+                    "not hold a 32-byte WASM hash; the value has ${wasmHash.size} bytes"
+            )
+        }
+        return wasmHash
+    }
+
+    /**
      * Loads the contract code entry (including WASM bytecode) for a given contract ID.
      *
      * This method:
-     * 1. Fetches the contract instance to get the WASM hash
+     * 1. Fetches the contract instance to determine the WASM hash from its executable:
+     *    a WASM executable carries the hash directly, and a CAP-85 external reference
+     *    is resolved through the owner contract's tag entry via [getExternalRefWasmHash].
+     *    A Stellar Asset Contract has no WASM on-chain, so it yields null.
      * 2. Fetches the contract code using the WASM hash
      *
      * ## Example
@@ -1023,9 +1094,13 @@ class SorobanServer(
      * ```
      *
      * @param contractId The contract address (C... format)
-     * @return The contract code entry if found, null otherwise
+     * @return The contract code entry, or null when the instance or its code entry
+     * is not found, or when the contract is a Stellar Asset Contract
      * @throws SorobanRpcException If the RPC request fails
-     * @throws IllegalArgumentException If contractId is not a valid contract address
+     * @throws IllegalArgumentException If contractId is not a valid contract address, or
+     * if the instance carries an external reference whose owner is not a contract address
+     * @throws IllegalStateException If an external reference cannot be resolved: the tag
+     * entry is missing, is not a contract data entry, or does not hold a 32-byte hash
      *
      * @see loadContractCodeForWasmId
      * @see loadContractInfoForContractId
@@ -1061,9 +1136,11 @@ class SorobanServer(
             else -> throw IllegalStateException("Expected Instance SCVal, got ${contractData.`val`.discriminant}")
         }
 
-        val wasmHash = when (instance.executable) {
-            is ContractExecutableXdr.WasmHash -> instance.executable.value.value
-            else -> return null
+        val executable = instance.executable
+        val wasmHash = when (executable) {
+            is ContractExecutableXdr.WasmHash -> executable.value.value
+            is ContractExecutableXdr.ExternalRef -> getExternalRefWasmHash(executable.value)
+            is ContractExecutableXdr.Void -> return null
         }
 
         // Convert hash to hex string
@@ -1137,10 +1214,14 @@ class SorobanServer(
      * ```
      *
      * @param contractId The contract address (C... format)
-     * @return The parsed contract information if found, null if the contract doesn't exist
+     * @return The parsed contract information, or null when the instance or its code
+     * entry is not found, or when the contract is a Stellar Asset Contract
      * @throws SorobanRpcException If the RPC request fails
      * @throws com.soneso.stellar.sdk.contract.SorobanContractParserException If the WASM bytecode cannot be parsed
-     * @throws IllegalArgumentException If contractId is not a valid contract address
+     * @throws IllegalArgumentException If contractId is not a valid contract address, or
+     * if the instance carries an external reference whose owner is not a contract address
+     * @throws IllegalStateException If an external reference cannot be resolved: the tag
+     * entry is missing, is not a contract data entry, or does not hold a 32-byte hash
      *
      * @see loadContractCodeForContractId
      * @see loadContractInfoForWasmId

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/P28ExternalRefIntegrationTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/P28ExternalRefIntegrationTest.kt
@@ -1,0 +1,106 @@
+package com.soneso.stellar.sdk.integrationTests
+
+import com.soneso.stellar.sdk.Address
+import com.soneso.stellar.sdk.KeyPair
+import com.soneso.stellar.sdk.Network
+import com.soneso.stellar.sdk.contract.ContractClient
+import com.soneso.stellar.sdk.rpc.SorobanServer
+import com.soneso.stellar.sdk.util.TestResourceUtil
+import com.soneso.stellar.sdk.xdr.ContractDataDurabilityXdr
+import com.soneso.stellar.sdk.xdr.ContractExecutableExternalRefXdr
+import com.soneso.stellar.sdk.xdr.LedgerKeyContractDataXdr
+import com.soneso.stellar.sdk.xdr.LedgerKeyXdr
+import com.soneso.stellar.sdk.xdr.SCStringXdr
+import com.soneso.stellar.sdk.xdr.SCValXdr
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Verifies CAP-85 external reference resolution against a live network.
+ *
+ * Self-contained: deploys its own contract, checks that the contract code
+ * loader still reads it, and checks that a protocol 28 RPC accepts the
+ * executable tag ledger key the resolver builds. The full resolution happy
+ * path needs an owner contract that writes an executable tag entry, which no
+ * fixture provides yet.
+ *
+ * The body is gated on protocol 28 via [networkProtocolAtLeast]; below that the
+ * test prints why it skipped and returns. Futurenet runs protocol 28 already.
+ */
+class P28ExternalRefIntegrationTest {
+
+    private val testOn = "testnet" // "testnet" or "futurenet"
+
+    private val rpcUrl = if (testOn == "testnet") {
+        "https://soroban-testnet.stellar.org"
+    } else {
+        "https://rpc-futurenet.stellar.org"
+    }
+    private val sorobanServer = SorobanServer(rpcUrl)
+    private val network = if (testOn == "testnet") Network.TESTNET else Network.FUTURENET
+
+    @Test
+    fun testExternalRefLedgerKeyAcceptedByRpc() = runTest(timeout = 300.seconds) {
+        if (!networkProtocolAtLeast(sorobanServer, 28)) {
+            println("Skipping P28 external-ref test: the network at $rpcUrl runs a protocol below 28")
+            return@runTest
+        }
+
+        val keyPair = KeyPair.random()
+        fundTestAccountAndAwaitVisibility(
+            keyPair.getAccountId(),
+            rpc = sorobanServer,
+            useFuturenet = testOn != "testnet"
+        )
+
+        val contractId = ContractClient.deploy(
+            wasmBytes = TestResourceUtil.readWasmFile("soroban_hello_world_contract.wasm"),
+            source = keyPair.getAccountId(),
+            signer = keyPair,
+            network = network,
+            rpcUrl = rpcUrl
+        ).contractId
+
+        realDelay(3000)
+
+        // The executable dispatch still loads a wasm instance from the live ledger.
+        val codeEntry = sorobanServer.loadContractCodeForContractId(contractId)
+        assertNotNull(codeEntry, "The deployed contract's code should load by contract id")
+        assertTrue(codeEntry.code.isNotEmpty(), "Loaded code should not be empty")
+
+        // The RPC must accept the executable tag ledger key the resolver builds,
+        // answering an empty entry list for a tag no entry exists under. This is
+        // asserted on the raw response because getLedgerEntries throws on a
+        // rejected request, so reaching the assertion proves acceptance.
+        val unusedTag = "no entry exists under this tag"
+        val tagKey = LedgerKeyXdr.ContractData(
+            LedgerKeyContractDataXdr(
+                contract = Address(contractId).toSCAddress(),
+                key = SCValXdr.ExecutableTag(SCStringXdr(unusedTag)),
+                durability = ContractDataDurabilityXdr.PERSISTENT
+            )
+        )
+        val response = sorobanServer.getLedgerEntries(listOf(tagKey))
+        assertTrue(
+            response.entries.isNullOrEmpty(),
+            "The RPC should answer no entries for an absent tag"
+        )
+
+        // The resolver reports the same absence with its missing-entry exception.
+        val ref = ContractExecutableExternalRefXdr(
+            executableOwner = Address(contractId).toSCAddress(),
+            tag = SCStringXdr(unusedTag)
+        )
+        val exception = assertFailsWith<IllegalStateException> {
+            sorobanServer.getExternalRefWasmHash(ref)
+        }
+        assertTrue(
+            exception.message?.contains("No executable tag entry found") ?: false,
+            "Unexpected message: ${exception.message}"
+        )
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/TestUtils.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/integrationTests/TestUtils.kt
@@ -138,3 +138,14 @@ suspend fun fundTestAccountAndAwaitVisibility(
         )
     }
 }
+
+/**
+ * Returns true when the connected network's current protocol version is at
+ * least [version], read from the RPC's latest ledger.
+ *
+ * Tests whose body needs a minimum protocol call this and return early with a
+ * printed reason when it is false, so a skipped run is visible in the output.
+ */
+suspend fun networkProtocolAtLeast(server: SorobanServer, version: Int): Boolean {
+    return server.getLatestLedger().protocolVersion >= version
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/contract/ContractSpecTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/contract/ContractSpecTest.kt
@@ -941,6 +941,17 @@ class ContractSpecTest {
     // ========== scValToNative Tests ==========
 
     @Test
+    fun testScValToNativeExecutableTag() {
+        val spec = ContractSpec(emptyList())
+
+        // The executable tag carries its tag text; no spec type describes it,
+        // so the conversion runs on the discriminant alone.
+        val tagVal = SCValXdr.ExecutableTag(SCStringXdr("token-v1"))
+        val tagResult = spec.scValToNative(tagVal, null)
+        assertEquals("token-v1", tagResult)
+    }
+
+    @Test
     fun testScValToNativePrimitives() {
         val spec = ContractSpec(emptyList())
 

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/rpc/SorobanServerTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/rpc/SorobanServerTest.kt
@@ -14,6 +14,7 @@ import com.soneso.stellar.sdk.rpc.responses.SimulateTransactionResponse
 import com.soneso.stellar.sdk.rpc.responses.TransactionStatus
 import com.soneso.stellar.sdk.scval.Scv
 import com.soneso.stellar.sdk.xdr.*
+import kotlin.io.encoding.Base64
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import io.ktor.client.*
 import io.ktor.client.engine.mock.*
@@ -285,6 +286,10 @@ class SorobanServerTest {
         /** Hex-encoded 32-byte WASM hash. */
         private const val TEST_WASM_ID =
             "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+
+        /** A valid contract id distinct from [TEST_CONTRACT_ID]; owns executable tag entries. */
+        private const val TEST_OWNER_CONTRACT_ID =
+            "CDCYWK73YTYFJZZSJ5V7EDFNHYBG4QN3VUNG2IGD27KJDDPNCZKBCBXK"
 
         /**
          * Builds WASM bytecode that [com.soneso.stellar.sdk.contract.SorobanContractParser]
@@ -1660,6 +1665,370 @@ class SorobanServerTest {
             // When/Then: No code is returned and no second lookup is attempted
             assertNull(server.loadContractCodeForContractId(TEST_CONTRACT_ID))
             assertEquals(1, requests.size)
+        }
+    }
+
+    // ========== External Reference Resolution Tests ==========
+
+    private fun externalRefInstanceEntryXdr(owner: SCAddressXdr, tag: SCStringXdr): String {
+        val instanceValue = SCValXdr.Instance(
+            SCContractInstanceXdr(
+                executable = ContractExecutableXdr.ExternalRef(
+                    ContractExecutableExternalRefXdr(executableOwner = owner, tag = tag)
+                ),
+                storage = null
+            )
+        )
+        return contractDataEntryXdr(
+            contractAddress = Address(TEST_CONTRACT_ID).toSCAddress(),
+            key = Scv.toLedgerKeyContractInstance(),
+            value = instanceValue
+        )
+    }
+
+    private fun externalRefTagEntryXdr(owner: SCAddressXdr, tag: SCStringXdr, value: SCValXdr): String {
+        return contractDataEntryXdr(
+            contractAddress = owner,
+            key = SCValXdr.ExecutableTag(tag),
+            value = value
+        )
+    }
+
+    private fun externalRef(tag: String = "token-v1"): ContractExecutableExternalRefXdr {
+        return ContractExecutableExternalRefXdr(
+            executableOwner = Address(TEST_OWNER_CONTRACT_ID).toSCAddress(),
+            tag = SCStringXdr(tag)
+        )
+    }
+
+    /** Replaces the single occurrence of [needle] in [bytes] with [replacement]. */
+    private fun replaceOnce(bytes: ByteArray, needle: ByteArray, replacement: ByteArray): ByteArray {
+        var found = -1
+        var count = 0
+        for (start in 0..bytes.size - needle.size) {
+            var match = true
+            for (i in needle.indices) {
+                if (bytes[start + i] != needle[i]) {
+                    match = false
+                    break
+                }
+            }
+            if (match) {
+                count++
+                found = start
+            }
+        }
+        assertEquals(1, count, "The placeholder must occur exactly once in the fixture bytes")
+        return bytes.copyOfRange(0, found) + replacement +
+            bytes.copyOfRange(found + needle.size, bytes.size)
+    }
+
+    @Test
+    fun testLoadContractCodeForContractId_resolvesExternalRef() = runTest {
+        val code = byteArrayOf(0, 97, 115, 109, 1, 0, 0, 0)
+        val owner = Address(TEST_OWNER_CONTRACT_ID).toSCAddress()
+        val tag = SCStringXdr("token-v1")
+        val requests = mutableListOf<String>()
+        createSequencedMockServer(
+            ledgerEntriesResult(keyXdr = "AAAAAA==", entryXdr = externalRefInstanceEntryXdr(owner, tag)),
+            ledgerEntriesResult(
+                keyXdr = "AAAAAA==",
+                entryXdr = externalRefTagEntryXdr(owner, tag, SCValXdr.Bytes(SCBytesXdr(Util.hexToBytes(TEST_WASM_ID))))
+            ),
+            ledgerEntriesResult(keyXdr = "AAAAAA==", entryXdr = contractCodeEntryXdr(code)),
+            capturedRequests = requests
+        ).use { server ->
+            val entry = server.loadContractCodeForContractId(TEST_CONTRACT_ID)
+
+            val codeEntry = assertNotNull(entry)
+            assertEquals(code.toList(), codeEntry.code.toList())
+
+            // The request sequence pins the resolution: the tag lookup carries the
+            // executable tag key on the owner at persistent durability, and the code
+            // lookup carries the hash the tag entry held.
+            assertEquals(3, requests.size)
+            val expectedTagKey = LedgerKeyXdr.ContractData(
+                LedgerKeyContractDataXdr(
+                    contract = owner,
+                    key = SCValXdr.ExecutableTag(tag),
+                    durability = ContractDataDurabilityXdr.PERSISTENT
+                )
+            ).toXdrBase64()
+            assertTrue(
+                requests[1].contains(expectedTagKey),
+                "Second request must carry the executable tag key. Body: ${requests[1]}"
+            )
+            val expectedCodeKey = LedgerKeyXdr.ContractCode(
+                LedgerKeyContractCodeXdr(hash = HashXdr(Util.hexToBytes(TEST_WASM_ID)))
+            ).toXdrBase64()
+            assertTrue(
+                requests[2].contains(expectedCodeKey),
+                "Third request must key on the resolved WASM hash. Body: ${requests[2]}"
+            )
+        }
+    }
+
+    @Test
+    fun testGetExternalRefWasmHash_returnsTheHashTheTagEntryHolds() = runTest {
+        val owner = Address(TEST_OWNER_CONTRACT_ID).toSCAddress()
+        val tag = SCStringXdr("token-v1")
+        createSequencedMockServer(
+            ledgerEntriesResult(
+                keyXdr = "AAAAAA==",
+                entryXdr = externalRefTagEntryXdr(owner, tag, SCValXdr.Bytes(SCBytesXdr(Util.hexToBytes(TEST_WASM_ID))))
+            )
+        ).use { server ->
+            val hash = server.getExternalRefWasmHash(externalRef())
+            assertEquals(Util.hexToBytes(TEST_WASM_ID).toList(), hash.toList())
+        }
+    }
+
+    @Test
+    fun testGetExternalRefWasmHash_tagBytesReachTheLedgerKeyExactly() = runTest {
+        // The fixture tag originates from raw XDR bytes, not from an
+        // SDK-constructed String, so a lossy decode/encode round trip would
+        // change the key this test pins. The tag bytes are valid UTF-8 with an
+        // embedded NUL and multi-byte characters: "t", NUL, U+00F8, U+706B.
+        val rawTagBytes = byteArrayOf(
+            0x74, 0x00, 0xC3.toByte(), 0xB8.toByte(), 0xE7.toByte(), 0x81.toByte(), 0xAB.toByte()
+        )
+        val placeholder = "0123456" // same byte length as rawTagBytes
+        val owner = Address(TEST_OWNER_CONTRACT_ID).toSCAddress()
+
+        val instanceEntryBytes = Base64.decode(
+            externalRefInstanceEntryXdr(owner, SCStringXdr(placeholder))
+        )
+        val splicedInstanceEntry = Base64.encode(
+            replaceOnce(instanceEntryBytes, placeholder.encodeToByteArray(), rawTagBytes)
+        )
+        val expectedTagKeyBytes = replaceOnce(
+            Base64.decode(
+                LedgerKeyXdr.ContractData(
+                    LedgerKeyContractDataXdr(
+                        contract = owner,
+                        key = SCValXdr.ExecutableTag(SCStringXdr(placeholder)),
+                        durability = ContractDataDurabilityXdr.PERSISTENT
+                    )
+                ).toXdrBase64()
+            ),
+            placeholder.encodeToByteArray(),
+            rawTagBytes
+        )
+        val expectedTagKey = Base64.encode(expectedTagKeyBytes)
+
+        val requests = mutableListOf<String>()
+        createSequencedMockServer(
+            ledgerEntriesResult(keyXdr = "AAAAAA==", entryXdr = splicedInstanceEntry),
+            GET_LEDGER_ENTRIES_RESPONSE,
+            capturedRequests = requests
+        ).use { server ->
+            assertFailsWith<IllegalStateException> {
+                server.loadContractCodeForContractId(TEST_CONTRACT_ID)
+            }
+            assertEquals(2, requests.size)
+            assertTrue(
+                requests[1].contains(expectedTagKey),
+                "The tag bytes must reach the ledger key unchanged. Body: ${requests[1]}"
+            )
+        }
+    }
+
+    @Test
+    fun testGetExternalRefWasmHash_nonUtf8TagBytesAreReplaced() = runTest {
+        // Kotlin decodes XDR strings with replacement characters, so a tag that
+        // is not valid UTF-8 cannot round-trip: the SDK builds the lookup key
+        // from the replaced text. This pins that limitation; such a tag is an
+        // unsupported input, and its resolution surfaces as a missing entry.
+        val rawTagBytes = byteArrayOf(0x80.toByte(), 0xFF.toByte())
+        val placeholder = "01" // same byte length as rawTagBytes
+        val owner = Address(TEST_OWNER_CONTRACT_ID).toSCAddress()
+
+        val instanceEntryBytes = Base64.decode(
+            externalRefInstanceEntryXdr(owner, SCStringXdr(placeholder))
+        )
+        val splicedInstanceEntry = Base64.encode(
+            replaceOnce(instanceEntryBytes, placeholder.encodeToByteArray(), rawTagBytes)
+        )
+        val rawByteKey = Base64.encode(
+            replaceOnce(
+                Base64.decode(
+                    LedgerKeyXdr.ContractData(
+                        LedgerKeyContractDataXdr(
+                            contract = owner,
+                            key = SCValXdr.ExecutableTag(SCStringXdr(placeholder)),
+                            durability = ContractDataDurabilityXdr.PERSISTENT
+                        )
+                    ).toXdrBase64()
+                ),
+                placeholder.encodeToByteArray(),
+                rawTagBytes
+            )
+        )
+        val replacementKey = LedgerKeyXdr.ContractData(
+            LedgerKeyContractDataXdr(
+                contract = owner,
+                key = SCValXdr.ExecutableTag(SCStringXdr("\uFFFD\uFFFD")),
+                durability = ContractDataDurabilityXdr.PERSISTENT
+            )
+        ).toXdrBase64()
+
+        val requests = mutableListOf<String>()
+        createSequencedMockServer(
+            ledgerEntriesResult(keyXdr = "AAAAAA==", entryXdr = splicedInstanceEntry),
+            GET_LEDGER_ENTRIES_RESPONSE,
+            capturedRequests = requests
+        ).use { server ->
+            assertFailsWith<IllegalStateException> {
+                server.loadContractCodeForContractId(TEST_CONTRACT_ID)
+            }
+            assertEquals(2, requests.size)
+            assertTrue(
+                !requests[1].contains(rawByteKey),
+                "The raw non-UTF-8 tag bytes cannot reach the key. Body: ${requests[1]}"
+            )
+            assertTrue(
+                requests[1].contains(replacementKey),
+                "The key is built from the replacement text. Body: ${requests[1]}"
+            )
+        }
+    }
+
+    @Test
+    fun testGetExternalRefWasmHash_missingTagEntry_throwsIllegalStateException() = runTest {
+        val requests = mutableListOf<String>()
+        createSequencedMockServer(
+            GET_LEDGER_ENTRIES_RESPONSE,
+            capturedRequests = requests
+        ).use { server ->
+            val exception = assertFailsWith<IllegalStateException> {
+                server.getExternalRefWasmHash(externalRef())
+            }
+            assertTrue(
+                exception.message?.contains("No executable tag entry found on owner contract $TEST_OWNER_CONTRACT_ID") ?: false,
+                "Unexpected message: ${exception.message}"
+            )
+            assertTrue(
+                exception.message?.contains("token-v1") ?: false,
+                "The message must name the tag: ${exception.message}"
+            )
+            assertEquals(1, requests.size)
+        }
+    }
+
+    @Test
+    fun testGetExternalRefWasmHash_nonContractDataEntry_throwsIllegalStateException() = runTest {
+        createSequencedMockServer(
+            ledgerEntriesResult(
+                keyXdr = "AAAAAA==",
+                entryXdr = accountEntryXdr(TEST_ACCOUNT_ID, 1L)
+            )
+        ).use { server ->
+            val exception = assertFailsWith<IllegalStateException> {
+                server.getExternalRefWasmHash(externalRef())
+            }
+            assertTrue(
+                exception.message?.contains("is not a contract data entry") ?: false,
+                "Unexpected message: ${exception.message}"
+            )
+            assertTrue(
+                exception.message?.contains("token-v1") ?: false,
+                "The message must name the tag: ${exception.message}"
+            )
+        }
+    }
+
+    @Test
+    fun testGetExternalRefWasmHash_nonBytesValue_throwsIllegalStateException() = runTest {
+        val owner = Address(TEST_OWNER_CONTRACT_ID).toSCAddress()
+        val tag = SCStringXdr("token-v1")
+        createSequencedMockServer(
+            ledgerEntriesResult(
+                keyXdr = "AAAAAA==",
+                entryXdr = externalRefTagEntryXdr(owner, tag, Scv.toSymbol("not_a_hash"))
+            )
+        ).use { server ->
+            val exception = assertFailsWith<IllegalStateException> {
+                server.getExternalRefWasmHash(externalRef())
+            }
+            assertTrue(
+                exception.message?.contains("does not hold a 32-byte WASM hash") ?: false,
+                "Unexpected message: ${exception.message}"
+            )
+            assertTrue(
+                exception.message?.contains("token-v1") ?: false,
+                "The message must name the tag: ${exception.message}"
+            )
+        }
+    }
+
+    @Test
+    fun testGetExternalRefWasmHash_wrongLengthBytes_throwsIllegalStateException() = runTest {
+        val owner = Address(TEST_OWNER_CONTRACT_ID).toSCAddress()
+        val tag = SCStringXdr("token-v1")
+        for (length in listOf(31, 33)) {
+            createSequencedMockServer(
+                ledgerEntriesResult(
+                    keyXdr = "AAAAAA==",
+                    entryXdr = externalRefTagEntryXdr(owner, tag, SCValXdr.Bytes(SCBytesXdr(ByteArray(length))))
+                )
+            ).use { server ->
+                val exception = assertFailsWith<IllegalStateException> {
+                    server.getExternalRefWasmHash(externalRef())
+                }
+                assertTrue(
+                    exception.message?.contains("the value has $length bytes") ?: false,
+                    "Unexpected message for length $length: ${exception.message}"
+                )
+                assertTrue(
+                    exception.message?.contains("token-v1") ?: false,
+                    "The message must name the tag: ${exception.message}"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testGetExternalRefWasmHash_nonContractOwner_rejectsWithoutRequest() = runTest {
+        val requests = mutableListOf<String>()
+        createSequencedMockServer(
+            GET_LEDGER_ENTRIES_RESPONSE,
+            capturedRequests = requests
+        ).use { server ->
+            val ref = ContractExecutableExternalRefXdr(
+                executableOwner = Address(TEST_ACCOUNT_ID).toSCAddress(),
+                tag = SCStringXdr("token-v1")
+            )
+            val exception = assertFailsWith<IllegalArgumentException> {
+                server.getExternalRefWasmHash(ref)
+            }
+            assertTrue(
+                exception.message?.contains("$TEST_ACCOUNT_ID is not a contract address") ?: false,
+                "The message must name the owner: ${exception.message}"
+            )
+            assertTrue(requests.isEmpty(), "No request may be issued for a non-contract owner")
+        }
+    }
+
+    @Test
+    fun testLoadContractInfoForContractId_resolvesExternalRef() = runTest {
+        val owner = Address(TEST_OWNER_CONTRACT_ID).toSCAddress()
+        val tag = SCStringXdr("token-v1")
+        createSequencedMockServer(
+            ledgerEntriesResult(keyXdr = "AAAAAA==", entryXdr = externalRefInstanceEntryXdr(owner, tag)),
+            ledgerEntriesResult(
+                keyXdr = "AAAAAA==",
+                entryXdr = externalRefTagEntryXdr(owner, tag, SCValXdr.Bytes(SCBytesXdr(Util.hexToBytes(TEST_WASM_ID))))
+            ),
+            ledgerEntriesResult(
+                keyXdr = "AAAAAA==",
+                entryXdr = contractCodeEntryXdr(parseableContractByteCode(functionName = "resolve"))
+            )
+        ).use { server ->
+            val info = assertNotNull(server.loadContractInfoForContractId(TEST_CONTRACT_ID))
+
+            assertEquals(22UL, info.envInterfaceVersion)
+            assertEquals(1, info.funcs.size)
+            assertEquals("resolve", info.funcs[0].name.value)
         }
     }
 


### PR DESCRIPTION
A contract created from a CAP-85 external reference (Protocol 28) does not carry its own WASM hash. The instance names an owner contract and a tag, and the owner holds a persistent contract data entry under that tag whose value is the hash of an already uploaded WASM. The contract code loading path read only the WASM arm, so an external-ref contract was indistinguishable from a Stellar Asset Contract: the loaders returned null and `ContractClient.forContract` failed with "Contract spec not found".

`loadContractCodeForContractId` now dispatches exhaustively over the executable arms: the WASM arm loads as before, an external reference resolves through the owner's tag entry, and a Stellar Asset Contract still yields null. An external reference that cannot be resolved throws rather than returning null; a null from the loaders still means not found or a Stellar Asset Contract. `loadContractInfoForContractId` and `ContractClient.forContract` inherit the resolution.

The new `SorobanServer.getExternalRefWasmHash(ref)` resolves a reference directly and returns the 32-byte hash as a `ByteArray`. A reference whose owner is not a contract address throws `IllegalArgumentException` before any request is issued; a missing, wrongly typed or wrong-length tag entry throws `IllegalStateException` naming the owner and tag. Through `ContractClient.forContract` the `IllegalStateException` passes unwrapped, while the `IllegalArgumentException` is wrapped as `IllegalStateException("Failed to load contract spec for ...")` with the cause preserved. Resolution costs one additional `getLedgerEntries` call; the owner contract is read, never invoked.

A tag that is not valid UTF-8 cannot be resolved: XDR strings decode into Kotlin strings with replacement characters, so the lookup key would name a different entry, and such a tag surfaces as a missing tag entry.

`ContractSpec.scValToNative` converts an `SCV_EXECUTABLE_TAG` value to its tag string; it previously failed the conversion.

Resolution is covered by unit tests against fixture ledger entries. No live external reference exists to test against yet, so the integration test only checks that a Protocol 28 RPC accepts the executable tag ledger key the resolver builds.
