### PR TITLE
Add SCValXdr.toNative()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `SCValXdr.toNative()` converts a smart contract value to native Kotlin values
+  without a contract spec: `UInt`/`Int` and `ULong`/`Long` for the 32- and
+  64-bit arms, `BigInteger` for the 128- and 256-bit arms, strkey strings for
+  addresses, `ByteArray` for bytes, lists for vecs and maps for maps. A value
+  with no faithful native representation, such as an error or a map whose keys
+  cannot serve as Kotlin map keys, comes back as the `SCValXdr` itself.
+
 ## [1.12.0] - 2026-08-26
 
 Migration guide: [docs/migration/1.12.0.md](docs/migration/1.12.0.md)

--- a/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/scval/ScValToNative.kt
+++ b/stellar-sdk/src/commonMain/kotlin/com/soneso/stellar/sdk/scval/ScValToNative.kt
@@ -1,0 +1,231 @@
+package com.soneso.stellar.sdk.scval
+
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import com.soneso.stellar.sdk.Address
+import com.soneso.stellar.sdk.Util
+import com.soneso.stellar.sdk.xdr.SCMapEntryXdr
+import com.soneso.stellar.sdk.xdr.SCValTypeXdr
+import com.soneso.stellar.sdk.xdr.SCValXdr
+
+/**
+ * Converts this [SCValXdr] to a native Kotlin value without a contract spec.
+ *
+ * The conversion is total: it never throws, whatever the receiver contains. Every arm
+ * has a defined result, and where a value has no native representation the result is
+ * the [SCValXdr] itself (the same instance, never a copy), so a caller detects that
+ * case with `is SCValXdr`. The receiver and its children are never mutated. The
+ * `ByteArray` returned for a bytes value is the stored payload array, so writing to it
+ * writes through to the receiver.
+ *
+ * ## Value conversion
+ *
+ * - `SCV_BOOL` → `Boolean`
+ * - `SCV_VOID` → `null`
+ * - `SCV_U32` → `UInt`; `SCV_I32` → `Int`
+ * - `SCV_U64`, `SCV_TIMEPOINT`, `SCV_DURATION` → `ULong`; `SCV_I64` → `Long`
+ * - `SCV_U128`, `SCV_I128`, `SCV_U256`, `SCV_I256` → `BigInteger`
+ *   (`com.ionspin.kotlin.bignum.integer.BigInteger`, as returned by [Scv.fromUint128],
+ *   [Scv.fromInt128], [Scv.fromUint256] and [Scv.fromInt256])
+ * - `SCV_BYTES` → `ByteArray`
+ * - `SCV_STRING`, `SCV_SYMBOL` → `String`
+ * - `SCV_ADDRESS` → strkey `String` (`G...`, `C...`, `M...`, `B...` or `L...`)
+ * - `SCV_VEC` → `List<Any?>` with each element converted recursively, in order; an
+ *   absent payload yields an empty list
+ * - `SCV_MAP` → `Map<Any?, Any?>` under the key rules below; an absent payload yields
+ *   an empty map
+ * - `SCV_ERROR`, `SCV_CONTRACT_INSTANCE`, `SCV_LEDGER_KEY_CONTRACT_INSTANCE`,
+ *   `SCV_LEDGER_KEY_NONCE`, `SCV_EXECUTABLE_TAG` → the [SCValXdr] itself. The same holds
+ *   for an address whose bytes have no strkey encoding and for a [SCValXdr.Void] whose
+ *   discriminant is anything other than `SCV_VOID`. The `Scv.from*` accessors, for
+ *   example [Scv.fromError] or [Scv.fromExecutableTagBytes], read those payloads on
+ *   request.
+ *
+ * ## Map keys
+ *
+ * Map keys need value-based equality, which `ByteArray` and the generated XDR types do
+ * not provide, so keys use a narrower conversion than values:
+ *
+ * - `SCV_SYMBOL`, `SCV_STRING` → `String`
+ * - `SCV_U32` → `UInt`; `SCV_I32` → `Int`
+ * - `SCV_U64`, `SCV_TIMEPOINT`, `SCV_DURATION` → `ULong`; `SCV_I64` → `Long`
+ * - `SCV_U128`, `SCV_I128`, `SCV_U256`, `SCV_I256` → `BigInteger`
+ * - `SCV_BOOL` → `Boolean`
+ * - `SCV_VOID` → `null`
+ * - `SCV_BYTES` → lowercase hex `String`; this is the one asymmetry between the two
+ *   tables, since a bytes value stays a `ByteArray`
+ * - `SCV_ADDRESS` → strkey `String`, the same representation as for a value
+ *
+ * Every other key arm is unrepresentable. A map with an unrepresentable key, or with two
+ * entries whose converted keys are equal, converts to the [SCValXdr] itself as a whole.
+ * A nested map that falls back is contained: the enclosing vec or map still converts,
+ * with that map left as an [SCValXdr] element.
+ *
+ * Key equality is plain Kotlin `equals`/`hashCode` on the converted keys, and a key is
+ * looked up with the exact type the table above gives, so a 128-bit or 256-bit key is
+ * looked up with a `BigInteger`. The primitive integer types are never normalized
+ * against each other, and a wide-integer key and a primitive integer key are compared
+ * by numeric value:
+ *
+ * - Primitive integer keys of equal value from different arms are distinct: a `U32` key
+ *   `5` (`UInt`) and a `U64` key `5` (`ULong`) coexist as two entries.
+ * - A wide-integer key and a primitive integer key of equal value are the same key: an
+ *   `I128` key `5` and a `U64` key `5` collide, so such a map falls back. Keys whose
+ *   values differ never collide, so an `I128` key `-1` and a `U64` key
+ *   `18446744073709551615` coexist.
+ * - Wide-integer keys of equal value collide even across arms: a `U128` key `5` and an
+ *   `I256` key `5` are the same key, so such a map falls back.
+ * - A bytes key collides with a symbol or string key spelling its hex: the bytes
+ *   `[0x30, 0x31]` and the symbol `"3031"` are the same key, so such a map falls back.
+ *
+ * The resulting map preserves the entry order of the XDR map.
+ *
+ * ## Relation to ContractSpec
+ *
+ * [com.soneso.stellar.sdk.contract.ContractSpec.funcResToNative] and
+ * [com.soneso.stellar.sdk.contract.ContractSpec.scValToNative] convert with a contract
+ * spec, which lets them reconstruct structs, unions and enums. This function is the
+ * spec-less companion for values whose spec is unavailable or unneeded, and its output
+ * shapes differ: a map becomes a `Map` here and a list of pairs on the spec path, and
+ * error, contract-instance and executable-tag values are returned as the [SCValXdr]
+ * itself here where the spec path unwraps their payloads.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val scVal = Scv.toMap(linkedMapOf(
+ *     Scv.toSymbol("balance") to Scv.toInt128(BigInteger.fromLong(1_000L)),
+ *     Scv.toSymbol("tags") to Scv.toVec(listOf(Scv.toString("a"), Scv.toString("b")))
+ * ))
+ * val native = scVal.toNative() as Map<*, *>
+ * native["balance"]  // BigInteger 1000
+ * native["tags"]     // ["a", "b"]
+ *
+ * // A value with no native form comes back unchanged
+ * val tag = Scv.toExecutableTag("v1").toNative()
+ * check(tag is SCValXdr)
+ * ```
+ *
+ * @receiver the value to convert
+ * @return the native Kotlin value, `null` for `SCV_VOID`, or this [SCValXdr] itself when
+ * the value has no native representation
+ */
+public fun SCValXdr.toNative(): Any? = when (this) {
+    is SCValXdr.B -> value
+    is SCValXdr.Void -> if (discriminant == SCValTypeXdr.SCV_VOID) null else this
+    is SCValXdr.Error -> this
+    is SCValXdr.U32 -> value.value
+    is SCValXdr.I32 -> value.value
+    is SCValXdr.U64 -> value.value
+    is SCValXdr.I64 -> value.value
+    is SCValXdr.Timepoint -> value.value.value
+    is SCValXdr.Duration -> value.value.value
+    is SCValXdr.U128 -> Scv.fromUint128(this)
+    is SCValXdr.I128 -> Scv.fromInt128(this)
+    is SCValXdr.U256 -> Scv.fromUint256(this)
+    is SCValXdr.I256 -> Scv.fromInt256(this)
+    is SCValXdr.Bytes -> value.value
+    is SCValXdr.Str -> value.value
+    is SCValXdr.Sym -> value.value
+    is SCValXdr.Vec -> value?.value?.map { it.toNative() } ?: emptyList<Any?>()
+    is SCValXdr.Map -> mapToNative(value?.value ?: emptyList()) ?: this
+    is SCValXdr.Address -> try {
+        Address.fromSCAddress(value).toString()
+    } catch (_: Exception) {
+        this
+    }
+    is SCValXdr.Instance -> this
+    is SCValXdr.NonceKey -> this
+    is SCValXdr.ExecutableTag -> this
+}
+
+/**
+ * Marker returned by [mapKeyToNative] for a key with no native representation.
+ *
+ * `null` cannot serve as that marker because it is the legitimate result for an
+ * `SCV_VOID` key, so an identity-compared object is used instead.
+ */
+private val unrepresentableKey = Any()
+
+/**
+ * Assembles a native map from [entries] in order, or returns `null` when the map has no
+ * native representation: a key is unrepresentable, or two entries collide on equal
+ * converted keys.
+ *
+ * A wide-integer key and a primitive integer key of equal value are a collision, which
+ * is detected by tracking the numeric values of both kinds of integer key as
+ * `BigInteger`s and checking each integer key against the values of the other kind.
+ * Every other collision is detected by the assembled map being smaller than the entry
+ * list, since a later entry with an equal key overwrites the earlier one.
+ */
+private fun mapToNative(entries: List<SCMapEntryXdr>): Map<Any?, Any?>? {
+    val result = LinkedHashMap<Any?, Any?>(entries.size)
+    val wideIntegerKeys = HashSet<BigInteger>()
+    val primitiveIntegerKeys = HashSet<BigInteger>()
+    for (entry in entries) {
+        val key = mapKeyToNative(entry.key)
+        if (key === unrepresentableKey) {
+            return null
+        }
+        if (key is BigInteger) {
+            if (key in primitiveIntegerKeys) {
+                return null
+            }
+            wideIntegerKeys.add(key)
+        } else {
+            val numericValue = primitiveIntegerValue(key)
+            if (numericValue != null) {
+                if (numericValue in wideIntegerKeys) {
+                    return null
+                }
+                primitiveIntegerKeys.add(numericValue)
+            }
+        }
+        result[key] = entry.`val`.toNative()
+    }
+    return if (result.size == entries.size) result else null
+}
+
+/**
+ * Returns the numeric value of a primitive integer map key as a [BigInteger], or `null`
+ * for a key of any other type.
+ */
+private fun primitiveIntegerValue(key: Any?): BigInteger? = when (key) {
+    is UInt -> BigInteger.fromUInt(key)
+    is Int -> BigInteger.fromInt(key)
+    is ULong -> BigInteger.fromULong(key)
+    is Long -> BigInteger.fromLong(key)
+    else -> null
+}
+
+/**
+ * Converts a map key to a value with value-based `equals`/`hashCode`, or returns
+ * [unrepresentableKey] when the key arm has no such representation.
+ */
+private fun mapKeyToNative(key: SCValXdr): Any? = when (key) {
+    is SCValXdr.Sym -> key.value.value
+    is SCValXdr.Str -> key.value.value
+    is SCValXdr.U32 -> key.value.value
+    is SCValXdr.I32 -> key.value.value
+    is SCValXdr.U64 -> key.value.value
+    is SCValXdr.I64 -> key.value.value
+    is SCValXdr.Timepoint -> key.value.value.value
+    is SCValXdr.Duration -> key.value.value.value
+    is SCValXdr.U128 -> Scv.fromUint128(key)
+    is SCValXdr.I128 -> Scv.fromInt128(key)
+    is SCValXdr.U256 -> Scv.fromUint256(key)
+    is SCValXdr.I256 -> Scv.fromInt256(key)
+    is SCValXdr.B -> key.value
+    is SCValXdr.Void -> if (key.discriminant == SCValTypeXdr.SCV_VOID) null else unrepresentableKey
+    is SCValXdr.Bytes -> Util.bytesToHex(key.value.value)
+    is SCValXdr.Address -> try {
+        Address.fromSCAddress(key.value).toString()
+    } catch (_: Exception) {
+        unrepresentableKey
+    }
+    is SCValXdr.Vec,
+    is SCValXdr.Map,
+    is SCValXdr.Error,
+    is SCValXdr.Instance,
+    is SCValXdr.NonceKey,
+    is SCValXdr.ExecutableTag -> unrepresentableKey
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/scval/ScValToNativeDocSnippetsCompileTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/scval/ScValToNativeDocSnippetsCompileTest.kt
@@ -1,0 +1,65 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.unitTests.scval
+
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import com.soneso.stellar.sdk.Address
+import com.soneso.stellar.sdk.scval.Scv
+import com.soneso.stellar.sdk.scval.toNative
+import com.soneso.stellar.sdk.xdr.SCValXdr
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Runs the `toNative()` example the documentation shows and asserts the values it quotes, so
+ * a change to the conversion that would make the documentation wrong fails the build instead.
+ */
+class ScValToNativeDocSnippetsCompileTest {
+
+    @Test
+    fun specLessConversion() {
+        // A u64 above Long.MAX_VALUE converts to a ULong and keeps its exact value
+        val count = Scv.toUint64(18446744073709551615uL).toNative()
+        assertTrue(count is ULong)
+        assertEquals(18446744073709551615uL, count)
+
+        // A map with symbol keys converts to a Map keyed by String, in entry order
+        val owner = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+        val record = Scv.toMap(
+            linkedMapOf(
+                Scv.toSymbol("name") to Scv.toString("Alice"),
+                Scv.toSymbol("age") to Scv.toUint32(30u),
+                Scv.toSymbol("balance") to Scv.toInt128(BigInteger.parseString("1000000000")),
+                Scv.toSymbol("owner") to Scv.toAddress(Address(owner).toSCAddress())
+            )
+        )
+        val fields = record.toNative() as Map<*, *>
+        val name = fields["name"] as String
+        val age = fields["age"] as UInt
+        val balance = fields["balance"] as BigInteger
+        val ownerAddress = fields["owner"] as String
+        assertEquals("Alice", name)
+        assertEquals(30u, age)
+        assertEquals(BigInteger.parseString("1000000000"), balance)
+        assertEquals(owner, ownerAddress)
+        assertEquals(listOf("name", "age", "balance", "owner"), fields.keys.toList())
+
+        // A vec converts to a List with each element converted in turn
+        val items = Scv.toVec(
+            listOf(Scv.toUint32(1u), Scv.toSymbol("a"), Scv.toVec(listOf(Scv.toBoolean(true))))
+        ).toNative()
+        assertEquals(listOf(1u, "a", listOf(true)), items)
+
+        // A map whose key has no native representation comes back as the SCValXdr itself
+        val keyedByVec = Scv.toMap(
+            linkedMapOf(Scv.toVec(listOf(Scv.toUint32(1u))) to Scv.toUint32(2u))
+        )
+        val result = keyedByVec.toNative()
+        assertTrue(result is SCValXdr)
+        assertSame(keyedByVec, result)
+    }
+}

--- a/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/scval/ScValToNativeTest.kt
+++ b/stellar-sdk/src/commonTest/kotlin/com/soneso/stellar/sdk/unitTests/scval/ScValToNativeTest.kt
@@ -1,0 +1,777 @@
+// Copyright 2026 Soneso. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package com.soneso.stellar.sdk.unitTests.scval
+
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import com.soneso.stellar.sdk.Address
+import com.soneso.stellar.sdk.Util
+import com.soneso.stellar.sdk.scval.Scv
+import com.soneso.stellar.sdk.scval.toNative
+import com.soneso.stellar.sdk.xdr.ContractExecutableXdr
+import com.soneso.stellar.sdk.xdr.ContractIDXdr
+import com.soneso.stellar.sdk.xdr.HashXdr
+import com.soneso.stellar.sdk.xdr.Int64Xdr
+import com.soneso.stellar.sdk.xdr.SCAddressXdr
+import com.soneso.stellar.sdk.xdr.SCContractInstanceXdr
+import com.soneso.stellar.sdk.xdr.SCErrorCodeXdr
+import com.soneso.stellar.sdk.xdr.SCErrorTypeXdr
+import com.soneso.stellar.sdk.xdr.SCErrorXdr
+import com.soneso.stellar.sdk.xdr.SCMapEntryXdr
+import com.soneso.stellar.sdk.xdr.SCMapXdr
+import com.soneso.stellar.sdk.xdr.SCNonceKeyXdr
+import com.soneso.stellar.sdk.xdr.SCValTypeXdr
+import com.soneso.stellar.sdk.xdr.SCValXdr
+import com.soneso.stellar.sdk.xdr.fromXdrBase64
+import com.soneso.stellar.sdk.xdr.toXdrBase64
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class ScValToNativeTest {
+    private val accountId = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+    private val contractId = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
+    private val muxedAccountId = "MAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSAAAAAAAAAAE2LP26"
+    private val claimableBalanceId = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+    private val liquidityPoolId = "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN"
+
+    private fun scMap(vararg entries: Pair<SCValXdr, SCValXdr>): SCValXdr =
+        Scv.toMap(linkedMapOf(*entries))
+
+    private fun nativeMap(scVal: SCValXdr): Map<*, *> = assertIs<Map<*, *>>(scVal.toNative())
+
+    private fun addressValue(strKey: String): SCValXdr = Scv.toAddress(Address(strKey).toSCAddress())
+
+    private fun errorValue(): SCValXdr =
+        Scv.toError(SCErrorXdr.Code(SCErrorTypeXdr.SCE_CONTEXT, SCErrorCodeXdr.SCEC_INVALID_INPUT))
+
+    private fun instanceValue(): SCValXdr =
+        Scv.toContractInstance(SCContractInstanceXdr(ContractExecutableXdr.Void, null))
+
+    private fun nonceKeyValue(): SCValXdr = Scv.toLedgerKeyNonce(SCNonceKeyXdr(Int64Xdr(42L)))
+
+    /**
+     * A contract address whose hash is one byte short, which the strkey encoder rejects.
+     */
+    private fun illFormedAddress(): SCAddressXdr =
+        SCAddressXdr.ContractId(ContractIDXdr(HashXdr(ByteArray(31))))
+
+    /**
+     * Asserts that a map holding the two entries falls back in both insertion orders.
+     */
+    private fun assertMapFallsBackInEitherOrder(first: Pair<SCValXdr, SCValXdr>, second: Pair<SCValXdr, SCValXdr>) {
+        val firstThenSecond = scMap(first, second)
+        assertSame(firstThenSecond, firstThenSecond.toNative())
+
+        val secondThenFirst = scMap(second, first)
+        assertSame(secondThenFirst, secondThenFirst.toNative())
+    }
+
+    // ------------------------------------------------------------------
+    // Scalars
+    // ------------------------------------------------------------------
+
+    @Test
+    fun testBoolean() {
+        assertEquals(true, Scv.toBoolean(true).toNative())
+        assertEquals(false, Scv.toBoolean(false).toNative())
+    }
+
+    @Test
+    fun testVoid() {
+        assertNull(Scv.toVoid().toNative())
+    }
+
+    @Test
+    fun testLedgerKeyContractInstance() {
+        val scVal = Scv.toLedgerKeyContractInstance()
+        assertSame(scVal, scVal.toNative())
+    }
+
+    @Test
+    fun testVoidWithForeignDiscriminant() {
+        val scVal = SCValXdr.Void(SCValTypeXdr.SCV_U32)
+        assertSame(scVal, scVal.toNative())
+    }
+
+    @Test
+    fun testUint32() {
+        val zero = Scv.toUint32(0u).toNative()
+        assertIs<UInt>(zero)
+        assertEquals(0u, zero)
+
+        val max = Scv.toUint32(4294967295u).toNative()
+        assertIs<UInt>(max)
+        assertEquals(4294967295u, max)
+    }
+
+    @Test
+    fun testInt32() {
+        val min = Scv.toInt32(Int.MIN_VALUE).toNative()
+        assertIs<Int>(min)
+        assertEquals(Int.MIN_VALUE, min)
+
+        val max = Scv.toInt32(Int.MAX_VALUE).toNative()
+        assertIs<Int>(max)
+        assertEquals(Int.MAX_VALUE, max)
+    }
+
+    @Test
+    fun testUint64() {
+        val zero = Scv.toUint64(0u).toNative()
+        assertTrue(zero is ULong)
+        assertEquals(0uL, zero)
+
+        val max = Scv.toUint64(ULong.MAX_VALUE).toNative()
+        assertTrue(max is ULong)
+        assertEquals(18446744073709551615uL, max)
+    }
+
+    @Test
+    fun testInt64() {
+        val min = Scv.toInt64(Long.MIN_VALUE).toNative()
+        assertIs<Long>(min)
+        assertEquals(Long.MIN_VALUE, min)
+
+        val max = Scv.toInt64(Long.MAX_VALUE).toNative()
+        assertIs<Long>(max)
+        assertEquals(Long.MAX_VALUE, max)
+    }
+
+    @Test
+    fun testTimepoint() {
+        val result = Scv.toTimePoint(1700000000u).toNative()
+        assertIs<ULong>(result)
+        assertEquals(1700000000uL, result)
+    }
+
+    @Test
+    fun testDuration() {
+        val result = Scv.toDuration(ULong.MAX_VALUE).toNative()
+        assertIs<ULong>(result)
+        assertEquals(ULong.MAX_VALUE, result)
+    }
+
+    @Test
+    fun testUint128() {
+        val value = BigInteger.parseString("340282366920938463463374607431768211455")
+        val result = Scv.toUint128(value).toNative()
+        assertIs<BigInteger>(result)
+        assertEquals(value, result)
+    }
+
+    @Test
+    fun testInt128() {
+        val min = BigInteger.parseString("-170141183460469231731687303715884105728")
+        val minResult = Scv.toInt128(min).toNative()
+        assertIs<BigInteger>(minResult)
+        assertEquals(min, minResult)
+
+        val minusOne = BigInteger.parseString("-1")
+        val minusOneResult = Scv.toInt128(minusOne).toNative()
+        assertIs<BigInteger>(minusOneResult)
+        assertEquals(minusOne, minusOneResult)
+    }
+
+    @Test
+    fun testUint256() {
+        val value = BigInteger.parseString(
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+        )
+        val result = Scv.toUint256(value).toNative()
+        assertIs<BigInteger>(result)
+        assertEquals(value, result)
+    }
+
+    @Test
+    fun testInt256() {
+        val value = BigInteger.parseString(
+            "-57896044618658097711785492504343953926634992332820282019728792003956564819968"
+        )
+        val result = Scv.toInt256(value).toNative()
+        assertIs<BigInteger>(result)
+        assertEquals(value, result)
+    }
+
+    @Test
+    fun testBytes() {
+        val bytes = byteArrayOf(0, 1, 255.toByte())
+        val scVal = Scv.toBytes(bytes)
+        val result = scVal.toNative()
+        assertIs<ByteArray>(result)
+        assertContentEquals(byteArrayOf(0, 1, 255.toByte()), result)
+        assertSame(Scv.fromBytes(scVal), result)
+    }
+
+    @Test
+    fun testString() {
+        assertEquals("hello", Scv.toString("hello").toNative())
+        assertEquals("Grüße, 世界", Scv.toString("Grüße, 世界").toNative())
+    }
+
+    @Test
+    fun testSymbol() {
+        val result = Scv.toSymbol("transfer").toNative()
+        assertIs<String>(result)
+        assertEquals("transfer", result)
+    }
+
+    // ------------------------------------------------------------------
+    // Vec
+    // ------------------------------------------------------------------
+
+    @Test
+    fun testNestedVec() {
+        val scVal = Scv.toVec(
+            listOf(Scv.toUint32(1u), Scv.toSymbol("a"), Scv.toVec(listOf(Scv.toBoolean(true))))
+        )
+        val result = assertIs<List<*>>(scVal.toNative())
+        assertEquals(3, result.size)
+        assertIs<UInt>(result[0])
+        assertEquals(1u, result[0])
+        assertIs<String>(result[1])
+        assertEquals("a", result[1])
+        val inner = assertIs<List<*>>(result[2])
+        assertEquals(listOf(true), inner)
+        assertEquals(listOf(1u, "a", listOf(true)), result)
+    }
+
+    @Test
+    fun testEmptyVec() {
+        assertEquals(emptyList<Any?>(), Scv.toVec(emptyList()).toNative())
+    }
+
+    @Test
+    fun testVecWithoutPayload() {
+        assertEquals(emptyList<Any?>(), SCValXdr.Vec(null).toNative())
+    }
+
+    @Test
+    fun testVecWithVoidElement() {
+        val result = assertIs<List<*>>(Scv.toVec(listOf(Scv.toVoid(), Scv.toUint32(1u))).toNative())
+        assertEquals(2, result.size)
+        assertNull(result[0])
+        assertEquals(1u, result[1])
+    }
+
+    @Test
+    fun testVecContainsMapFallback() {
+        val mapWithVecKey = scMap(Scv.toVec(listOf(Scv.toUint32(1u))) to Scv.toUint32(2u))
+        val result = assertIs<List<*>>(Scv.toVec(listOf(Scv.toUint32(7u), mapWithVecKey)).toNative())
+        assertEquals(2, result.size)
+        assertEquals(7u, result[0])
+        assertSame(mapWithVecKey, result[1])
+    }
+
+    @Test
+    fun testVecIsNotMutated() {
+        val scVal = Scv.toVec(listOf(Scv.toUint32(1u), Scv.toSymbol("a")))
+        val elements = (scVal as SCValXdr.Vec).value!!.value
+        val snapshot = elements.toList()
+
+        scVal.toNative()
+
+        assertSame(elements, scVal.value!!.value)
+        assertEquals(snapshot, scVal.value!!.value)
+    }
+
+    // ------------------------------------------------------------------
+    // Map
+    // ------------------------------------------------------------------
+
+    @Test
+    fun testMapWithSymbolKeys() {
+        val result = nativeMap(
+            scMap(Scv.toSymbol("name") to Scv.toString("Alice"), Scv.toSymbol("age") to Scv.toUint32(30u))
+        )
+        assertEquals(2, result.size)
+        assertEquals("Alice", result["name"])
+        assertEquals(30u, result["age"])
+        assertEquals(listOf("name", "age"), result.keys.toList())
+    }
+
+    @Test
+    fun testMapWithUint32Keys() {
+        val result = nativeMap(
+            scMap(Scv.toUint32(1u) to Scv.toSymbol("one"), Scv.toUint32(2u) to Scv.toSymbol("two"))
+        )
+        assertEquals(2, result.size)
+        assertEquals("one", result[1u])
+        assertEquals("two", result[2u])
+        assertEquals(listOf(1u, 2u), result.keys.toList())
+    }
+
+    @Test
+    fun testMapWithInt64Key() {
+        val result = nativeMap(scMap(Scv.toInt64(-5L) to Scv.toSymbol("minus five")))
+        assertEquals(1, result.size)
+        assertEquals("minus five", result[-5L])
+    }
+
+    @Test
+    fun testMapWithUint64Key() {
+        val result = nativeMap(scMap(Scv.toUint64(ULong.MAX_VALUE) to Scv.toSymbol("max")))
+        assertEquals(1, result.size)
+        assertEquals("max", result[ULong.MAX_VALUE])
+        assertIs<ULong>(result.keys.single())
+    }
+
+    @Test
+    fun testMapWithInt128Key() {
+        val key = BigInteger.parseString("170141183460469231731687303715884105727")
+        val result = nativeMap(scMap(Scv.toInt128(key) to Scv.toSymbol("big")))
+        assertEquals(1, result.size)
+        assertEquals("big", result[key])
+    }
+
+    @Test
+    fun testMapWithBooleanKey() {
+        val result = nativeMap(scMap(Scv.toBoolean(true) to Scv.toSymbol("yes")))
+        assertEquals(1, result.size)
+        assertEquals("yes", result[true])
+    }
+
+    @Test
+    fun testMapWithVoidKey() {
+        val result = nativeMap(scMap(Scv.toVoid() to Scv.toSymbol("nothing")))
+        assertEquals(1, result.size)
+        assertTrue(result.containsKey(null))
+        assertEquals("nothing", result[null])
+    }
+
+    @Test
+    fun testMapWithBytesKey() {
+        val result = nativeMap(scMap(Scv.toBytes(byteArrayOf(1, 2)) to Scv.toSymbol("hex")))
+        assertEquals(1, result.size)
+        assertEquals("hex", result["0102"])
+        assertEquals(Util.bytesToHex(byteArrayOf(1, 2)), result.keys.single())
+    }
+
+    @Test
+    fun testMapWithBytesKeyUsesLowercaseHex() {
+        val result = nativeMap(scMap(Scv.toBytes(byteArrayOf(0xAB.toByte(), 0xCD.toByte())) to Scv.toSymbol("hex")))
+        assertEquals(1, result.size)
+        assertEquals("hex", result["abcd"])
+        assertFalse(result.containsKey("ABCD"))
+        assertEquals("abcd", result.keys.single())
+    }
+
+    @Test
+    fun testMapWithAddressKeys() {
+        val result = nativeMap(
+            scMap(
+                addressValue(accountId) to Scv.toSymbol("account"),
+                addressValue(contractId) to Scv.toSymbol("contract"),
+                addressValue(muxedAccountId) to Scv.toSymbol("muxed"),
+                addressValue(claimableBalanceId) to Scv.toSymbol("claimable balance"),
+                addressValue(liquidityPoolId) to Scv.toSymbol("liquidity pool")
+            )
+        )
+        assertEquals(5, result.size)
+        assertEquals("account", result[accountId])
+        assertEquals("contract", result[contractId])
+        assertEquals("muxed", result[muxedAccountId])
+        assertEquals("claimable balance", result[claimableBalanceId])
+        assertEquals("liquidity pool", result[liquidityPoolId])
+        assertEquals(
+            listOf(accountId, contractId, muxedAccountId, claimableBalanceId, liquidityPoolId),
+            result.keys.toList()
+        )
+    }
+
+    @Test
+    fun testMapWithRemainingScalarKeyArms() {
+        val u128 = BigInteger.parseString("340282366920938463463374607431768211455")
+        val u256 = BigInteger.parseString(
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+        )
+        val i256 = BigInteger.parseString(
+            "-57896044618658097711785492504343953926634992332820282019728792003956564819968"
+        )
+        val result = nativeMap(
+            scMap(
+                Scv.toString("text") to Scv.toUint32(1u),
+                Scv.toInt32(Int.MIN_VALUE) to Scv.toUint32(2u),
+                Scv.toTimePoint(1700000000u) to Scv.toUint32(3u),
+                Scv.toDuration(ULong.MAX_VALUE) to Scv.toUint32(4u),
+                Scv.toUint128(u128) to Scv.toUint32(5u),
+                Scv.toUint256(u256) to Scv.toUint32(6u),
+                Scv.toInt256(i256) to Scv.toUint32(7u)
+            )
+        )
+        assertEquals(7, result.size)
+        assertEquals(1u, result["text"])
+        assertEquals(2u, result[Int.MIN_VALUE])
+        assertEquals(3u, result[1700000000uL])
+        assertEquals(4u, result[ULong.MAX_VALUE])
+        assertEquals(5u, result[u128])
+        assertEquals(6u, result[u256])
+        assertEquals(7u, result[i256])
+        assertEquals(
+            listOf("text", Int.MIN_VALUE, 1700000000uL, ULong.MAX_VALUE, u128, u256, i256),
+            result.keys.toList()
+        )
+    }
+
+    @Test
+    fun testMapWithVoidValue() {
+        val result = nativeMap(scMap(Scv.toSymbol("a") to Scv.toVoid(), Scv.toSymbol("b") to Scv.toUint32(1u)))
+        assertEquals(2, result.size)
+        assertTrue(result.containsKey("a"))
+        assertNull(result["a"])
+        assertEquals(1u, result["b"])
+    }
+
+    @Test
+    fun testMapContainsFallbackValue() {
+        val error = errorValue()
+        val result = nativeMap(scMap(Scv.toSymbol("k") to error))
+        assertEquals(1, result.size)
+        assertSame(error, result["k"])
+    }
+
+    @Test
+    fun testMapContainsMapFallbackValue() {
+        val innerMap = scMap(Scv.toVec(listOf(Scv.toUint32(1u))) to Scv.toUint32(2u))
+        val result = nativeMap(scMap(Scv.toSymbol("inner") to innerMap, Scv.toSymbol("n") to Scv.toUint32(1u)))
+        assertEquals(2, result.size)
+        assertSame(innerMap, result["inner"])
+        assertEquals(1u, result["n"])
+        assertEquals(listOf("inner", "n"), result.keys.toList())
+    }
+
+    @Test
+    fun testEmptyMap() {
+        val result = nativeMap(Scv.toMap(LinkedHashMap()))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun testMapWithoutPayload() {
+        val result = nativeMap(SCValXdr.Map(null))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun testMapIsNotMutated() {
+        val scVal = scMap(Scv.toSymbol("a") to Scv.toUint32(1u), Scv.toSymbol("b") to Scv.toUint32(2u))
+        val entries = (scVal as SCValXdr.Map).value!!.value
+        val snapshot = entries.toList()
+
+        nativeMap(scVal)
+
+        assertSame(entries, scVal.value!!.value)
+        assertEquals(snapshot, scVal.value!!.value)
+    }
+
+    // ------------------------------------------------------------------
+    // Map key distinctness
+    // ------------------------------------------------------------------
+
+    @Test
+    fun testUint32AndUint64KeysAreDistinct() {
+        val result = nativeMap(scMap(Scv.toUint32(5u) to Scv.toSymbol("u32"), Scv.toUint64(5u) to Scv.toSymbol("u64")))
+        assertEquals(2, result.size)
+        assertEquals("u32", result[5u])
+        assertEquals("u64", result[5uL])
+        assertEquals(listOf<Any>(5u, 5uL), result.keys.toList())
+    }
+
+    @Test
+    fun testUint64AndInt64KeysAreDistinct() {
+        val result = nativeMap(scMap(Scv.toUint64(5u) to Scv.toSymbol("u64"), Scv.toInt64(5L) to Scv.toSymbol("i64")))
+        assertEquals(2, result.size)
+        assertEquals("u64", result[5uL])
+        assertEquals("i64", result[5L])
+        assertEquals(listOf<Any>(5uL, 5L), result.keys.toList())
+    }
+
+    @Test
+    fun testBooleanAndUint32KeysAreDistinct() {
+        val result = nativeMap(scMap(Scv.toBoolean(true) to Scv.toSymbol("bool"), Scv.toUint32(1u) to Scv.toSymbol("u32")))
+        assertEquals(2, result.size)
+        assertEquals("bool", result[true])
+        assertEquals("u32", result[1u])
+        assertEquals(listOf<Any>(true, 1u), result.keys.toList())
+    }
+
+    @Test
+    fun testSymbolAndUint32KeysAreDistinct() {
+        val result = nativeMap(scMap(Scv.toSymbol("5") to Scv.toSymbol("sym"), Scv.toUint32(5u) to Scv.toSymbol("u32")))
+        assertEquals(2, result.size)
+        assertEquals("sym", result["5"])
+        assertEquals("u32", result[5u])
+        assertEquals(listOf<Any>("5", 5u), result.keys.toList())
+    }
+
+    @Test
+    fun testUint64AndInt128KeysOfDifferentValueAreDistinct() {
+        val six = BigInteger.parseString("6")
+
+        val primitiveFirst = nativeMap(
+            scMap(Scv.toUint64(5u) to Scv.toSymbol("u64"), Scv.toInt128(six) to Scv.toSymbol("i128"))
+        )
+        assertEquals(2, primitiveFirst.size)
+        assertEquals("u64", primitiveFirst[5uL])
+        assertEquals("i128", primitiveFirst[six])
+        assertEquals(listOf<Any>(5uL, six), primitiveFirst.keys.toList())
+
+        val wideFirst = nativeMap(
+            scMap(Scv.toInt128(six) to Scv.toSymbol("i128"), Scv.toUint64(5u) to Scv.toSymbol("u64"))
+        )
+        assertEquals(2, wideFirst.size)
+        assertEquals("i128", wideFirst[six])
+        assertEquals("u64", wideFirst[5uL])
+        assertEquals(listOf<Any>(six, 5uL), wideFirst.keys.toList())
+    }
+
+    @Test
+    fun testUint64MaxAndNegativeInt128KeysAreDistinct() {
+        val minusOne = BigInteger.parseString("-1")
+
+        val primitiveFirst = nativeMap(
+            scMap(Scv.toUint64(ULong.MAX_VALUE) to Scv.toSymbol("u64"), Scv.toInt128(minusOne) to Scv.toSymbol("i128"))
+        )
+        assertEquals(2, primitiveFirst.size)
+        assertEquals("u64", primitiveFirst[ULong.MAX_VALUE])
+        assertEquals("i128", primitiveFirst[minusOne])
+        assertEquals(listOf<Any>(ULong.MAX_VALUE, minusOne), primitiveFirst.keys.toList())
+
+        val wideFirst = nativeMap(
+            scMap(Scv.toInt128(minusOne) to Scv.toSymbol("i128"), Scv.toUint64(ULong.MAX_VALUE) to Scv.toSymbol("u64"))
+        )
+        assertEquals(2, wideFirst.size)
+        assertEquals("i128", wideFirst[minusOne])
+        assertEquals("u64", wideFirst[ULong.MAX_VALUE])
+        assertEquals(listOf<Any>(minusOne, ULong.MAX_VALUE), wideFirst.keys.toList())
+    }
+
+    @Test
+    fun testBytesAndUint32KeysAreDistinct() {
+        val result = nativeMap(
+            scMap(Scv.toBytes(byteArrayOf(0x35)) to Scv.toSymbol("bytes"), Scv.toUint32(5u) to Scv.toSymbol("u32"))
+        )
+        assertEquals(2, result.size)
+        assertEquals("bytes", result["35"])
+        assertEquals("u32", result[5u])
+        assertEquals(listOf<Any>("35", 5u), result.keys.toList())
+    }
+
+    // ------------------------------------------------------------------
+    // Map fallbacks
+    // ------------------------------------------------------------------
+
+    @Test
+    fun testMapWithDuplicateKeyFallsBack() {
+        val scVal = SCValXdr.Map(
+            SCMapXdr(
+                listOf(
+                    SCMapEntryXdr(Scv.toSymbol("a"), Scv.toUint32(1u)),
+                    SCMapEntryXdr(Scv.toSymbol("a"), Scv.toUint32(2u))
+                )
+            )
+        )
+        assertSame(scVal, scVal.toNative())
+    }
+
+    @Test
+    fun testMapWithEqualWideIntegerKeysFallsBack() {
+        val seven = BigInteger.parseString("7")
+        val scVal = scMap(Scv.toUint128(seven) to Scv.toSymbol("u128"), Scv.toInt256(seven) to Scv.toSymbol("i256"))
+        assertSame(scVal, scVal.toNative())
+    }
+
+    @Test
+    fun testMapWithUint64AndInt128KeysOfEqualValueFallsBack() {
+        val five = BigInteger.parseString("5")
+        assertMapFallsBackInEitherOrder(
+            Scv.toUint64(5u) to Scv.toSymbol("u64"),
+            Scv.toInt128(five) to Scv.toSymbol("i128")
+        )
+    }
+
+    @Test
+    fun testMapWithUint32AndUint128KeysOfEqualValueFallsBack() {
+        val five = BigInteger.parseString("5")
+        assertMapFallsBackInEitherOrder(
+            Scv.toUint32(5u) to Scv.toSymbol("u32"),
+            Scv.toUint128(five) to Scv.toSymbol("u128")
+        )
+    }
+
+    @Test
+    fun testMapWithInt32AndInt256KeysOfEqualValueFallsBack() {
+        val minusFive = BigInteger.parseString("-5")
+        assertMapFallsBackInEitherOrder(
+            Scv.toInt32(-5) to Scv.toSymbol("i32"),
+            Scv.toInt256(minusFive) to Scv.toSymbol("i256")
+        )
+    }
+
+    @Test
+    fun testMapWithInt64AndUint256KeysOfEqualValueFallsBack() {
+        val five = BigInteger.parseString("5")
+        assertMapFallsBackInEitherOrder(
+            Scv.toInt64(5L) to Scv.toSymbol("i64"),
+            Scv.toUint256(five) to Scv.toSymbol("u256")
+        )
+    }
+
+    @Test
+    fun testMapWithUint64MaxAndUint128KeysOfEqualValueFallsBack() {
+        val uint64Max = BigInteger.parseString("18446744073709551615")
+        assertMapFallsBackInEitherOrder(
+            Scv.toUint64(ULong.MAX_VALUE) to Scv.toSymbol("u64"),
+            Scv.toUint128(uint64Max) to Scv.toSymbol("u128")
+        )
+    }
+
+    @Test
+    fun testMapWithTimepointAndInt128KeysOfEqualValueFallsBack() {
+        val timepoint = BigInteger.parseString("1700000000")
+        assertMapFallsBackInEitherOrder(
+            Scv.toTimePoint(1700000000u) to Scv.toSymbol("timepoint"),
+            Scv.toInt128(timepoint) to Scv.toSymbol("i128")
+        )
+    }
+
+    @Test
+    fun testMapWithDurationAndUint256KeysOfEqualValueFallsBack() {
+        val duration = BigInteger.parseString("3600")
+        assertMapFallsBackInEitherOrder(
+            Scv.toDuration(3600u) to Scv.toSymbol("duration"),
+            Scv.toUint256(duration) to Scv.toSymbol("u256")
+        )
+    }
+
+    @Test
+    fun testMapWithBytesAndSymbolSpellingItsHexFallsBack() {
+        val scVal = scMap(
+            Scv.toBytes(byteArrayOf(0x30, 0x31)) to Scv.toSymbol("bytes"),
+            Scv.toSymbol("3031") to Scv.toSymbol("sym")
+        )
+        assertSame(scVal, scVal.toNative())
+    }
+
+    @Test
+    fun testMapWithUnrepresentableKeyFallsBack() {
+        val keys = listOf(
+            "vec" to Scv.toVec(listOf(Scv.toUint32(1u))),
+            "map" to scMap(Scv.toSymbol("inner") to Scv.toUint32(1u)),
+            "error" to errorValue(),
+            "instance" to instanceValue(),
+            "nonce key" to nonceKeyValue(),
+            "executable tag" to Scv.toExecutableTag("v1"),
+            "ledger key contract instance" to Scv.toLedgerKeyContractInstance()
+        )
+        for ((name, key) in keys) {
+            val scVal = scMap(Scv.toSymbol("first") to Scv.toUint32(1u), key to Scv.toUint32(2u))
+            assertSame(scVal, scVal.toNative(), "map with a $name key")
+        }
+    }
+
+    @Test
+    fun testMapWithIllFormedAddressKeyFallsBack() {
+        val scVal = scMap(Scv.toAddress(illFormedAddress()) to Scv.toUint32(1u))
+        assertSame(scVal, scVal.toNative())
+    }
+
+    // ------------------------------------------------------------------
+    // Addresses
+    // ------------------------------------------------------------------
+
+    @Test
+    fun testAddressValues() {
+        assertEquals(accountId, addressValue(accountId).toNative())
+        assertEquals(contractId, addressValue(contractId).toNative())
+        assertEquals(muxedAccountId, addressValue(muxedAccountId).toNative())
+        assertEquals(claimableBalanceId, addressValue(claimableBalanceId).toNative())
+        assertEquals(liquidityPoolId, addressValue(liquidityPoolId).toNative())
+    }
+
+    @Test
+    fun testIllFormedAddressValue() {
+        val address = illFormedAddress()
+        assertFailsWith<IllegalArgumentException> { Address.fromSCAddress(address) }
+
+        val scVal = Scv.toAddress(address)
+        assertSame(scVal, scVal.toNative())
+    }
+
+    // ------------------------------------------------------------------
+    // Arms with no native representation
+    // ------------------------------------------------------------------
+
+    @Test
+    fun testErrorValue() {
+        val scVal = errorValue()
+        assertSame(scVal, scVal.toNative())
+    }
+
+    @Test
+    fun testContractInstanceValue() {
+        val scVal = instanceValue()
+        assertSame(scVal, scVal.toNative())
+    }
+
+    @Test
+    fun testNonceKeyValue() {
+        val scVal = nonceKeyValue()
+        assertSame(scVal, scVal.toNative())
+    }
+
+    @Test
+    fun testExecutableTagValue() {
+        val scVal = Scv.toExecutableTag("v1")
+        assertSame(scVal, scVal.toNative())
+
+        val rawTag = Scv.toExecutableTagBytes(byteArrayOf(0xFF.toByte(), 0xFE.toByte()))
+        assertSame(rawTag, rawTag.toNative())
+    }
+
+    // ------------------------------------------------------------------
+    // Wire round trip
+    // ------------------------------------------------------------------
+
+    @Test
+    fun testDecodedValueConvertsLikeFactoryBuiltValue() {
+        val amount = BigInteger.parseString("-170141183460469231731687303715884105728")
+        val original = scMap(
+            Scv.toSymbol("items") to Scv.toVec(listOf(Scv.toUint32(1u), Scv.toSymbol("two"))),
+            Scv.toSymbol("amount") to Scv.toInt128(amount),
+            Scv.toSymbol("owner") to addressValue(contractId),
+            Scv.toSymbol("count") to Scv.toUint64(9223372036854775808uL),
+            Scv.toSymbol("data") to Scv.toBytes(byteArrayOf(0, 1, 255.toByte()))
+        )
+        val decoded = SCValXdr.fromXdrBase64(original.toXdrBase64())
+
+        val fromOriginal = nativeMap(original)
+        val fromDecoded = nativeMap(decoded)
+
+        assertEquals(listOf("items", "amount", "owner", "count", "data"), fromDecoded.keys.toList())
+        assertEquals(fromOriginal.keys.toList(), fromDecoded.keys.toList())
+
+        assertEquals(listOf(1u, "two"), fromDecoded["items"])
+        assertEquals(fromOriginal["items"], fromDecoded["items"])
+
+        assertEquals(amount, fromDecoded["amount"])
+        assertEquals(fromOriginal["amount"], fromDecoded["amount"])
+
+        assertEquals(contractId, fromDecoded["owner"])
+        assertEquals(fromOriginal["owner"], fromDecoded["owner"])
+
+        assertEquals(9223372036854775808uL, fromDecoded["count"])
+        assertEquals(fromOriginal["count"], fromDecoded["count"])
+
+        val decodedBytes = assertIs<ByteArray>(fromDecoded["data"])
+        assertContentEquals(byteArrayOf(0, 1, 255.toByte()), decodedBytes)
+        assertContentEquals(assertIs<ByteArray>(fromOriginal["data"]), decodedBytes)
+    }
+}


### PR DESCRIPTION
Adds an opt-in `SCValXdr.toNative()` extension that converts a smart contract value to native Kotlin values without a contract spec: `UInt`/`Int` and `ULong`/`Long` for the 32- and 64-bit arms, `BigInteger` for 128- and 256-bit values, strkey strings for addresses, `ByteArray` for bytes, and lists and maps for vecs and maps. The conversion is best effort and never throws. A value with no faithful native form, such as an error or a map whose keys cannot serve as Kotlin map keys, is returned as the `SCValXdr` itself. Existing APIs, including the spec-driven converters on `ContractSpec` and `ContractClient`, are unchanged. The conversion and map key rules are documented in the function's KDoc.
